### PR TITLE
feat: accounts list iteration

### DIFF
--- a/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
@@ -133,6 +133,10 @@ export const Wrapper = styled.div<{
     column-gap: 1rem;
     padding-left: 1rem;
 
+    .account-action-btn {
+      min-width: 60px;
+    }
+
     button {
       flex-basis: 50%;
       flex-grow: 1;

--- a/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
@@ -204,6 +204,10 @@ export const Wrapper = styled.div<{
             display: flex;
             flex: 1;
 
+            .fade {
+              opacity: 0.5;
+            }
+
             .chain-icon {
               position: absolute;
               top: 5px;
@@ -211,6 +215,7 @@ export const Wrapper = styled.div<{
               width: 1.5rem;
               height: 1.5rem;
               margin-top: 4px;
+              transition: opacity 0.1s ease-out;
 
               ellipse {
                 fill: #953254;

--- a/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
@@ -76,8 +76,9 @@ export const Wrapper = styled.div<{ $noBorder?: boolean }>`
     }
   }
 
+  transition: background-color 0.1s ease-out;
   &:hover {
-    background-color: var(--background-menu);
+    background-color: var(--background-primary);
     cursor: default;
   }
 

--- a/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 export const Wrapper = styled.div<{ $noBorder?: boolean }>`
   border-bottom: ${(props) =>
-    String(props.$noBorder) === 'true'
+    props.$noBorder === true
       ? 'none'
       : '1px solid var(--border-primary-color)'};
   display: flex;

--- a/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/Wrapper.ts
@@ -3,11 +3,17 @@
 
 import styled from 'styled-components';
 
-export const Wrapper = styled.div<{ $noBorder?: boolean }>`
+export const Wrapper = styled.div<{
+  $orderData?: { curIndex: number; lastIndex: number };
+}>`
+  // No border bottom if last item in list.
   border-bottom: ${(props) =>
-    props.$noBorder === true
+    !props.$orderData
       ? 'none'
-      : '1px solid var(--border-primary-color)'};
+      : props.$orderData.curIndex === props.$orderData.lastIndex
+        ? 'none'
+        : '1px solid var(--border-primary-color)'};
+
   display: flex;
   align-items: center;
   padding: 1rem;
@@ -78,6 +84,35 @@ export const Wrapper = styled.div<{ $noBorder?: boolean }>`
 
   transition: background-color 0.1s ease-out;
   &:hover {
+    // Specify border radius on first and last items in list.
+    border-top-right-radius: ${(props) =>
+      props.$orderData
+        ? props.$orderData.curIndex === 0
+          ? '1.25rem'
+          : '0'
+        : '0'};
+
+    border-top-left-radius: ${(props) =>
+      props.$orderData
+        ? props.$orderData.curIndex === 0
+          ? '1.25rem'
+          : '0'
+        : '0'};
+
+    border-bottom-left-radius: ${(props) =>
+      props.$orderData
+        ? props.$orderData.curIndex === props.$orderData.lastIndex
+          ? '1.25rem'
+          : '0'
+        : '0'};
+
+    border-bottom-right-radius: ${(props) =>
+      props.$orderData
+        ? props.$orderData.curIndex === props.$orderData.lastIndex
+          ? '1.25rem'
+          : '0'
+        : '0'};
+
     background-color: var(--background-primary);
     cursor: default;
   }

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -117,7 +117,7 @@ export const HardwareAddress = ({
   const renderChainIcon = () => {
     const chainId = getAddressChainId(address);
     const ChainIcon = chainIcon(chainId);
-    return <ChainIcon className="chain-icon" />;
+    return <ChainIcon className={editing ? 'chain-icon' : 'chain-icon fade'} />;
   };
 
   // Function to render wrapper JSX.

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -27,7 +27,7 @@ export const HardwareAddress = ({
   address,
   index,
   isImported,
-  isLast,
+  orderData,
   isProcessing,
   accountName,
   renameHandler,
@@ -225,9 +225,5 @@ export const HardwareAddress = ({
   );
 
   // Don't render bottom border on the address if it's the last one.
-  if (isLast) {
-    return <Wrapper $noBorder>{renderContent()}</Wrapper>;
-  } else {
-    return <Wrapper>{renderContent()}</Wrapper>;
-  }
+  return <Wrapper $orderData={orderData}>{renderContent()}</Wrapper>;
 };

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import {
-  faCheck,
-  faMinus,
-  faPlus,
-  faTimes,
-  faXmark,
-} from '@fortawesome/free-solid-svg-icons';
+  faDownFromDottedLine,
+  faEraser,
+  faTrash,
+} from '@fortawesome/pro-light-svg-icons';
+import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { chainIcon } from '@/config/chains';
 import { unescape } from '@w3ux/utils';
@@ -181,30 +180,44 @@ export const HardwareAddress = ({
       </div>
       <div className="action">
         {isImported && !isProcessing ? (
-          <ButtonMonoInvert
-            iconLeft={faMinus}
-            text={'Remove'}
-            onClick={() => openRemoveHandler()}
-          />
+          <div
+            style={{ position: 'relative' }}
+            className="tooltip-trigger-element"
+            data-tooltip-text={'Remove'}
+            onMouseMove={() => setTooltipTextAndOpen('Remove')}
+          >
+            <ButtonMonoInvert
+              className="account-action-btn"
+              iconLeft={faEraser}
+              text={''}
+              onClick={() => openRemoveHandler()}
+            />
+          </div>
         ) : (
           <div
             style={{ position: 'relative' }}
             className="tooltip-trigger-element"
-            data-tooltip-text={'Offline Mode'}
-            onMouseMove={() => {
-              !isConnected && setTooltipTextAndOpen('Offline Mode');
-            }}
+            data-tooltip-text={isConnected ? 'Import' : 'Offline Mode'}
+            onMouseMove={() =>
+              isConnected
+                ? setTooltipTextAndOpen('Import')
+                : setTooltipTextAndOpen('Offline Mode')
+            }
           >
             <ButtonMonoInvert
               disabled={!isConnected}
-              iconLeft={faPlus}
-              text={'Import'}
+              iconLeft={faDownFromDottedLine}
+              text={''}
               onClick={() => openConfirmHandler()}
-              className={isProcessing ? 'processing' : ''}
+              className={
+                isProcessing
+                  ? 'account-action-btn processing'
+                  : 'account-action-btn'
+              }
             />
             {isProcessing && (
               <div
-                style={{ position: 'absolute', left: '15px', top: '10px' }}
+                style={{ position: 'absolute', left: '3px', top: '8px' }}
                 className="lds-ellipsis"
               >
                 <div></div>
@@ -215,11 +228,18 @@ export const HardwareAddress = ({
             )}
           </div>
         )}
-        <ButtonMonoInvert
-          iconLeft={faTimes}
-          text={'Delete'}
-          onClick={() => openDeleteHandler()}
-        />
+        <div
+          className="tooltip-trigger-element"
+          data-tooltip-text={'Delete'}
+          onMouseMove={() => setTooltipTextAndOpen('Delete')}
+        >
+          <ButtonMonoInvert
+            className="account-action-btn"
+            iconLeft={faTrash}
+            text={''}
+            onClick={() => openDeleteHandler()}
+          />
+        </div>
       </div>
     </>
   );

--- a/src/renderer/library/Hardware/HardwareAddress/types.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/types.ts
@@ -10,8 +10,8 @@ export type HardwareAddressProps = ComponentBase & {
   index: number;
   // Whether this address is imported in main window.
   isImported: boolean;
-  // Whether the address is the last in the list (used for styling).
-  isLast: boolean;
+  // Index data for the current address.
+  orderData: { curIndex: number; lastIndex: number };
   // The account's processing flag.
   isProcessing: boolean;
   // current name of the account.

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -39,10 +39,41 @@ export const Accounts = ({
     useSubscriptions();
   const { setRenderedSubscriptions } = useManage();
 
+  // Categorise addresses by their chain ID, sort by name.
+  const getSortedAddresses = () => {
+    const sorted = new Map<ChainID, FlattenedAccountData[]>();
+
+    // Map addresses to their chain ID.
+    for (const address of addresses) {
+      const chainId = address.chain;
+
+      if (sorted.has(chainId)) {
+        sorted.set(chainId, [...sorted.get(chainId)!, { ...address }]);
+      } else {
+        sorted.set(chainId, [{ ...address }]);
+      }
+    }
+
+    // Sort addresses by their name.
+    for (const [chainId, chainAddresses] of sorted.entries()) {
+      sorted.set(
+        chainId,
+        chainAddresses.sort((x, y) => x.name.localeCompare(y.name))
+      );
+    }
+
+    return sorted;
+  };
+
   // Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
     number[]
-  >([0, 1]);
+  >(
+    Array.from(
+      { length: Array.from(getSortedAddresses().keys()).length + 1 },
+      (_, index) => index
+    )
+  );
 
   // Utility to copy tasks.
   const copyTasks = (tasks: SubscriptionTask[]) =>
@@ -89,73 +120,80 @@ export const Accounts = ({
         setExternalIndices={setAccordionActiveIndices}
       >
         {/* Manage Accounts */}
-        <AccordionItem>
-          <HeadingWrapper>
-            <AccordionHeader>
-              <div className="flex">
-                <div className="left">
-                  <div className="icon-wrapper">
-                    {accordionActiveIndices.includes(0) ? (
-                      <FontAwesomeIcon
-                        icon={faCaretDown}
-                        transform={'shrink-1'}
-                      />
-                    ) : (
-                      <FontAwesomeIcon
-                        icon={faCaretRight}
-                        transform={'shrink-1'}
-                      />
-                    )}
+        {Array.from(getSortedAddresses().entries()).map(
+          ([chainId, chainAddresses]) => (
+            <AccordionItem key={`${chainId}_accounts`}>
+              <HeadingWrapper>
+                <AccordionHeader>
+                  <div className="flex">
+                    <div className="left">
+                      <div className="icon-wrapper">
+                        {accordionActiveIndices.includes(0) ? (
+                          <FontAwesomeIcon
+                            icon={faCaretDown}
+                            transform={'shrink-1'}
+                          />
+                        ) : (
+                          <FontAwesomeIcon
+                            icon={faCaretRight}
+                            transform={'shrink-1'}
+                          />
+                        )}
+                      </div>
+                      <h5>{chainId} Accounts</h5>
+                    </div>
                   </div>
-                  <h5>Accounts</h5>
-                </div>
-              </div>
-            </AccordionHeader>
-          </HeadingWrapper>
-          <AccordionPanel>
-            <div style={{ padding: '0 0.75rem' }}>
-              {addresses.length ? (
-                <div className="flex-column">
-                  {addresses.map(
-                    ({ address, name }: FlattenedAccountData, i: number) => (
-                      <AccountWrapper
-                        whileHover={{ scale: 1.01 }}
-                        key={`manage_account_${i}`}
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleClickAccount(name, address)}
-                        ></button>
-                        <div className="inner">
-                          <div>
-                            <span className="icon">
-                              <Identicon value={address} size={26} />
-                            </span>
-                            <div className="content">
-                              <h3>{name}</h3>
+                </AccordionHeader>
+              </HeadingWrapper>
+              <AccordionPanel>
+                <div style={{ padding: '0 0.75rem' }}>
+                  {addresses.length ? (
+                    <div className="flex-column">
+                      {chainAddresses.map(
+                        (
+                          { address, name }: FlattenedAccountData,
+                          i: number
+                        ) => (
+                          <AccountWrapper
+                            whileHover={{ scale: 1.01 }}
+                            key={`manage_account_${i}`}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => handleClickAccount(name, address)}
+                            ></button>
+                            <div className="inner">
+                              <div>
+                                <span className="icon">
+                                  <Identicon value={address} size={26} />
+                                </span>
+                                <div className="content">
+                                  <h3>{name}</h3>
+                                </div>
+                              </div>
+                              <div>
+                                <ButtonText
+                                  text=""
+                                  iconRight={faChevronRight}
+                                  iconTransform="shrink-3"
+                                />
+                              </div>
                             </div>
-                          </div>
-                          <div>
-                            <ButtonText
-                              text=""
-                              iconRight={faChevronRight}
-                              iconTransform="shrink-3"
-                            />
-                          </div>
-                        </div>
-                      </AccountWrapper>
-                    )
+                          </AccountWrapper>
+                        )
+                      )}
+                    </div>
+                  ) : (
+                    <NoAccounts />
                   )}
                 </div>
-              ) : (
-                <NoAccounts />
-              )}
-            </div>
-          </AccordionPanel>
-        </AccordionItem>
+              </AccordionPanel>
+            </AccordionItem>
+          )
+        )}
 
         {/* Manage Chains */}
-        <AccordionItem key={1}>
+        <AccordionItem key={'chain_accounts'}>
           <HeadingWrapper>
             <AccordionHeader>
               <div className="flex">

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -43,6 +43,11 @@ export const Accounts = ({
   const getSortedAddresses = () => {
     const sorted = new Map<ChainID, FlattenedAccountData[]>();
 
+    // Insert map keys in a certain order.
+    for (const chainId of ['Polkadot', 'Kusama', 'Westend'] as ChainID[]) {
+      sorted.set(chainId, []);
+    }
+
     // Map addresses to their chain ID.
     for (const address of addresses) {
       const chainId = address.chain;

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -126,14 +126,14 @@ export const Accounts = ({
       >
         {/* Manage Accounts */}
         {Array.from(getSortedAddresses().entries()).map(
-          ([chainId, chainAddresses]) => (
+          ([chainId, chainAddresses], i) => (
             <AccordionItem key={`${chainId}_accounts`}>
               <HeadingWrapper>
                 <AccordionHeader>
                   <div className="flex">
                     <div className="left">
                       <div className="icon-wrapper">
-                        {accordionActiveIndices.includes(0) ? (
+                        {accordionActiveIndices.includes(i) ? (
                           <FontAwesomeIcon
                             icon={faCaretDown}
                             transform={'shrink-1'}
@@ -157,11 +157,11 @@ export const Accounts = ({
                       {chainAddresses.map(
                         (
                           { address, name }: FlattenedAccountData,
-                          i: number
+                          j: number
                         ) => (
                           <AccountWrapper
                             whileHover={{ scale: 1.01 }}
-                            key={`manage_account_${i}`}
+                            key={`manage_account_${j}`}
                           >
                             <button
                               type="button"
@@ -204,7 +204,7 @@ export const Accounts = ({
               <div className="flex">
                 <div className="left">
                   <div className="icon-wrapper">
-                    {accordionActiveIndices.includes(1) ? (
+                    {accordionActiveIndices.includes(3) ? (
                       <FontAwesomeIcon
                         icon={faCaretDown}
                         transform={'shrink-1'}

--- a/src/renderer/screens/Home/Manage/Wrappers.tsx
+++ b/src/renderer/screens/Home/Manage/Wrappers.tsx
@@ -102,8 +102,7 @@ export const AccountsWrapper = styled.div`
   --item-height: 2.75rem;
   width: 100%;
   margin-top: 1.25rem;
-  margin-bottom: 2rem;
-  padding: 0 0.5rem;
+  padding: 0 0.5rem 1rem;
 
   .flex-column {
     display: flex;

--- a/src/renderer/screens/Import/Addresses/Wrappers.tsx
+++ b/src/renderer/screens/Import/Addresses/Wrappers.tsx
@@ -43,11 +43,11 @@ export const AddressWrapper = styled.div`
     }
   }
 
-  .items-wrapper {
+  .outer-wrapper {
     height: calc(100% - 5.5rem);
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1.5rem;
+    padding: 1.25rem;
     padding-top: 2.25rem;
 
     &::-webkit-scrollbar {
@@ -60,13 +60,17 @@ export const AddressWrapper = styled.div`
       background-color: #212121;
     }
 
-    .items {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      margin: 1rem;
-      border: 1px solid var(--border-primary-color);
-      border-radius: 1.25rem;
+    .items-wrapper {
+      padding-bottom: 1rem;
+
+      .items {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin: 0 1rem;
+        border: 1px solid var(--border-primary-color);
+        border-radius: 1.25rem;
+      }
     }
     .edit {
       margin-left: 0.75rem;

--- a/src/renderer/screens/Import/Addresses/Wrappers.tsx
+++ b/src/renderer/screens/Import/Addresses/Wrappers.tsx
@@ -47,7 +47,7 @@ export const AddressWrapper = styled.div`
     height: calc(100% - 5.5rem);
     overflow-y: auto;
     overflow-x: hidden;
-    padding: 1.25rem;
+    padding: 1.5rem;
     padding-top: 2.25rem;
 
     &::-webkit-scrollbar {
@@ -67,7 +67,7 @@ export const AddressWrapper = styled.div`
         display: flex;
         flex-direction: column;
         justify-content: center;
-        margin: 0 1rem;
+        margin: 0 0.25rem;
         border: 1px solid var(--border-primary-color);
         border-radius: 1.25rem;
       }

--- a/src/renderer/screens/Import/Addresses/Wrappers.tsx
+++ b/src/renderer/screens/Import/Addresses/Wrappers.tsx
@@ -63,10 +63,10 @@ export const AddressWrapper = styled.div`
     .items {
       display: flex;
       flex-direction: column;
-      width: 100%;
+      justify-content: center;
+      margin: 1rem;
       border: 1px solid var(--border-primary-color);
       border-radius: 1.25rem;
-      justify-content: center;
     }
     .edit {
       margin-left: 0.75rem;

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -12,7 +12,10 @@ export interface AddressProps {
   isImported: boolean;
   setAddresses: AnyFunction;
   setSection: AnyFunction;
-  isLast: boolean;
+  orderData: {
+    curIndex: number;
+    lastIndex: number;
+  };
 }
 
 export interface ConfirmProps {

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -21,7 +21,7 @@ export const Address = ({
   setAddresses,
   index,
   isImported,
-  isLast,
+  orderData,
   setSection,
 }: LedgerAddressProps) => {
   // State for account name.
@@ -48,7 +48,7 @@ export const Address = ({
       accountName={accountNameState}
       renameHandler={renameHandler}
       isImported={isImported}
-      isLast={isLast}
+      orderData={orderData}
       isProcessing={getStatusForAccount(address, source) || false}
       openRemoveHandler={() =>
         openOverlayWith(

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -22,7 +22,7 @@ import {
   AccordionItem,
   AccordionPanel,
 } from '@/renderer/library/Accordion';
-import { HeadingWrapper } from '../../Home/Manage/Wrappers';
+import { HeadingWrapper } from '../Wrappers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faCaretRight } from '@fortawesome/pro-solid-svg-icons';
 

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -67,7 +67,7 @@ export const Manage = ({
       <BodyInterfaceWrapper $maxHeight>
         {addresses.length ? (
           <AddressWrapper>
-            <div className="items-wrapper">
+            <div className="outer-wrapper">
               <div className="more">
                 <ButtonText
                   iconLeft={faArrowDown}
@@ -114,27 +114,32 @@ export const Manage = ({
                         </AccordionHeader>
                       </HeadingWrapper>
                       <AccordionPanel>
-                        <div className="items">
-                          {chainAddresses.map(
-                            ({
-                              address,
-                              index,
-                              isImported,
-                              name,
-                            }: LedgerLocalAddress) => (
-                              <Address
-                                key={address}
-                                address={address}
-                                source={'ledger'}
-                                accountName={name}
-                                setAddresses={setAddresses}
-                                index={index}
-                                isImported={isImported}
-                                isLast={index === addresses.length - 1}
-                                setSection={setSection}
-                              />
-                            )
-                          )}
+                        <div className="items-wrapper">
+                          <div className="items">
+                            {chainAddresses.map(
+                              (
+                                {
+                                  address,
+                                  index,
+                                  isImported,
+                                  name,
+                                }: LedgerLocalAddress,
+                                i
+                              ) => (
+                                <Address
+                                  key={address}
+                                  address={address}
+                                  source={'ledger'}
+                                  accountName={name}
+                                  setAddresses={setAddresses}
+                                  index={index}
+                                  isImported={isImported}
+                                  isLast={i === chainAddresses.length - 1}
+                                  setSection={setSection}
+                                />
+                              )
+                            )}
+                          </div>
                         </div>
                       </AccordionPanel>
                     </AccordionItem>

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -134,7 +134,10 @@ export const Manage = ({
                                   setAddresses={setAddresses}
                                   index={index}
                                   isImported={isImported}
-                                  isLast={i === chainAddresses.length - 1}
+                                  orderData={{
+                                    curIndex: i,
+                                    lastIndex: chainAddresses.length - 1,
+                                  }}
                                   setSection={setSection}
                                 />
                               )

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -22,7 +22,7 @@ export const Address = ({
   setAddresses,
   isImported,
   setSection,
-  isLast,
+  orderData,
 }: AddressProps) => {
   // State for account name.
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
@@ -45,7 +45,7 @@ export const Address = ({
       key={index}
       address={address}
       isImported={isImported}
-      isLast={isLast}
+      orderData={orderData}
       isProcessing={getStatusForAccount(address, source) || false}
       index={index}
       accountName={accountNameState}

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -27,7 +27,7 @@ import {
   AccordionItem,
   AccordionPanel,
 } from '@/renderer/library/Accordion';
-import { HeadingWrapper } from '../../Home/Manage/Wrappers';
+import { HeadingWrapper } from '../Wrappers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faCaretRight } from '@fortawesome/pro-solid-svg-icons';
 

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -279,7 +279,10 @@ export const Manage = ({
                                       address={address}
                                       index={index}
                                       isImported={isImported || false}
-                                      isLast={i === chainAddresses.length - 1}
+                                      orderData={{
+                                        curIndex: i,
+                                        lastIndex: chainAddresses.length - 1,
+                                      }}
                                       setSection={setSection}
                                     />
                                   )

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -224,7 +224,7 @@ export const Manage = ({
         </Wrapper>
 
         <AddressWrapper>
-          <div className="items-wrapper" style={{ paddingTop: '1rem' }}>
+          <div className="outer-wrapper" style={{ paddingTop: '1rem' }}>
             <Accordion
               multiple
               defaultIndex={accordionActiveIndices}
@@ -257,33 +257,38 @@ export const Manage = ({
                         </AccordionHeader>
                       </HeadingWrapper>
                       <AccordionPanel>
-                        <div className="items">
-                          {addresses.length ? (
-                            <>
-                              {chainAddresses.map(
-                                ({
-                                  address,
-                                  index,
-                                  isImported,
-                                  name,
-                                }: LocalAddress) => (
-                                  <Address
-                                    key={address}
-                                    accountName={name}
-                                    source={'read-only'}
-                                    setAddresses={setAddresses}
-                                    address={address}
-                                    index={index}
-                                    isImported={isImported || false}
-                                    isLast={index === addresses.length - 1}
-                                    setSection={setSection}
-                                  />
-                                )
-                              )}
-                            </>
-                          ) : (
-                            <p>No read only addresses imported.</p>
-                          )}
+                        <div className="items-wrapper">
+                          <div className="items">
+                            {addresses.length ? (
+                              <>
+                                {chainAddresses.map(
+                                  (
+                                    {
+                                      address,
+                                      index,
+                                      isImported,
+                                      name,
+                                    }: LocalAddress,
+                                    i
+                                  ) => (
+                                    <Address
+                                      key={address}
+                                      accountName={name}
+                                      source={'read-only'}
+                                      setAddresses={setAddresses}
+                                      address={address}
+                                      index={index}
+                                      isImported={isImported || false}
+                                      isLast={i === chainAddresses.length - 1}
+                                      setSection={setSection}
+                                    />
+                                  )
+                                )}
+                              </>
+                            ) : (
+                              <p>No read only addresses imported.</p>
+                            )}
+                          </div>
                         </div>
                       </AccordionPanel>
                     </AccordionItem>

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -21,6 +21,15 @@ import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import type { FormEvent } from 'react';
 import type { LocalAddress } from '@/types/accounts';
 import type { ManageReadOnlyProps } from '../types';
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+} from '@/renderer/library/Accordion';
+import { HeadingWrapper } from '../../Home/Manage/Wrappers';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCaretDown, faCaretRight } from '@fortawesome/pro-solid-svg-icons';
 
 export const Manage = ({
   setSection,
@@ -31,6 +40,18 @@ export const Manage = ({
   const [editName, setEditName] = useState<string>('');
   const { insertAccountStatus } = useAccountStatuses();
 
+  // Active accordion indices for account subscription tasks categories.
+  const [accordionActiveIndices, setAccordionActiveIndices] = useState<
+    number[]
+  >(
+    Array.from(
+      {
+        length:
+          Array.from(getSortedLocalAddresses(addresses).keys()).length + 1,
+      },
+      (_, index) => index
+    )
+  );
   // Cancel button clicked for address field.
   const onCancel = () => {
     setEditName('');
@@ -203,30 +224,73 @@ export const Manage = ({
         </Wrapper>
 
         <AddressWrapper>
-          <div className="items-wrapper">
-            <div className="items">
-              {addresses.length ? (
-                <>
-                  {getSortedLocalAddresses(addresses).map(
-                    ({ address, index, isImported, name }: LocalAddress) => (
-                      <Address
-                        key={address}
-                        accountName={name}
-                        source={'read-only'}
-                        setAddresses={setAddresses}
-                        address={address}
-                        index={index}
-                        isImported={isImported || false}
-                        isLast={index === addresses.length - 1}
-                        setSection={setSection}
-                      />
-                    )
-                  )}
-                </>
-              ) : (
-                <p>No read only addresses imported.</p>
+          <div className="items-wrapper" style={{ paddingTop: '1rem' }}>
+            <Accordion
+              multiple
+              defaultIndex={accordionActiveIndices}
+              setExternalIndices={setAccordionActiveIndices}
+            >
+              {Array.from(getSortedLocalAddresses(addresses).entries()).map(
+                ([chainId, chainAddresses]) => (
+                  <div key={`${chainId}_read_only_addresses`}>
+                    <AccordionItem>
+                      <HeadingWrapper>
+                        <AccordionHeader>
+                          <div className="flex">
+                            <div className="left">
+                              <div className="icon-wrapper">
+                                {accordionActiveIndices.includes(0) ? (
+                                  <FontAwesomeIcon
+                                    icon={faCaretDown}
+                                    transform={'shrink-1'}
+                                  />
+                                ) : (
+                                  <FontAwesomeIcon
+                                    icon={faCaretRight}
+                                    transform={'shrink-1'}
+                                  />
+                                )}
+                              </div>
+                              <h5>{chainId} Accounts</h5>
+                            </div>
+                          </div>
+                        </AccordionHeader>
+                      </HeadingWrapper>
+                      <AccordionPanel>
+                        <div className="items">
+                          {addresses.length ? (
+                            <>
+                              {chainAddresses.map(
+                                ({
+                                  address,
+                                  index,
+                                  isImported,
+                                  name,
+                                }: LocalAddress) => (
+                                  <Address
+                                    key={address}
+                                    accountName={name}
+                                    source={'read-only'}
+                                    setAddresses={setAddresses}
+                                    address={address}
+                                    index={index}
+                                    isImported={isImported || false}
+                                    isLast={index === addresses.length - 1}
+                                    setSection={setSection}
+                                  />
+                                )
+                              )}
+                            </>
+                          ) : (
+                            <p>No read only addresses imported.</p>
+                          )}
+                        </div>
+                      </AccordionPanel>
+                    </AccordionItem>
+                  </div>
+                )
               )}
-            </div>
+            </Accordion>
           </div>
         </AddressWrapper>
 

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -22,7 +22,7 @@ export const Address = ({
   setAddresses,
   isImported,
   setSection,
-  isLast,
+  orderData,
 }: AddressProps) => {
   // State for account name.
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
@@ -45,7 +45,7 @@ export const Address = ({
       key={index}
       address={address}
       isImported={isImported}
-      isLast={isLast}
+      orderData={orderData}
       isProcessing={getStatusForAccount(address, source) || false}
       index={index}
       accountName={accountNameState}

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -65,7 +65,7 @@ export const Manage = ({
       <BodyInterfaceWrapper $maxHeight>
         {addresses.length ? (
           <AddressWrapper>
-            <div className="items-wrapper">
+            <div className="outer-wrapper">
               <div className="more">
                 <ButtonText
                   iconLeft={faQrcode}
@@ -119,22 +119,24 @@ export const Manage = ({
                           </AccordionHeader>
                         </HeadingWrapper>
                         <AccordionPanel>
-                          <div className="items">
-                            {chainAddresses.map(
-                              ({ address, index, isImported, name }) => (
-                                <Address
-                                  key={address}
-                                  accountName={name}
-                                  source={'vault'}
-                                  setAddresses={setAddresses}
-                                  address={address}
-                                  index={index}
-                                  isImported={isImported || false}
-                                  isLast={index === addresses.length - 1}
-                                  setSection={setSection}
-                                />
-                              )
-                            )}
+                          <div className="items-wrapper">
+                            <div className="items">
+                              {chainAddresses.map(
+                                ({ address, index, isImported, name }, i) => (
+                                  <Address
+                                    key={address}
+                                    accountName={name}
+                                    source={'vault'}
+                                    setAddresses={setAddresses}
+                                    address={address}
+                                    index={index}
+                                    isImported={isImported || false}
+                                    isLast={i === chainAddresses.length - 1}
+                                    setSection={setSection}
+                                  />
+                                )
+                              )}
+                            </div>
                           </div>
                         </AccordionPanel>
                       </AccordionItem>

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -131,8 +131,11 @@ export const Manage = ({
                                     address={address}
                                     index={index}
                                     isImported={isImported || false}
-                                    isLast={i === chainAddresses.length - 1}
                                     setSection={setSection}
+                                    orderData={{
+                                      curIndex: i,
+                                      lastIndex: chainAddresses.length - 1,
+                                    }}
                                   />
                                 )
                               )}

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -15,8 +15,17 @@ import { ButtonText } from '@/renderer/kits/Buttons/ButtonText';
 import { getSortedLocalAddresses } from '@/renderer/utils/ImportUtils';
 import { HeaderWrapper } from '../../Wrappers';
 import { HardwareStatusBar } from '@app/library/Hardware/HardwareStatusBar';
-import type { LocalAddress } from '@/types/accounts';
 import type { ManageVaultProps } from '../types';
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+} from '@/renderer/library/Accordion';
+import { HeadingWrapper } from '../../Home/Manage/Wrappers';
+import { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCaretDown, faCaretRight } from '@fortawesome/pro-solid-svg-icons';
 
 export const Manage = ({
   setSection,
@@ -25,6 +34,19 @@ export const Manage = ({
   setAddresses,
 }: ManageVaultProps) => {
   const { openOverlayWith } = useOverlay();
+
+  // Active accordion indices for account subscription tasks categories.
+  const [accordionActiveIndices, setAccordionActiveIndices] = useState<
+    number[]
+  >(
+    Array.from(
+      {
+        length:
+          Array.from(getSortedLocalAddresses(addresses).keys()).length + 1,
+      },
+      (_, index) => index
+    )
+  );
 
   return (
     <>
@@ -65,23 +87,61 @@ export const Manage = ({
                 />
               </div>
 
-              <div className="items">
-                {getSortedLocalAddresses(addresses).map(
-                  ({ address, index, isImported, name }: LocalAddress) => (
-                    <Address
-                      key={address}
-                      accountName={name}
-                      source={'vault'}
-                      setAddresses={setAddresses}
-                      address={address}
-                      index={index}
-                      isImported={isImported || false}
-                      isLast={index === addresses.length - 1}
-                      setSection={setSection}
-                    />
+              <Accordion
+                multiple
+                defaultIndex={accordionActiveIndices}
+                setExternalIndices={setAccordionActiveIndices}
+              >
+                {Array.from(getSortedLocalAddresses(addresses).entries()).map(
+                  ([chainId, chainAddresses]) => (
+                    <div key={`${chainId}_vault_addresses`}>
+                      <AccordionItem>
+                        <HeadingWrapper>
+                          <AccordionHeader>
+                            <div className="flex">
+                              <div className="left">
+                                <div className="icon-wrapper">
+                                  {accordionActiveIndices.includes(0) ? (
+                                    <FontAwesomeIcon
+                                      icon={faCaretDown}
+                                      transform={'shrink-1'}
+                                    />
+                                  ) : (
+                                    <FontAwesomeIcon
+                                      icon={faCaretRight}
+                                      transform={'shrink-1'}
+                                    />
+                                  )}
+                                </div>
+                                <h5>{chainId} Accounts</h5>
+                              </div>
+                            </div>
+                          </AccordionHeader>
+                        </HeadingWrapper>
+                        <AccordionPanel>
+                          <div className="items">
+                            {chainAddresses.map(
+                              ({ address, index, isImported, name }) => (
+                                <Address
+                                  key={address}
+                                  accountName={name}
+                                  source={'vault'}
+                                  setAddresses={setAddresses}
+                                  address={address}
+                                  index={index}
+                                  isImported={isImported || false}
+                                  isLast={index === addresses.length - 1}
+                                  setSection={setSection}
+                                />
+                              )
+                            )}
+                          </div>
+                        </AccordionPanel>
+                      </AccordionItem>
+                    </div>
                   )
                 )}
-              </div>
+              </Accordion>
             </div>
           </AddressWrapper>
         ) : null}

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -22,7 +22,7 @@ import {
   AccordionItem,
   AccordionPanel,
 } from '@/renderer/library/Accordion';
-import { HeadingWrapper } from '../../Home/Manage/Wrappers';
+import { HeadingWrapper } from '../Wrappers';
 import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faCaretRight } from '@fortawesome/pro-solid-svg-icons';

--- a/src/renderer/screens/Import/Wrappers.ts
+++ b/src/renderer/screens/Import/Wrappers.ts
@@ -56,6 +56,56 @@ export const SplashWrapper = styled.div`
   }
 `;
 
+export const HeadingWrapper = styled.div`
+  width: 100%;
+  padding: 0.5rem 1rem;
+  z-index: 3;
+  opacity: 0.75;
+  user-select: none;
+  cursor: pointer;
+
+  .flex {
+    display: flex;
+    column-gap: 0.5rem;
+    align-items: center;
+    padding: 0.25rem 0.5rem;
+    transition: background-color 0.15s ease-in-out;
+    border-bottom: 1px solid var(--border-secondary-color);
+
+    &:hover {
+      background-color: #141414;
+    }
+    > div {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      column-gap: 1rem;
+      padding: 0.5rem;
+    }
+
+    .left {
+      flex: 1;
+      display: flex;
+      column-gap: 0.75rem;
+      justify-content: flex-start;
+
+      .icon-wrapper {
+        min-width: 0.75rem;
+        opacity: 0.4;
+      }
+      h5 {
+        > span {
+          color: var(--text-color-primary);
+        }
+      }
+    }
+    .right {
+      display: flex;
+      justify-content: flex-end;
+    }
+  }
+`;
+
 export const QRVieweraWrapper = styled.div`
   width: 100%;
   display: flex;

--- a/src/renderer/screens/Import/Wrappers.ts
+++ b/src/renderer/screens/Import/Wrappers.ts
@@ -57,8 +57,8 @@ export const SplashWrapper = styled.div`
 `;
 
 export const HeadingWrapper = styled.div`
+  margin-bottom: 1rem;
   width: 100%;
-  padding: 0.5rem 1rem;
   z-index: 3;
   opacity: 0.75;
   user-select: none;
@@ -68,7 +68,7 @@ export const HeadingWrapper = styled.div`
     display: flex;
     column-gap: 0.5rem;
     align-items: center;
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem 0;
     transition: background-color 0.15s ease-in-out;
     border-bottom: 1px solid var(--border-secondary-color);
 
@@ -94,6 +94,7 @@ export const HeadingWrapper = styled.div`
         opacity: 0.4;
       }
       h5 {
+        font-size: 0.95rem;
         > span {
           color: var(--text-color-primary);
         }

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -56,7 +56,10 @@ export interface LedgerAddressProps {
   source: AccountSource;
   index: number;
   isImported: boolean;
-  isLast: boolean;
+  orderData: {
+    curIndex: number;
+    lastIndex: number;
+  };
   setAddresses: AnyFunction;
   setSection: AnyFunction;
 }

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -9,6 +9,7 @@ import type {
   LocalAddress,
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
+import type { ChainID } from '@/types/chains';
 
 /**
  * @name renameLocalAccount
@@ -118,14 +119,17 @@ export const getLocalAccountName = (
  * @summary Function to get addresses categorized by chain ID and sorted by name.
  */
 export const getSortedLocalAddresses = (addresses: LocalAddress[]) => {
-  let sorted: LocalAddress[] = [];
+  const sorted = new Map<ChainID, LocalAddress[]>();
 
-  for (const chainId of ['Polkadot', 'Kusama', 'Westend']) {
-    sorted = sorted.concat(
-      addresses
-        .filter((a) => getAddressChainId(a.address) === chainId)
-        .sort((a, b) => a.name.localeCompare(b.name))
-    );
+  // Insert keys in a preferred order.
+  for (const chainId of ['Polkadot', 'Kusama', 'Westend'] as ChainID[]) {
+    const filtered = addresses
+      .filter((a) => getAddressChainId(a.address) === chainId)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    if (filtered.length !== 0) {
+      sorted.set(chainId, filtered);
+    }
   }
 
   return sorted;
@@ -138,14 +142,17 @@ export const getSortedLocalAddresses = (addresses: LocalAddress[]) => {
 export const getSortedLocalLedgerAddresses = (
   addresses: LedgerLocalAddress[]
 ) => {
-  let sorted: LedgerLocalAddress[] = [];
+  const sorted = new Map<ChainID, LedgerLocalAddress[]>();
 
-  for (const chainId of ['Polkadot', 'Kusama', 'Westend']) {
-    sorted = sorted.concat(
-      addresses
-        .filter((a) => getAddressChainId(a.address) === chainId)
-        .sort((a, b) => a.name.localeCompare(b.name))
-    );
+  // Insert keys in preferred order.
+  for (const chainId of ['Polkadot', 'Kusama'] as ChainID[]) {
+    const filtered = addresses
+      .filter((a) => getAddressChainId(a.address) === chainId)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    if (filtered.length !== 0) {
+      sorted.set(chainId, filtered);
+    }
   }
 
   return sorted;


### PR DESCRIPTION
# Summary

This PR improves the import window's account listing UX.

- [x] Accordion component used to organise accounts by chain.
  - The priority of chain rendering is in the order `Polkadot`, `Kusama`, `Westend`.
  - Accounts are listed alphabetically according to their associated name.
- [x] Correct border radius for first and last account item's hover container.
- [x] Account item's chain icon is faded by default and transitions to fully opaque when its name is being edited.
- [x] Account `Import`, `Remove` and `Delete` buttons replaced with an icon and tooltip. 