### PR TITLE
feat: import one ledger account

### DIFF
--- a/src/renderer/screens/Import/Addresses/Delete.tsx
+++ b/src/renderer/screens/Import/Addresses/Delete.tsx
@@ -11,7 +11,12 @@ import { useOverlay } from '@/renderer/contexts/Overlay';
 import type { DeleteProps } from './types';
 import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
 
-export const Delete = ({ address, setAddresses, source }: DeleteProps) => {
+export const Delete = ({
+  address,
+  setAddresses,
+  source,
+  setSection,
+}: DeleteProps) => {
   const { setStatus } = useOverlay();
 
   // Click handler function.
@@ -40,6 +45,9 @@ export const Delete = ({ address, setAddresses, source }: DeleteProps) => {
 
       return newAddresses;
     });
+
+    // Go back to import home page.
+    setSection(0);
 
     postAddressDeleteMessage();
   };

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -28,4 +28,5 @@ export interface DeleteProps {
   address: string;
   setAddresses: AnyFunction;
   source: AccountSource;
+  setSection: AnyFunction | null;
 }

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -19,6 +19,7 @@ export const Address = ({
   setAddresses,
   index,
   isImported,
+  setSection,
 }: LedgerAddressProps) => {
   // State for account name.
   const [accountName, setAccountName] = useState<string>(
@@ -71,6 +72,7 @@ export const Address = ({
             setAddresses={setAddresses}
             address={address}
             source="ledger"
+            setSection={setSection}
           />
         )
       }

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -44,6 +44,7 @@ export const Manage = ({
                   setAddresses={setAddresses}
                   index={index}
                   isImported={isImported}
+                  setSection={setSection}
                 />
               )
             )}
@@ -51,8 +52,12 @@ export const Manage = ({
           <div className="more">
             <ButtonText
               iconLeft={faArrowDown}
-              text={isImporting ? ' Getting Account' : 'Get Another Account'}
-              disabled={isImporting}
+              text={
+                isImporting
+                  ? ' Getting Account'
+                  : 'Get Another Account (Coming Soon)'
+              }
+              disabled={isImporting || true}
               onClick={() => toggleImport(true)}
             />
           </div>

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -71,6 +71,7 @@ export const Address = ({
             setAddresses={setAddresses}
             address={address}
             source="vault"
+            setSection={null}
           />
         )
       }

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -51,4 +51,5 @@ export interface LedgerAddressProps {
   index: number;
   isImported: boolean;
   setAddresses: AnyFunction;
+  setSection: AnyFunction;
 }


### PR DESCRIPTION
# Summary

The current polling mechanism to fetch a ledger address causes issues when trying to fetch more than one address.

With this in mind, adding more than one ledger account has been disabled until the importing mechanism is improved.

Tasks to complete in a future PR:
- Change UI to allow importing multiple ledger addresses. 
- Allow importing a Kusama account through the Kusama ledger app.

## Notes

A possible solution is to let the user choose how many accounts they wish to import from the ledger device. The UI needs additional development to accommodate this change, and to support importing Kusama accounts from a ledger device.