### PR TITLE
fix: application debugging iteration

### DIFF
--- a/src/controller/renderer/APIsController.ts
+++ b/src/controller/renderer/APIsController.ts
@@ -3,11 +3,8 @@
 
 import { Api } from '@/model/Api';
 import { ChainList } from '@/config/chains';
-import { MainDebug } from '@/utils/DebugUtils';
 import type { ChainID } from '@/types/chains';
 import type { FlattenedAPIData } from '@/types/apis';
-
-const debug = MainDebug.extend('APIs');
 
 /**
  *  A static class that manages active api providers.
@@ -41,7 +38,7 @@ export class APIsController {
       );
     }
 
-    debug('🤖 Creating new api interface: %o', endpoint);
+    console.log('🤖 Creating new api interface: %o', endpoint);
 
     // Create API instance.
     const instance = new Api(endpoint, chainId);
@@ -49,7 +46,7 @@ export class APIsController {
     // Set remaining instance properties and add to instances.
     this.instances.push(instance);
 
-    debug(
+    console.log(
       '🔧 New api disconnected instances: %o',
       this.instances.map((i) => i.chain)
     );
@@ -58,13 +55,12 @@ export class APIsController {
   /**
    * @name close
    * @summary Disconnect from a chain.
-   * @param {ChainID} chain - the chain identifier.
    */
   static close = async (chain: ChainID) => {
     const instance = this.instances.find((s) => s.chain === chain);
 
     if (instance) {
-      debug('🔷 Disconnect chain API instance %o.', chain);
+      console.log('🔷 Disconnect chain API instance %o.', chain);
       await instance.disconnect();
     }
   };

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -84,6 +84,9 @@ export class AccountsController {
    * @name unsubscribeAccounts
    * @summary Calls `unsub` for each account's queryMulti entries, but keeps the
    * subscription data. This method is called when the app goes into offline mode.
+   *
+   * @deprecated Since API instances re-connect automatically, we don't need to
+   * manually unsubscribe and re-build the query multi.
    */
   static unsubscribeAccounts() {
     for (const accounts of this.accounts.values()) {

--- a/src/controller/renderer/SubscriptionsController.ts
+++ b/src/controller/renderer/SubscriptionsController.ts
@@ -57,6 +57,9 @@ export class SubscriptionsController {
    * @name unsubscribeChains
    * @summary Calls `unsub` for each chain's queryMulti entry, but keeps the
    * subscription data. This method is called when the app goes into offline mode.
+   *
+   * @deprecated Since API instances re-connect automatically, we don't need to
+   * manually unsubscribe and re-build the query multi.
    */
   static unsubscribeChains() {
     this.chainSubscriptions?.unsubOnly();

--- a/src/model/Account.ts
+++ b/src/model/Account.ts
@@ -67,6 +67,11 @@ export class Account {
     }
   };
 
+  /**
+   * @name unsubQueryMulti
+   * @deprecated Since API instances re-connect automatically, we don't need to
+   * manually unsubscribe and re-build the query multi.
+   */
   unsubQueryMulti = () => {
     this.queryMulti?.unsubOnly();
   };

--- a/src/model/Api.ts
+++ b/src/model/Api.ts
@@ -151,17 +151,17 @@ export class Api {
    */
   initEvents = () => {
     this.provider?.on('connected', () => {
-      debug('⭕ %o', this.endpoint, ' CONNECTED');
+      console.log('⭕ %o', this.endpoint, ' CONNECTED');
       this.status = 'connected';
     });
 
-    this.provider?.on('disconnected', () => {
-      debug('❌ %o', this.endpoint, ' DISCONNECTED');
+    this.provider?.on('disconnected', async () => {
+      console.log('❌ %o', this.endpoint, ' DISCONNECTED');
       this.status = 'disconnected';
     });
 
-    this.provider?.on('error', () => {
-      debug('❗ %o', this.endpoint, ' ERROR');
+    this.provider?.on('error', async () => {
+      console.log('❗ %o', this.endpoint, ' ERROR');
       this.status = 'disconnected';
     });
   };

--- a/src/model/QueryMultiWrapper.ts
+++ b/src/model/QueryMultiWrapper.ts
@@ -26,7 +26,7 @@ export class QueryMultiWrapper {
    * @summary Returns `true` if an API instance is required for the provided chain ID for this wrapper, and `false` otherwise.
    * @returns {boolean} Represents if API instance is required for the provided chainID.
    */
-  requiresApiInstanceForChain(chainId: ChainID) {
+  requiresApiInstanceForChain(chainId: ChainID): boolean {
     return this.subscriptions.has(chainId);
   }
 
@@ -237,16 +237,13 @@ export class QueryMultiWrapper {
    */
   async build(chainId: ChainID) {
     if (!this.subscriptions.get(chainId)) {
-      debug('🟠 queryMulti map is empty.');
+      console.log('🟠 queryMulti map is empty.');
       return;
     }
 
     // Construct the argument for new queryMulti call.
     const finalArg: AnyData = await this.buildQueryMultiArg(chainId);
     const instance = await ApiUtils.getApiInstance(chainId);
-
-    // Make the new call to queryMulti.
-    debug('🔷 Call to api.queryMulti.');
 
     // Call queryMulti api.
     const unsub = await instance.api.queryMulti(
@@ -361,6 +358,9 @@ export class QueryMultiWrapper {
    * @name unsubOnly
    * @summary Unsubscribe from the wrapped queryMulti but keep the cached call entries.
    * This method is called when the app goes into offline mode.
+   *
+   * @deprecated APIs will automatically re-connect to queries. Manually unsubscribing
+   * is not required.
    */
   unsubOnly() {
     for (const { unsub } of this.subscriptions.values()) {

--- a/src/model/QueryMultiWrapper.ts
+++ b/src/model/QueryMultiWrapper.ts
@@ -419,8 +419,9 @@ export class QueryMultiWrapper {
    * @summary Dynamically build the query multi argument by iterating the target chain's call entries (subscription tasks).
    */
   private async buildQueryMultiArg(chainId: ChainID) {
-    const entry: QueryMultiEntry | undefined = this.subscriptions.get(chainId);
+    // An array of arrays. The inner array represents a single API call.
     const argument: AnyData = [];
+    const entry: QueryMultiEntry | undefined = this.subscriptions.get(chainId);
 
     if (!entry) {
       return argument;
@@ -442,7 +443,7 @@ export class QueryMultiWrapper {
         const apiCall: AnyFunction = await TaskOrchestrator.getApiCall(task);
 
         const callArray: AnyData[] = task.actionArgs
-          ? [apiCall].concat(task.actionArgs)
+          ? [apiCall].concat([...task.actionArgs])
           : [apiCall];
 
         argument.push(callArray);
@@ -467,7 +468,7 @@ export class QueryMultiWrapper {
 
           const apiCall: AnyFunction = await TaskOrchestrator.getApiCall(task);
           const callArray: AnyData[] = task.actionArgs
-            ? [apiCall].concat(task.actionArgs)
+            ? [apiCall].concat([...task.actionArgs])
             : [apiCall];
 
           argument.push(callArray);
@@ -535,7 +536,7 @@ export class QueryMultiWrapper {
     console.log('debug: data index registry:');
     console.log(dataIndexRegistry);
 
-    // Get updated entries with correct dataIndex for each task and set `justBuilt` flag.
+    // Get updated entries with correct `dataIndex` for each task and set `justBuilt` flag.
     const updatedEntries = entry.callEntries.map((e, i) => {
       const { entryIndex, dataIndex } = dataIndexRegistry[i];
 

--- a/src/orchestrators/TaskOrchestrator.ts
+++ b/src/orchestrators/TaskOrchestrator.ts
@@ -51,13 +51,11 @@ export class TaskOrchestrator {
         // Identify task
         switch (task.action) {
           case 'subscribe:chain:timestamp': {
-            debug('🟢 subscribe:chain:timestamp');
             await TaskOrchestrator.subscribe_query_timestamp_now(task, wrapper);
             break;
           }
 
           case 'subscribe:chain:currentSlot': {
-            debug('🟢 subscribe:chain:currentSlot');
             await TaskOrchestrator.subscribe_query_babe_currentSlot(
               task,
               wrapper
@@ -66,7 +64,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:balance': {
-            debug('🟢 subscribe:query.system.account (account)');
             await TaskOrchestrator.subscribe_query_system_account(
               task,
               wrapper
@@ -75,7 +72,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominationPools:rewards': {
-            debug('🟢 subscribe:account:nominationPools:rewards');
             await TaskOrchestrator.subscribe_nomination_pool_rewards(
               task,
               wrapper
@@ -84,7 +80,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominationPools:state': {
-            debug('🟢 subscribe:account:nominationPools:state');
             await TaskOrchestrator.subscribe_nomination_pool_state(
               task,
               wrapper
@@ -93,7 +88,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominationPools:renamed': {
-            debug('🟢 subscribe:account:nominationPools:renamed');
             await TaskOrchestrator.subscribe_nomination_pool_renamed(
               task,
               wrapper
@@ -102,7 +96,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominationPools:roles': {
-            debug('🟢 subscribe:account:nominationPools:roles');
             await TaskOrchestrator.subscribe_nomination_pool_roles(
               task,
               wrapper
@@ -111,7 +104,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominationPools:commission': {
-            debug('🟢 subscribe:account:nominationPools:commission');
             await TaskOrchestrator.subscribe_nomination_pool_commission(
               task,
               wrapper
@@ -120,7 +112,6 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominating:pendingPayouts': {
-            debug('🟢 subscribe:account:nominating:pendingPayouts');
             await TaskOrchestrator.subscribe_nominating_pending_payouts(
               task,
               wrapper
@@ -129,13 +120,11 @@ export class TaskOrchestrator {
           }
 
           case 'subscribe:account:nominating:exposure': {
-            debug('🟢 subscribe:account:nominating:exposure');
             await TaskOrchestrator.subscribe_nominating_exposure(task, wrapper);
             break;
           }
 
           case 'subscribe:account:nominating:commission': {
-            debug('🟢 subscribe:account:nominating:commission');
             await TaskOrchestrator.subscribe_nominating_commission(
               task,
               wrapper

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -3,13 +3,13 @@
 
 import { AccountsController } from '@/controller/renderer/AccountsController';
 import BigNumber from 'bignumber.js';
+import { checkAccountWithProperties } from '@/utils/AccountUtils';
+import { EventsController } from '@/controller/renderer/EventsController';
 import {
-  checkAccountWithProperties,
   getAccountExposed,
   getAccountExposedWestend,
-} from '@/utils/AccountUtils';
-import { EventsController } from '@/controller/renderer/EventsController';
-import { getUnclaimedPayouts } from './nominating';
+  getUnclaimedPayouts,
+} from './nominating';
 import { NotificationsController } from '@/controller/renderer/NotificationsController';
 import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
 import * as ApiUtils from '@/utils/ApiUtils';

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -115,7 +115,15 @@ export class Callbacks {
     isOneShot = false
   ) {
     try {
-      const account = checkAccountWithProperties(entry, ['balance']);
+      // Get account.
+      const account = AccountsController.get(
+        entry.task.chainId,
+        entry.task.account!.address
+      );
+
+      if (!account) {
+        return;
+      }
 
       // Get the received balance.
       const received: AccountBalance = {

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -187,15 +187,23 @@ export class Callbacks {
       const pendingRewardsPlanck: BigNumber =
         await api.call.nominationPoolsApi.pendingRewards(account.address);
 
-      // Return if pending rewards is zero.
-      if (!isOneShot && pendingRewardsPlanck.eq(0)) {
+      const isSame =
+        account.nominationPoolData!.poolPendingRewards.eq(pendingRewardsPlanck);
+
+      // Return if pending rewards is zero or no change.
+      if (
+        (!isOneShot && isSame) ||
+        (!isOneShot && pendingRewardsPlanck.eq(0))
+      ) {
         return;
       }
 
       // Update account and entry data.
-      account.nominationPoolData!.poolPendingRewards = pendingRewardsPlanck;
-      await AccountsController.set(chainId, account);
-      entry.task.account = account.flatten();
+      if (!isSame) {
+        account.nominationPoolData!.poolPendingRewards = pendingRewardsPlanck;
+        await AccountsController.set(chainId, account);
+        entry.task.account = account.flatten();
+      }
 
       // Get notification.
       const notification =

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -295,7 +295,7 @@ export class Callbacks {
       // Get the received pool name.
       const receivedPoolName: string = u8aToString(u8aUnwrapBytes(data));
       const prevName = account.nominationPoolData!.poolName;
-      const isSame = prevName === receivedPoolName;
+      const isSame = prevName === receivedPoolName || receivedPoolName === '';
 
       if (!isOneShot && isSame) {
         return;

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -343,7 +343,14 @@ export class Callbacks {
       const account = checkAccountWithProperties(entry, ['nominationPoolData']);
 
       // Get the received pool roles.
-      const { depositor, root, nominator, bouncer } = data.toHuman().roles;
+      interface Target {
+        depositor: string;
+        root: string;
+        nominator: string;
+        bouncer: string;
+      }
+      const humanData: AnyData = data.toHuman();
+      const { depositor, root, nominator, bouncer }: Target = humanData.roles;
 
       // Return if roles have not changed.
       const poolRoles = account.nominationPoolData!.poolRoles;
@@ -401,8 +408,8 @@ export class Callbacks {
       const account = checkAccountWithProperties(entry, ['nominationPoolData']);
 
       // Get the received pool commission.
-      const { changeRate, current, max, throttleFrom } =
-        data.toHuman().commission;
+      const humanData: AnyData = data.toHuman();
+      const { changeRate, current, max, throttleFrom } = humanData.commission;
 
       // Return if roles have not changed.
       const poolCommission = account.nominationPoolData!.poolCommission;

--- a/src/renderer/callbacks/nominating.ts
+++ b/src/renderer/callbacks/nominating.ts
@@ -3,9 +3,11 @@
 
 import BigNumber from 'bignumber.js';
 import { rmCommas } from '@w3ux/utils';
-import type { ApiPromise } from '@polkadot/api';
+import type { Account } from '@/model/Account';
 import type { AnyData } from '@/types/misc';
+import type { ApiPromise } from '@polkadot/api';
 import type { ChainID } from '@/types/chains';
+import type { ValidatorData } from '@/types/accounts';
 
 const MaxSupportedPayoutEras = 7;
 
@@ -526,4 +528,92 @@ export const getUnclaimedPayouts = async (
   }
 
   return unclaimed;
+};
+
+/**
+ * @name getAccountExposed
+ * @summary Return `true` if address is exposed in `era`. Return `false` otherwise.
+ */
+export const getAccountExposed = async (
+  api: ApiPromise,
+  era: number,
+  account: Account
+): Promise<boolean> => {
+  const result: AnyData = await api.query.staking.erasStakers.entries(era);
+
+  let exposed = false;
+  for (const val of result) {
+    // Check if account address is the validator.
+    if (val[0].toHuman() === account.address) {
+      exposed = true;
+      break;
+    }
+
+    // Check if account address is nominating this validator.
+    let counter = 0;
+    for (const { who } of val[1].toHuman().others) {
+      if (counter >= 512) {
+        break;
+      } else if (who === account.address) {
+        exposed = true;
+        break;
+      }
+      counter += 1;
+    }
+
+    // Break if the inner loop found exposure.
+    if (exposed) {
+      break;
+    }
+  }
+
+  return exposed;
+};
+
+/**
+ * @name getAccountExposedWestend
+ * @summary Return `true` if address is exposed in `era`. Return `false` otherwise.
+ */
+export const getAccountExposedWestend = async (
+  api: ApiPromise,
+  era: number,
+  account: Account,
+  validatorData: ValidatorData[]
+): Promise<boolean> => {
+  const validators = validatorData.map((v) => v.validatorId);
+  let exposed = false;
+
+  // Iterate validators account is nominating.
+  validatorLoop: for (const vId of validators) {
+    // Check if target address is the validator.
+    if (account.address === vId) {
+      exposed = true;
+      break;
+    }
+
+    // Iterate validator paged exposures.
+    const result: AnyData = await api.query.staking.erasStakersPaged.entries(
+      era,
+      vId
+    );
+
+    let counter = 0;
+
+    for (const item of result) {
+      for (const { who } of item[1].toHuman().others) {
+        // Move to next validator if account is not in top 512 stakers for this validator.
+        if (counter >= 512) {
+          continue validatorLoop;
+        }
+        // We know the account is exposed for this era if their address is found.
+        if ((who as string) === account.address) {
+          exposed = true;
+          break validatorLoop;
+        }
+        counter += 1;
+      }
+    }
+  }
+
+  return exposed;
 };

--- a/src/renderer/contexts/Subscriptions/index.tsx
+++ b/src/renderer/contexts/Subscriptions/index.tsx
@@ -128,7 +128,7 @@ export const SubscriptionsProvider = ({
     setNativeChecked: AnyFunction
   ) => {
     const p = async () => await toggleSubscription(cached, setNativeChecked);
-    await TaskQueue.add(p);
+    TaskQueue.add(p);
   };
 
   /// Handle subscription task toggle.

--- a/src/renderer/hooks/useInitIpcHandlers.ts
+++ b/src/renderer/hooks/useInitIpcHandlers.ts
@@ -86,17 +86,6 @@ export const useInitIpcHandlers = () => {
      * Handle switching to offline mode.
      */
     window.myAPI.initializeAppOffline(async () => {
-      // Unsubscribe queryMulti API calls for managed accounts.
-      AccountsController.unsubscribeAccounts();
-
-      // Unsubscribe queryMulti API calls for managed chains.
-      SubscriptionsController.unsubscribeChains();
-
-      // Disconnect from any active API instances.
-      for (const chainId of Array.from(ChainList.keys())) {
-        await APIsController.close(chainId);
-      }
-
       // Report online status to renderer.
       setOnline(await window.myAPI.getOnlineStatus());
     });

--- a/src/renderer/library/Header/index.tsx
+++ b/src/renderer/library/Header/index.tsx
@@ -7,11 +7,6 @@ import { Menu } from '@app/library/Menu';
 import { useLocation } from 'react-router-dom';
 import { HeaderWrapper } from './Wrapper';
 import type { HeaderProps } from './types';
-//TMP
-import BigNumber from 'bignumber.js';
-import { getApiInstance } from '@/utils/ApiUtils';
-import { getUnclaimedPayouts } from '@/renderer/callbacks/nominating';
-import type { ChainID } from '@/types/chains';
 
 export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
   const { pathname } = useLocation();
@@ -26,27 +21,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
       activeWindow = 'menu';
   }
 
-  // Function to calculate an account's unclaimed payouts.
-  const doUnclaimedPayouts = async () => {
-    //const address = '13htYtmALyHWxz6s6zcEnDtwBmtL1Ay54U3i4TEM555HJEhL';
-    //const chainId = 'Polkadot' as ChainID;
-    const address = '5ExuYYE7Qfq2BJYqUygBa8Nr2y1qemkuGwZHEuEujkqnL4Xs';
-    const chainId = 'Westend' as ChainID;
-    const { api } = await getApiInstance(chainId);
-
-    const unclaimed = await getUnclaimedPayouts(address, api, chainId);
-    let pendingPayout = new BigNumber(0);
-
-    for (const validatorToPayout of unclaimed.values()) {
-      for (const payoutItem of validatorToPayout.values()) {
-        const payout = payoutItem[1];
-        pendingPayout = pendingPayout.plus(new BigNumber(payout as string));
-      }
-    }
-
-    console.log(`Pending payout: ${pendingPayout}`);
-  };
-
   return (
     <HeaderWrapper>
       <div />
@@ -56,7 +30,7 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
             <button
               type="button"
               disabled={appLoading}
-              onClick={async () => await doUnclaimedPayouts()}
+              onClick={() => console.log('TODO')}
             >
               <FontAwesomeIcon icon={faToggleOn} transform="grow-3" />
             </button>

--- a/src/renderer/screens/Home/Manage/Wrappers.tsx
+++ b/src/renderer/screens/Home/Manage/Wrappers.tsx
@@ -15,10 +15,6 @@ export const Wrapper = styled.div`
   align-items: center;
   height: 100%;
   max-height: 100%;
-  overflow: hidden;
-  overflow-y: scroll;
-  width: 105%;
-  padding-right: 5%;
 `;
 
 export const BreadcrumbsWrapper = styled.div`

--- a/src/renderer/screens/Home/Manage/index.tsx
+++ b/src/renderer/screens/Home/Manage/index.tsx
@@ -36,9 +36,9 @@ export const Manage = ({ addresses }: ManageProps) => {
         },
       }}
     >
-      <div>
+      <div className="scrollable">
         {/* List of accounts and chains */}
-        <Wrapper className="scrollable">
+        <Wrapper>
           <Accounts
             setSection={setSection}
             setBreadcrumb={setBreadcrumb}
@@ -47,7 +47,7 @@ export const Manage = ({ addresses }: ManageProps) => {
           />
         </Wrapper>
       </div>
-      <div>
+      <div className="scrollable">
         {/* Subscription toggles for selected account or chain */}
         <Permissions
           setSection={setSection}

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -62,6 +62,7 @@ export interface NominationPoolCommission {
 export interface AccountNominatingData {
   exposed: boolean;
   lastCheckedEra: number;
+  submittedIn: number;
   validators: ValidatorData[];
 }
 

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -60,6 +60,8 @@ export interface NominationPoolCommission {
  */
 
 export interface AccountNominatingData {
+  exposed: boolean;
+  lastCheckedEra: number;
   validators: ValidatorData[];
 }
 

--- a/src/utils/AccountUtils.ts
+++ b/src/utils/AccountUtils.ts
@@ -100,13 +100,20 @@ export const setNominatingDataForAccount = async (
   account: Account
 ) => {
   // Check if account is currently nominating.
-  const resA: AnyData = await api.query.staking.nominators(account.address);
-  const nominators = resA.toHuman();
+  const nominatorData: AnyData = await api.query.staking.nominators(
+    account.address
+  );
+  const nominators = nominatorData.toHuman();
 
   // Return early if account is not nominating.
   if (nominators === null) {
     return;
   }
+
+  // Get submitted in era.
+  const submittedIn: number = parseInt(
+    (nominators.submittedIn as string).replace(/,/g, '')
+  );
 
   // Set account's nominating data.
   const accumulated: ValidatorData[] = [];
@@ -132,6 +139,7 @@ export const setNominatingDataForAccount = async (
   account.nominatingData = {
     exposed,
     lastCheckedEra: era,
+    submittedIn,
     validators: accumulated,
   };
 

--- a/src/utils/AccountUtils.ts
+++ b/src/utils/AccountUtils.ts
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { AccountsController } from '@/controller/renderer/AccountsController';
-import { planckToUnit } from '@w3ux/utils';
-import { chainUnits } from '@/config/chains';
 import BigNumber from 'bignumber.js';
 import {
   BN,
@@ -186,14 +184,9 @@ const setNominationPoolDataForAccount = async (
   const { reward: poolRewardAddress } = getPoolAccounts(poolId, api);
 
   // Get pending rewards for the account.
-  const pendingRewardsResult = await api.call.nominationPoolsApi.pendingRewards(
-    account.address
-  );
-
-  const poolPendingRewards = planckToUnit(
-    new BigNumber(pendingRewardsResult.toString()),
-    chainUnits(chainId)
-  );
+  const pendingRewardsResult: AnyJson =
+    await api.call.nominationPoolsApi.pendingRewards(account.address);
+  const poolPendingRewards = new BigNumber(pendingRewardsResult);
 
   // Get nomination pool data.
   const npResult: AnyData = (

--- a/src/utils/AccountUtils.ts
+++ b/src/utils/AccountUtils.ts
@@ -52,6 +52,8 @@ export const fetchAccountBalances = async () => {
         reserved: new BigNumber(result.data.reserved),
         frozen: new BigNumber(result.data.frozen),
       } as AccountBalance;
+
+      await AccountsController.set(account.chain, account);
     }
   }
 };


### PR DESCRIPTION
# Summary

## Bug fixes

- [x] Callback for `subscribe:account:nominating:exposure` 
Callback now only executes when the network starts a new era that hasn't been checked for the respective account's exposure.
  
- [x] Callback for `subscribe:account:nominating:commission`
The callback algorithm has been re-implemented to fetch potentially new nominated validators for the respective account. The callback now only executes when the network starts a new era that has not yet been checked for the respective account's nominations. Overview of the new algorithm:
  - Fetch live nominations for the account.
  - Check any validators that the account was nominating before for commission changes.
  - Get commissions for any new nominated validators in this era.
  - Re-cache validator information for the account if anything has changed.
  - Combine the commission change data for the event and notification.

- [x] Fix scrolling in main window.
A scrollbar is dynamically rendered when accordions overflow the window.

- [x] Callback for `subscribe:account:balance`
The `checkAccountWithProperties` call has been removed as an account doesn't need existing balance data for this callback to process. As a result, the callback will not crash for accounts with no cached balance data.

- [x] Fix offline mode API errors.
Manually disconnecting from APIs and unsubscribing from queries has been deprecated. API instances will automatically re-connect and complete requests when the app goes back into online mode. 

- [x] Task queue behaviour improved.
Rapidly toggling off and on subscriptions generally holds up and doesn't break the system. Tests indicate that a subscription task may fail to register in some cases. However, re-toggling the subscription in question re-builds the data correctly.