### PR TITLE
refactor: separate `Themes.tsx`, remove `getSubscriptionConfig`

### DIFF
--- a/src/controller/Discover.ts
+++ b/src/controller/Discover.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { All, AnyJson, MethodSubscription } from '@polkadot-live/types';
-import { ChainID, SomeChainState } from '@polkadot-live/types/chains';
+import { ChainID } from '@polkadot-live/types/chains';
 import { MainDebug } from '@/debugging';
 import { Account } from '@/model/Account';
 import { APIs } from './APIs';
@@ -23,25 +23,13 @@ export class Discover {
     const chainState = await ChainState.get(chain, address);
 
     // Calculate config from account's chain state.
-    const config = Discover.getSubscriptionConfig(chainState);
-
-    return { chainState, config };
-  };
-
-  // From chain state, configure subscription config to apply to an account.
-  // TODO: remove this, fall back to what is in the store.
-  static getSubscriptionConfig = (chainState: SomeChainState) => {
-    debug(`🧑🏻‍🔧 Configuring account config with chain state:`);
-    debug('⛓️ %o', chainState);
-
-    if (chainState.inNominationPool) {
-      debug(`🏖️ This account is in a nomination pool! add events to config...`);
-    }
-
-    // Return `all` for now.
-    return {
+    //
+    // TODO: fetch from store. No store item should mean that all events are subscribed to.
+    const config = {
       type: 'all',
     } as All;
+
+    return { chainState, config };
   };
 
   /**

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -1,8 +1,6 @@
 // Copyright 2023 @paritytech/polkadot-live authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { setStateWithRef } from '@polkadot-cloud/utils';
-import { Router } from './Router';
 import { AccountStateProvider } from '@app/contexts/AccountState';
 import { AddressesProvider } from '@app/contexts/Addresses';
 import { ChainsProvider } from '@app/contexts/Chains';
@@ -11,36 +9,7 @@ import { OverlayProvider } from '@app/contexts/Overlay';
 import { TooltipProvider } from '@app/contexts/Tooltip';
 import { TxMetaProvider } from '@app/contexts/TxMeta';
 import { withProviders } from '@app/library/Hooks/withProviders';
-import { useRef, useState } from 'react';
-import { ThemeProvider } from 'styled-components';
-
-// TODO: add new Themes.tsx file and move theming to it.
-export const ThemedRouter: React.FC = () => {
-  // check whether system is initially on dark mode.
-  const { matches: isDarkMode } = window.matchMedia(
-    '(prefers-color-scheme: dark)'
-  );
-  const initialTheme = isDarkMode ? 'dark' : 'light';
-
-  // store initial theme in state.
-  const [mode, setMode] = useState(initialTheme);
-  const modeRef = useRef(mode);
-
-  // subscribe to system theme changes.
-  window
-    .matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', (event) => {
-      setStateWithRef(event.matches ? 'dark' : 'light', setMode, modeRef);
-    });
-
-  return (
-    <ThemeProvider theme={{ mode: modeRef.current }}>
-      <div className="theme-polkadot-relay">
-        <Router />
-      </div>
-    </ThemeProvider>
-  );
-};
+import { Theme } from './Theme';
 
 export const Providers = withProviders(
   OverlayProvider,
@@ -50,4 +19,4 @@ export const Providers = withProviders(
   EventsProvider,
   TxMetaProvider,
   TooltipProvider
-)(ThemedRouter);
+)(Theme);

--- a/src/renderer/Theme.tsx
+++ b/src/renderer/Theme.tsx
@@ -1,0 +1,33 @@
+// Copyright 2023 @paritytech/polkadot-live authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { setStateWithRef } from '@polkadot-cloud/utils';
+import { Router } from './Router';
+import { useRef, useState } from 'react';
+import { ThemeProvider } from 'styled-components';
+
+export const Theme = () => {
+  // Check whether system is initially on dark mode.
+  const { matches: isDarkMode } = window.matchMedia(
+    '(prefers-color-scheme: dark)'
+  );
+
+  // Store initial theme in state.
+  const [mode, setMode] = useState(isDarkMode ? 'dark' : 'light');
+  const modeRef = useRef(mode);
+
+  // Subscribe to system theme changes.
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (event) => {
+      setStateWithRef(event.matches ? 'dark' : 'light', setMode, modeRef);
+    });
+
+  return (
+    <ThemeProvider theme={{ mode: modeRef.current }}>
+      <div className={`theme-polkadot-relay theme-${modeRef.current}`}>
+        <Router />
+      </div>
+    </ThemeProvider>
+  );
+};


### PR DESCRIPTION
- [x] Separates Theme component from Providers.
- [x] Remove `getSubscriptionConfig` and add TODO for fetching config from store. By default accounts will be subscribed to everything.