### PR TITLE
feat: ui tasks

### DIFF
--- a/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
@@ -10,7 +10,7 @@ export const Wrapper = styled.div<{ $noBorder?: boolean }>`
       : '1px solid var(--border-primary-color)'};
   display: flex;
   align-items: center;
-  padding: 1.25rem;
+  padding: 1rem;
 
   /* 3 Dot Spinner */
   .lds-ellipsis {
@@ -108,7 +108,7 @@ export const Wrapper = styled.div<{ $noBorder?: boolean }>`
 
     > .inner {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
 
       > .identicon {
         flex-shrink: 1;
@@ -155,8 +155,32 @@ export const Wrapper = styled.div<{ $noBorder?: boolean }>`
           display: flex;
           padding-left: 1.5rem;
 
+          .input-wrapper {
+            position: relative;
+            display: flex;
+            flex: 1;
+
+            .chain-icon {
+              position: absolute;
+              top: 5px;
+              left: 10px;
+              width: 1.5rem;
+              height: 1.5rem;
+              margin-top: 4px;
+
+              ellipse {
+                fill: #953254;
+              }
+            }
+
+            input {
+              padding-left: 38px;
+            }
+          }
+
           &.row {
             align-items: center;
+            column-gap: 1rem;
 
             .edit {
               margin-left: 0.75rem;
@@ -188,15 +212,15 @@ export const Wrapper = styled.div<{ $noBorder?: boolean }>`
           white-space: nowrap;
           overflow: hidden;
           width: 100%;
-          max-width: 175px;
+          max-width: 300px;
           transition:
             background-color 0.2s,
             max-width 0.2s,
             padding 0.2s;
 
           &:focus {
-            background: var(--background-menu);
-            max-width: 300px;
+            background: var(--background-modal);
+            max-width: 350px;
           }
 
           &:disabled {

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -8,6 +8,7 @@ import {
   faXmark,
 } from '@fortawesome/free-solid-svg-icons';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
+import { chainIcon } from '@/config/chains';
 import { unescape } from '@w3ux/utils';
 import { Flip, toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -17,6 +18,7 @@ import { validateAccountName } from '@/renderer/utils/ImportUtils';
 import { Wrapper } from './Wrapper';
 import type { FormEvent } from 'react';
 import type { HardwareAddressProps } from './types';
+import { getAddressChainId } from '@/renderer/Utils';
 
 export const HardwareAddress = ({
   address,
@@ -102,6 +104,13 @@ export const HardwareAddress = ({
     setEditName(val);
   };
 
+  // Function to render a chain icon.
+  const renderChainIcon = () => {
+    const chainId = getAddressChainId(address);
+    const ChainIcon = chainIcon(chainId);
+    return <ChainIcon className="chain-icon" />;
+  };
+
   // Function to render wrapper JSX.
   const renderContent = () => (
     <>
@@ -113,44 +122,47 @@ export const HardwareAddress = ({
           </div>
           <div>
             <section className="row">
-              <input
-                type="text"
-                value={editing ? editName : accountName}
-                onChange={(e) => handleChange(e)}
-                onFocus={() => setEditing(true)}
-                onKeyUp={(e) => {
-                  if (e.key === 'Enter') {
-                    commitEdit();
-                    e.currentTarget.blur();
-                  }
-                }}
-              />
+              <div className="input-wrapper">
+                {renderChainIcon()}
+                <input
+                  type="text"
+                  value={editing ? editName : accountName}
+                  onChange={(e) => handleChange(e)}
+                  onFocus={() => setEditing(true)}
+                  onKeyUp={(e) => {
+                    if (e.key === 'Enter') {
+                      commitEdit();
+                      e.currentTarget.blur();
+                    }
+                  }}
+                />
 
-              {editing && (
-                <div style={{ display: 'flex' }}>
-                  &nbsp;
-                  <button
-                    id="commit-btn"
-                    type="button"
-                    className="edit"
-                    onPointerDown={() => commitEdit()}
-                  >
-                    <FontAwesomeIcon
-                      icon={faCheck}
-                      transform="grow-1"
-                      className="icon"
-                    />
-                  </button>
-                  &nbsp;
-                  <button
-                    type="button"
-                    className="edit"
-                    onPointerDown={() => cancelEditing()}
-                  >
-                    <FontAwesomeIcon icon={faXmark} transform="grow-1" />
-                  </button>
-                </div>
-              )}
+                {editing && (
+                  <div style={{ display: 'flex' }}>
+                    &nbsp;
+                    <button
+                      id="commit-btn"
+                      type="button"
+                      className="edit"
+                      onPointerDown={() => commitEdit()}
+                    >
+                      <FontAwesomeIcon
+                        icon={faCheck}
+                        transform="grow-1"
+                        className="icon"
+                      />
+                    </button>
+                    &nbsp;
+                    <button
+                      type="button"
+                      className="edit"
+                      onPointerDown={() => cancelEditing()}
+                    >
+                      <FontAwesomeIcon icon={faXmark} transform="grow-1" />
+                    </button>
+                  </div>
+                )}
+              </div>
             </section>
             <h5 className="full">
               <span>{address}</span>

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -3,6 +3,7 @@
 
 import {
   faCheck,
+  faMinus,
   faPlus,
   faTimes,
   faXmark,
@@ -173,7 +174,7 @@ export const HardwareAddress = ({
       <div className="action">
         {isImported && !isProcessing ? (
           <ButtonMonoInvert
-            iconLeft={faTimes}
+            iconLeft={faMinus}
             text={'Remove'}
             onClick={() => openRemoveHandler()}
           />

--- a/src/renderer/screens/Action/SignOverlay.tsx
+++ b/src/renderer/screens/Action/SignOverlay.tsx
@@ -53,7 +53,7 @@ export const SignOverlay = ({ from }: { from: string }) => {
     }
   };
 
-  const containerStyle = useMemo(() => createImgSize(279), []);
+  const containerStyle = useMemo(() => createImgSize(300), []);
 
   return (
     <QRViewerWrapper>
@@ -67,7 +67,7 @@ export const SignOverlay = ({ from }: { from: string }) => {
         <span className={stage === 2 ? 'active' : undefined}>Sign</span>
       </div>
       {stage === 1 && (
-        <div className="viewer withBorder">
+        <div className="viewer withBorder payload-wrapper">
           <QrDisplayPayload
             address={from || ''}
             cmd={2}
@@ -79,7 +79,7 @@ export const SignOverlay = ({ from }: { from: string }) => {
       )}
       {stage === 2 && (
         <div className="viewer">
-          <ScanWrapper className={''} style={containerStyle}>
+          <ScanWrapper style={containerStyle}>
             <Html5QrCodePlugin
               fps={10}
               qrCodeSuccessCallback={onScan}

--- a/src/renderer/screens/Action/Wrappers.ts
+++ b/src/renderer/screens/Action/Wrappers.ts
@@ -66,14 +66,14 @@ export const QRViewerWrapper = styled.div`
       padding: 0.95rem;
       border: 3.75px solid var(--network-color-pending);
     }
+  }
 
-    /* Override QRScanner styles */
-    > div {
-      width: 175px !important;
-      height: 175px !important;
-      > section > section > div {
-        border-width: 20px !important;
-      }
+  /* Override QRScanner styles */
+  > .payload-wrapper {
+    width: 175px !important;
+    height: 175px !important;
+    > section > section > div {
+      border-width: 20px !important;
     }
   }
   .foot {

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -9,13 +9,18 @@ import {
 } from '@/renderer/library/Accordion';
 import { AccountWrapper, AccountsWrapper, HeadingWrapper } from './Wrappers';
 import { ButtonText } from '@/renderer/kits/Buttons/ButtonText';
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCaretDown,
+  faCaretRight,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getIcon } from '@/renderer/Utils';
 import { Identicon } from '@app/library/Identicon';
 import { NoAccounts } from '../NoAccounts';
-import PolkadotIcon from '@app/svg/polkadotIcon.svg?react';
 import { useManage } from './provider';
 import { useSubscriptions } from '@/renderer/contexts/Subscriptions';
+import { useState } from 'react';
 import type { AccountsProps } from './types';
 import type { ChainID } from '@/types/chains';
 import type { FlattenedAccountData } from '@/types/accounts';
@@ -33,6 +38,11 @@ export const Accounts = ({
   const { getChainSubscriptions, getAccountSubscriptions, chainSubscriptions } =
     useSubscriptions();
   const { setRenderedSubscriptions } = useManage();
+
+  // Active accordion indices for account subscription tasks categories.
+  const [accordionActiveIndices, setAccordionActiveIndices] = useState<
+    number[]
+  >([0, 1]);
 
   // Utility to copy tasks.
   const copyTasks = (tasks: SubscriptionTask[]) =>
@@ -73,19 +83,31 @@ export const Accounts = ({
 
   return (
     <AccountsWrapper>
-      <Accordion multiple defaultIndex={[0, 1]}>
+      <Accordion
+        multiple
+        defaultIndex={accordionActiveIndices}
+        setExternalIndices={setAccordionActiveIndices}
+      >
         {/* Manage Accounts */}
         <AccordionItem>
           <HeadingWrapper>
             <AccordionHeader>
               <div className="flex">
-                <div>
-                  <div className="left">
-                    <h5>
-                      <PolkadotIcon className="icon" />
-                      Accounts
-                    </h5>
+                <div className="left">
+                  <div className="icon-wrapper">
+                    {accordionActiveIndices.includes(0) ? (
+                      <FontAwesomeIcon
+                        icon={faCaretDown}
+                        transform={'shrink-1'}
+                      />
+                    ) : (
+                      <FontAwesomeIcon
+                        icon={faCaretRight}
+                        transform={'shrink-1'}
+                      />
+                    )}
                   </div>
+                  <h5>Accounts</h5>
                 </div>
               </div>
             </AccordionHeader>
@@ -135,13 +157,21 @@ export const Accounts = ({
           <HeadingWrapper>
             <AccordionHeader>
               <div className="flex">
-                <div>
-                  <div className="left">
-                    <h5>
-                      <PolkadotIcon className="icon" />
-                      Chains
-                    </h5>
+                <div className="left">
+                  <div className="icon-wrapper">
+                    {accordionActiveIndices.includes(1) ? (
+                      <FontAwesomeIcon
+                        icon={faCaretDown}
+                        transform={'shrink-1'}
+                      />
+                    ) : (
+                      <FontAwesomeIcon
+                        icon={faCaretRight}
+                        transform={'shrink-1'}
+                      />
+                    )}
                   </div>
+                  <h5>Chains</h5>
                 </div>
               </div>
             </AccordionHeader>

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -15,7 +15,11 @@ import {
 import { AccountsController } from '@/controller/renderer/AccountsController';
 import { ButtonText } from '@/renderer/kits/Buttons/ButtonText';
 import { executeOneShot } from '@/renderer/callbacks/oneshots';
-import { faAngleLeft, faToggleOn } from '@fortawesome/free-solid-svg-icons';
+import {
+  faAngleLeft,
+  faCaretDown,
+  faCaretRight,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PermissionRow } from './PermissionRow';
 import { Switch } from '@/renderer/library/Switch';
@@ -45,6 +49,10 @@ export const Permissions = ({
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
     number[]
   >([0, 1, 2]);
+
+  // Active accordion indices for chain subscription tasks categories.
+  const [accordionActiveChainIndices, setAccordionActiveChainIndices] =
+    useState<number[]>([0]);
 
   useEffect(() => {
     if (section === 1 && renderedSubscriptions.type == '') {
@@ -199,12 +207,16 @@ export const Permissions = ({
   /// Get dynamic accordion indices state for account categories or
   /// static accordion indices for chain categories.
   const getAccordionIndices = () =>
-    typeClicked === 'account' ? accordionActiveIndices : [0];
+    typeClicked === 'account'
+      ? accordionActiveIndices
+      : accordionActiveChainIndices;
 
   /// Provide the external indices setter if we are about to render
   /// account subscription tasks in the accordion.
   const getAccordionIndicesSetter = () =>
-    typeClicked === 'account' ? setAccordionActiveIndices : undefined;
+    typeClicked === 'account'
+      ? setAccordionActiveIndices
+      : setAccordionActiveChainIndices;
 
   /// Renders a list of categorised subscription tasks that can be toggled.
   const renderSubscriptionTasks = () => (
@@ -218,29 +230,39 @@ export const Permissions = ({
           <HeadingWrapper>
             <AccordionHeader>
               <div className="flex">
-                <div>
-                  <div className="left">
-                    <h5>
-                      <FontAwesomeIcon icon={faToggleOn} transform="grow-3" />
-                      <span>{category}</span>
-                    </h5>
+                <div className="left">
+                  <div className="icon-wrapper">
+                    {getAccordionIndices().includes(j) ? (
+                      <FontAwesomeIcon
+                        icon={faCaretDown}
+                        transform={'shrink-1'}
+                      />
+                    ) : (
+                      <FontAwesomeIcon
+                        icon={faCaretRight}
+                        transform={'shrink-1'}
+                      />
+                    )}
                   </div>
-                  <div className="right">
-                    <Switch
-                      size="sm"
-                      type="secondary"
-                      isOn={getCategoryToggles().get(category) || false}
-                      disabled={getDisabled(tasks[0])}
-                      handleToggle={async () =>
-                        await toggleCategoryTasks(
-                          category,
-                          getCategoryToggles().get(category) || false,
-                          renderedSubscriptions,
-                          updateRenderedSubscriptions
-                        )
-                      }
-                    />
-                  </div>
+                  <h5>
+                    <span>{category}</span>
+                  </h5>
+                </div>
+                <div className="right">
+                  <Switch
+                    size="sm"
+                    type="secondary"
+                    isOn={getCategoryToggles().get(category) || false}
+                    disabled={getDisabled(tasks[0])}
+                    handleToggle={async () =>
+                      await toggleCategoryTasks(
+                        category,
+                        getCategoryToggles().get(category) || false,
+                        renderedSubscriptions,
+                        updateRenderedSubscriptions
+                      )
+                    }
+                  />
                 </div>
               </div>
             </AccordionHeader>

--- a/src/renderer/screens/Home/Manage/Wrappers.tsx
+++ b/src/renderer/screens/Home/Manage/Wrappers.tsx
@@ -48,9 +48,7 @@ export const BreadcrumbsWrapper = styled.div`
 `;
 
 export const HeadingWrapper = styled.div`
-  position: sticky;
   width: 100%;
-  top: 0rem;
   padding: 0.5rem 1rem;
   z-index: 3;
   opacity: 0.75;
@@ -58,6 +56,9 @@ export const HeadingWrapper = styled.div`
   cursor: pointer;
 
   .flex {
+    display: flex;
+    column-gap: 0.5rem;
+    align-items: center;
     padding: 0.25rem 0.5rem;
     transition: background-color 0.15s ease-in-out;
     border-bottom: 1px solid var(--border-secondary-color);
@@ -74,26 +75,24 @@ export const HeadingWrapper = styled.div`
     }
 
     .left {
-      display: flex;
-      justify-content: flex-start;
       flex: 1;
+      display: flex;
+      column-gap: 0.75rem;
+      justify-content: flex-start;
+
+      .icon-wrapper {
+        min-width: 0.75rem;
+        opacity: 0.4;
+      }
+      h5 {
+        > span {
+          color: var(--text-color-primary);
+        }
+      }
     }
     .right {
       display: flex;
       justify-content: flex-end;
-    }
-  }
-
-  h5 {
-    > span {
-      margin-left: 1rem;
-      color: var(--text-color-primary);
-    }
-    .icon {
-      fill: var(--text-color-primary);
-      width: 0.95rem;
-      height: 0.95rem;
-      margin-right: 0.5rem;
     }
   }
 `;

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -11,9 +11,10 @@ import { Address } from './Address';
 import { determineStatusFromCodes } from './Utils';
 import { ButtonText } from '@/renderer/kits/Buttons/ButtonText';
 import { HardwareStatusBar } from '@app/library/Hardware/HardwareStatusBar';
+import { HeaderWrapper } from '../../Wrappers';
+import { getSortedLocalLedgerAddresses } from '@/renderer/utils/ImportUtils';
 import type { ImportLedgerManageProps } from '../types';
 import type { LedgerLocalAddress } from '@/types/accounts';
-import { HeaderWrapper } from '../../Wrappers';
 
 export const Manage = ({
   addresses,
@@ -56,7 +57,7 @@ export const Manage = ({
             </div>
 
             <div className="items">
-              {addresses.map(
+              {getSortedLocalLedgerAddresses(addresses).map(
                 ({ address, index, isImported, name }: LedgerLocalAddress) => (
                   <Address
                     key={address}

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -10,6 +10,8 @@ import { Config as ConfigImport } from '@/config/processes/import';
 import { DragClose } from '@/renderer/library/DragClose';
 import { ellipsisFn, unescape } from '@w3ux/utils';
 import { Flip, toast } from 'react-toastify';
+import { getSortedLocalAddresses } from '@/renderer/utils/ImportUtils';
+import { HeaderWrapper } from '../../Wrappers';
 import { HardwareStatusBar } from '@/renderer/library/Hardware/HardwareStatusBar';
 import { Identicon } from '@/renderer/library/Identicon';
 import ReadmeSVG from '@/config/svg/readonly.svg?react';
@@ -19,7 +21,6 @@ import { useAccountStatuses } from '@/renderer/contexts/AccountStatuses';
 import type { FormEvent } from 'react';
 import type { LocalAddress } from '@/types/accounts';
 import type { ManageReadOnlyProps } from '../types';
-import { HeaderWrapper } from '../../Wrappers';
 
 export const Manage = ({
   setSection,
@@ -206,7 +207,7 @@ export const Manage = ({
             <div className="items">
               {addresses.length ? (
                 <>
-                  {addresses.map(
+                  {getSortedLocalAddresses(addresses).map(
                     ({ address, index, isImported, name }: LocalAddress) => (
                       <Address
                         key={address}

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -12,10 +12,11 @@ import { AddressWrapper } from '../Addresses/Wrappers';
 import { Address } from './Address';
 import { Reader } from './Reader';
 import { ButtonText } from '@/renderer/kits/Buttons/ButtonText';
+import { getSortedLocalAddresses } from '@/renderer/utils/ImportUtils';
+import { HeaderWrapper } from '../../Wrappers';
 import { HardwareStatusBar } from '@app/library/Hardware/HardwareStatusBar';
 import type { LocalAddress } from '@/types/accounts';
 import type { ManageVaultProps } from '../types';
-import { HeaderWrapper } from '../../Wrappers';
 
 export const Manage = ({
   setSection,
@@ -65,7 +66,7 @@ export const Manage = ({
               </div>
 
               <div className="items">
-                {addresses.map(
+                {getSortedLocalAddresses(addresses).map(
                   ({ address, index, isImported, name }: LocalAddress) => (
                     <Address
                       key={address}

--- a/src/renderer/screens/Import/Vault/Reader.tsx
+++ b/src/renderer/screens/Import/Vault/Reader.tsx
@@ -129,12 +129,12 @@ export const Reader = ({ addresses, setAddresses }: ReaderVaultProps) => {
     setOverlayStatus(0);
   };
 
-  const containerStyle = useMemo(() => createImgSize(279), []);
+  const containerStyle = useMemo(() => createImgSize(400), []);
 
   return (
     <QRVieweraWrapper>
       <div className="viewer">
-        <ScanWrapper className={''} style={containerStyle}>
+        <ScanWrapper style={containerStyle}>
           <Html5QrCodePlugin
             fps={10}
             qrCodeSuccessCallback={onScan}

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -112,3 +112,41 @@ export const getLocalAccountName = (
     return 'System Account';
   }
 };
+
+/**
+ * @name getSortedLocalAddresses
+ * @summary Function to get addresses categorized by chain ID and sorted by name.
+ */
+export const getSortedLocalAddresses = (addresses: LocalAddress[]) => {
+  let sorted: LocalAddress[] = [];
+
+  for (const chainId of ['Polkadot', 'Kusama', 'Westend']) {
+    sorted = sorted.concat(
+      addresses
+        .filter((a) => getAddressChainId(a.address) === chainId)
+        .sort((a, b) => a.name.localeCompare(b.name))
+    );
+  }
+
+  return sorted;
+};
+
+/**
+ * @name getSortedLocalLedgerAddresses
+ * @summary Same as `getSortedLocalAddresses` but for the local Ledger address type.
+ */
+export const getSortedLocalLedgerAddresses = (
+  addresses: LedgerLocalAddress[]
+) => {
+  let sorted: LedgerLocalAddress[] = [];
+
+  for (const chainId of ['Polkadot', 'Kusama', 'Westend']) {
+    sorted = sorted.concat(
+      addresses
+        .filter((a) => getAddressChainId(a.address) === chainId)
+        .sort((a, b) => a.name.localeCompare(b.name))
+    );
+  }
+
+  return sorted;
+};


### PR DESCRIPTION
# Summary

- [x] **Fix or remove subscription task category header icons.**
Accordion headers now have a dynamic caret that will point right when the accordion item is collapsed, and down when it's open.

- [x] Increase size of QR scanner video.
The QR code scanner's video size has been increased to make use of the available screen real-estate. The video is rendered within an overlay, and appears in the process of importing an account or signing a transaction with the vault app.

- [x] Render imported accounts by chain ID in sorted order.
Imported addresses are categorised by chain ID in the order `Polkadot`, `Kusama` and `Westend`. They are then rendered in alphabetical order based on the its given name.