### PR TITLE
feat: show on all workspaces setting

### DIFF
--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -49,6 +49,7 @@ export class Config {
       const settings: PersistedSettings = {
         appDocked: true,
         appSilenceOsNotifications: false,
+        appShowOnAllWorkspaces: false,
       };
 
       // Persist default settings to store and return them.

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -49,7 +49,7 @@ export class Config {
       const settings: PersistedSettings = {
         appDocked: true,
         appSilenceOsNotifications: false,
-        appShowOnAllWorkspaces: false,
+        appShowOnAllWorkspaces: true,
       };
 
       // Persist default settings to store and return them.

--- a/src/controller/main/WindowsController.ts
+++ b/src/controller/main/WindowsController.ts
@@ -162,4 +162,11 @@ export class WindowsController {
       mainWindow.setPosition(storeMenuPos.x, storeMenuPos.y, false);
     }
   };
+
+  // Set workspaces flag on all active windows.
+  static setVisibleOnAllWorkspaces = (flag: boolean) => {
+    for (const { window } of this.active) {
+      window.setVisibleOnAllWorkspaces(flag);
+    }
+  };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -359,6 +359,20 @@ app.whenReady().then(async () => {
   // Get app settings.
   ipcMain.handle('app:settings:get', async () => ConfigMain.getAppSettings());
 
+  ipcMain.on('app:set:workspaceVisibility', () => {
+    // Get new flag.
+    const settings = ConfigMain.getAppSettings();
+    const flag = !settings.appShowOnAllWorkspaces;
+
+    // Update windows.
+    settings.appShowOnAllWorkspaces = flag;
+    WindowsController.setVisibleOnAllWorkspaces(flag);
+
+    // Update storage.
+    const key = ConfigMain.settingsStorageKey;
+    (store as Record<string, AnyData>).set(key, settings);
+  });
+
   /**
    * Ledger
    */

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -39,6 +39,9 @@ export const API: PreloadAPI = {
    * New handlers
    */
 
+  toggleWindowWorkspaceVisibility: () =>
+    ipcRenderer.send('app:set:workspaceVisibility'),
+
   getAppSettings: async () => await ipcRenderer.invoke('app:settings:get'),
 
   getDockedFlag: async () => await ipcRenderer.invoke('app:docked:get'),

--- a/src/renderer/contexts/settings/SettingFlags/defaults.ts
+++ b/src/renderer/contexts/settings/SettingFlags/defaults.ts
@@ -9,4 +9,5 @@ export const defaultSettingFlagsContext: SettingFlagsContextInterface = {
   handleSwitchToggle: (s) => {},
   setWindowDocked: (b) => {},
   setSilenceOsNotifications: (b) => {},
+  setShowOnAllWorkspaces: (b) => {},
 };

--- a/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -20,15 +20,17 @@ export const SettingFlagsProvider = ({
   /// Store state of window docked setting.
   const [windowDocked, setWindowDocked] = useState(true);
   const [silenceOsNotifications, setSilenceOsNotifications] = useState(true);
+  const [showOnAllWorkspaces, setShowOnAllWorkspaces] = useState(false);
 
   /// Fetch settings from store and set state.
   useEffect(() => {
     const initSettings = async () => {
-      const { appDocked, appSilenceOsNotifications } =
+      const { appDocked, appSilenceOsNotifications, appShowOnAllWorkspaces } =
         await window.myAPI.getAppSettings();
 
       setWindowDocked(appDocked);
       setSilenceOsNotifications(appSilenceOsNotifications);
+      setShowOnAllWorkspaces(appShowOnAllWorkspaces);
     };
 
     initSettings();
@@ -44,6 +46,9 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:silenceOsNotifications': {
         return silenceOsNotifications;
+      }
+      case 'settings:execute:showOnAllWorkspaces': {
+        return showOnAllWorkspaces;
       }
       default: {
         return true;
@@ -64,6 +69,10 @@ export const SettingFlagsProvider = ({
         setSilenceOsNotifications(!silenceOsNotifications);
         break;
       }
+      case 'settings:execute:showOnAllWorkspaces': {
+        setShowOnAllWorkspaces(!showOnAllWorkspaces);
+        break;
+      }
       default: {
         break;
       }
@@ -75,6 +84,7 @@ export const SettingFlagsProvider = ({
       value={{
         setWindowDocked,
         setSilenceOsNotifications,
+        setShowOnAllWorkspaces,
         getSwitchState,
         handleSwitchToggle,
       }}

--- a/src/renderer/contexts/settings/SettingFlags/types.ts
+++ b/src/renderer/contexts/settings/SettingFlags/types.ts
@@ -8,4 +8,5 @@ export interface SettingFlagsContextInterface {
   handleSwitchToggle: (setting: SettingItem) => void;
   setWindowDocked: (flag: boolean) => void;
   setSilenceOsNotifications: (flag: boolean) => void;
+  setShowOnAllWorkspaces: (flag: boolean) => void;
 }

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -388,7 +388,7 @@ export const useMessagePorts = () => {
                 break;
               }
               case 'settings:execute:showOnAllWorkspaces': {
-                console.log('todo: handle showOnAllWorkspaces');
+                window.myAPI.toggleWindowWorkspaceVisibility();
                 break;
               }
               case 'settings:execute:silenceOsNotifications': {

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -7,6 +7,7 @@ import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 export interface PersistedSettings {
   appDocked: boolean;
   appSilenceOsNotifications: boolean;
+  appShowOnAllWorkspaces: boolean;
 }
 
 export type SettingAction =

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -14,6 +14,7 @@ export interface PreloadAPI {
   getAppSettings: ApiGetAppSettings;
   getDockedFlag: ApiGetDockedFlag;
   setDockedFlag: ApiSetDockedFlag;
+  toggleWindowWorkspaceVisibility: ApiToggleWorkspaceVisibility;
 
   initializeApp: ApiInitializeApp;
   initializeAppOnline: ApiInitializeAppOnline;
@@ -108,6 +109,8 @@ type ApiOpenBrowserWindow = (url: string) => void;
 /**
  * New types
  */
+
+type ApiToggleWorkspaceVisibility = () => void;
 
 type ApiGetAppSettings = () => Promise<PersistedSettings>;
 

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -116,6 +116,9 @@ export const createMainWindow = (isTest: boolean) => {
     // Set window bounds.
     setMainWindowPosition(mainWindow);
 
+    // Set all workspaces visibility.
+    setAllWorkspaceVisibilityForWindow('menu');
+
     // Send IPC message to renderer for app Initialization.
     WindowsController.get('menu')?.webContents?.send('renderer:app:initialize');
 
@@ -282,6 +285,9 @@ export const handleWindowOnIPC = (
     // Have windows controller handle window.
     WindowsController.add(window, name);
     WindowsController.show(name);
+
+    // Set all workspaces visibility.
+    setAllWorkspaceVisibilityForWindow(name);
   });
 };
 
@@ -385,4 +391,14 @@ export const handleNewDockFlag = (isDocked: boolean) => {
     mainWindow.setMovable(true);
     mainWindow.setResizable(true);
   }
+};
+
+/**
+ * @name setAllWorkspaceVisibility
+ * @summary Sets windows all workspace visibiltiy flag.
+ */
+export const setAllWorkspaceVisibilityForWindow = (windowId: string) => {
+  const window = WindowsController.get(windowId);
+  const { appShowOnAllWorkspaces } = ConfigMain.getAppSettings();
+  window?.setVisibleOnAllWorkspaces(appShowOnAllWorkspaces);
 };


### PR DESCRIPTION
# Summary

This PR implements a `Show on all workspaces` setting in the settings window.

When toggled on, the app will render its windows in all workspaces. When off, the app will only render in a single (active) workspace.