### PR TITLE
chore: task queue implementation

### DIFF
--- a/src/orchestrators/TaskQueue.ts
+++ b/src/orchestrators/TaskQueue.ts
@@ -1,0 +1,38 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AnyData } from '@/types/misc';
+
+export class TaskQueue {
+  private static queue: (() => Promise<AnyData>)[] = [];
+  private static executing = false;
+
+  static add = (promiseGenerator: () => Promise<AnyData>) =>
+    new Promise<AnyData>((resolve, reject) => {
+      // The async function stored in the queue.
+      const task = async () => {
+        try {
+          const result = await promiseGenerator();
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        } finally {
+          this.executing = false;
+          this.next();
+        }
+      };
+
+      this.queue.push(task);
+      this.next();
+    });
+
+  private static next = () => {
+    if (!this.executing && this.queue.length > 0) {
+      const task = this.queue.shift();
+      if (task) {
+        this.executing = true;
+        task();
+      }
+    }
+  };
+}

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -25,6 +25,7 @@ import { useEffect } from 'react';
 import { useOnlineStatus } from '@/renderer/contexts/OnlineStatus';
 import { useManage } from './provider';
 import { SubscriptionsController } from '@/controller/renderer/SubscriptionsController';
+import { TaskQueue } from '@/orchestrators/TaskQueue';
 import * as ApiUtils from '@/utils/ApiUtils';
 import type { AnyFunction } from '@w3ux/utils/types';
 
@@ -39,6 +40,14 @@ export const Permissions = ({ setSection, section, breadcrumb }: AnyJson) => {
       setSection(0);
     }
   }, [renderedSubscriptions]);
+
+  const handleQueuedToggle = async (
+    cached: WrappedSubscriptionTasks,
+    setNativeChecked: AnyFunction
+  ) => {
+    const p = async () => await handleToggle(cached, setNativeChecked);
+    TaskQueue.add(p);
+  };
 
   /// Handle a toggle, which sends a subscription task to the back-end
   /// and updates the front-end subscriptions state.
@@ -279,7 +288,7 @@ export const Permissions = ({ setSection, section, breadcrumb }: AnyJson) => {
               <PermissionRow
                 key={`${i}_${getKey(category, task.action, task.chainId, task.account?.address)}`}
                 task={task}
-                handleToggle={handleToggle}
+                handleToggle={handleQueuedToggle}
                 handleOneShot={handleOneShot}
                 handleNativeCheckbox={handleNativeCheckbox}
                 getDisabled={getDisabled}


### PR DESCRIPTION
# Summary

A simple promise-based task queue to prevent subscription task toggles executing at the same time.

The queueing system mitigates the scenario where an API instance for a particular network is not currently instantiated, and the user toggles two subscriptions for that particular network in quick succession, causing an error. 

The reason for this error is because separate subscription tasks cannot know that an API instance is in the process of being instantiated. The `APIsController` may also mark an API instance as being connected, when in fact it's still in the process of establishing a connection.