### PR TITLE
fix: debugging subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,44 +7,27 @@
 
 Decentralised Polkadot Notifications and Chain Interactions on the Desktop.
 
-## Testing
+## Documentation
 
-Follow the steps below to run the WebdriverIO test suite:
+Find out more about Polkadot Live here:
+- https://github.com/polkadot-live/docs
 
-1. Install Chrome Driver on your system. For Mac OS:
+## Build and run
 
-   ```
-   brew install chromedriver
-   ```
+Polkadot Live is in active development and the codebase is constantly changing. Keep in mind that the application is still at an early stage at this time.
 
-  **Note:** You may need to allow the `chromedriver` program to run on Mac OS
-  via the system preferences Privacy & Security settings.
+With that disclaimer out the way, use the following commands to build and run Polkadot Live:
 
-2. Package dependencies as of WebdriverIO version 8:
+```
+# Clone this repository
+gh repo clone polkadot-live/polkadot-live-app
 
-   ```
-   yarn add --dev expect expect-webdriverio @types/mocha @wdio/globals @wdio/mocha-framework
-   ```
+# Enter project root directory
+cd polkadot-live-app
 
-   Add following to `tsconfig.json`:
+# Install dependencies
+yarn install
 
-   ```
-   {
-      "compilerOptions": {
-         "types": ["node", "@wdio/globals/types", "@wdio/mocha-framework"]
-      }
-   }
-   ```
-
-2. Build the app by invoking the `package:dev` script, which bundles
-  `devDepencies` with the app needed for running the WebdriverIO test runner:
-
-   ```
-   yarn run package:dev
-   ```
-
-3. Invoke the `wdio` script to run the entire WDIO test suite:
-
-   ```
-   yarn run wdio
-   ```
+# Run
+yarn dev
+```

--- a/src/config/subscriptions/account.ts
+++ b/src/config/subscriptions/account.ts
@@ -111,7 +111,7 @@ export const accountTasks: SubscriptionTask[] = [
     apiCallAsString: 'api.query.system.account',
     category: 'Nomination Pools',
     chainId: 'Kusama',
-    enableOsNotifications: true,
+    enableOsNotifications: false,
     label: 'Unclaimed Rewards',
     status: 'disable',
   },

--- a/src/model/QueryMultiWrapper.ts
+++ b/src/model/QueryMultiWrapper.ts
@@ -374,7 +374,7 @@ export class QueryMultiWrapper {
    * @summary Set the enableOsNotifications for a task.
    */
   setOsNotificationsFlag(task: SubscriptionTask) {
-    const { chainId } = task;
+    const { chainId, enableOsNotifications } = task;
     const chainEntry = this.subscriptions.get(chainId);
 
     if (chainEntry) {
@@ -384,7 +384,7 @@ export class QueryMultiWrapper {
           e.task.action === task.action
             ? {
                 ...e,
-                task,
+                task: { ...e.task, enableOsNotifications },
               }
             : e
         ),


### PR DESCRIPTION
# Summary

- [x] Native checkbox bug.
The `dataIndex` property is kept intact for a given task when its native checkbox is clicked.

- [x] Point to documentation repository in README.