### PR TITLE
chore: debugging iteration

### DIFF
--- a/src/model/Api.ts
+++ b/src/model/Api.ts
@@ -76,6 +76,7 @@ export class Api {
 
     this.setApi(api, chainId as ChainID);
     await this.getConsts();
+    this.status = 'connected';
   };
 
   get endpoint() {
@@ -152,7 +153,6 @@ export class Api {
   initEvents = () => {
     this.provider?.on('connected', () => {
       console.log('⭕ %o', this.endpoint, ' CONNECTED');
-      this.status = 'connected';
     });
 
     this.provider?.on('disconnected', async () => {

--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -109,11 +109,11 @@ export const Item = memo(function Item({ faIcon, event }: ItemProps) {
         >
           <span>{renderTimeAgo(event.timestamp)}</span>
           {/* Dismiss button */}
-          <div className="dismiss-btn">
-            <FontAwesomeIcon
-              icon={faTimes}
-              onClick={async () => await handleDismissEvent()}
-            />
+          <div
+            className="dismiss-btn"
+            onClick={async () => await handleDismissEvent()}
+          >
+            <FontAwesomeIcon icon={faTimes} />
           </div>
 
           {/* Expand actions button */}

--- a/src/renderer/screens/Home/Events/index.tsx
+++ b/src/renderer/screens/Home/Events/index.tsx
@@ -24,6 +24,11 @@ export const Events = () => {
   /// Get events state.
   const { events, sortAllGroupedEvents, sortAllEvents } = useEvents();
 
+  const sortedGroupedEvents = useMemo(
+    () => sortAllGroupedEvents(newestFirst),
+    [events, newestFirst]
+  );
+
   const sortedEvents = useMemo(
     () => sortAllEvents(newestFirst),
     [events, newestFirst]
@@ -34,7 +39,7 @@ export const Events = () => {
     number[]
   >(
     Array.from(
-      { length: Array.from(sortAllGroupedEvents(newestFirst).keys()).length },
+      { length: Array.from(sortedGroupedEvents.keys()).length },
       (_, index) => index
     )
   );
@@ -81,7 +86,7 @@ export const Events = () => {
             defaultIndex={accordionActiveIndices}
             setExternalIndices={setAccordionActiveIndices}
           >
-            {Array.from(sortAllGroupedEvents(newestFirst).entries()).map(
+            {Array.from(sortedGroupedEvents.entries()).map(
               ([category, categoryEvents], i) => (
                 <Category
                   key={`${category}_events`}

--- a/src/renderer/screens/Home/Events/index.tsx
+++ b/src/renderer/screens/Home/Events/index.tsx
@@ -24,12 +24,6 @@ export const Events = () => {
   /// Get events state.
   const { events, sortAllGroupedEvents, sortAllEvents } = useEvents();
 
-  /// Memoize sorted event data.
-  const sortedGroupedEvents = useMemo(
-    () => sortAllGroupedEvents(newestFirst),
-    [events, newestFirst]
-  );
-
   const sortedEvents = useMemo(
     () => sortAllEvents(newestFirst),
     [events, newestFirst]
@@ -40,7 +34,7 @@ export const Events = () => {
     number[]
   >(
     Array.from(
-      { length: Array.from(sortedGroupedEvents.keys()).length },
+      { length: Array.from(sortAllGroupedEvents(newestFirst).keys()).length },
       (_, index) => index
     )
   );
@@ -87,7 +81,7 @@ export const Events = () => {
             defaultIndex={accordionActiveIndices}
             setExternalIndices={setAccordionActiveIndices}
           >
-            {Array.from(sortedGroupedEvents.entries()).map(
+            {Array.from(sortAllGroupedEvents(newestFirst).entries()).map(
               ([category, categoryEvents], i) => (
                 <Category
                   key={`${category}_events`}

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -39,7 +39,7 @@ export const Accounts = ({
     useSubscriptions();
   const { setRenderedSubscriptions } = useManage();
 
-  // Categorise addresses by their chain ID, sort by name.
+  /// Categorise addresses by their chain ID, sort by name.
   const getSortedAddresses = () => {
     const sorted = new Map<ChainID, FlattenedAccountData[]>();
 
@@ -67,10 +67,20 @@ export const Accounts = ({
       );
     }
 
+    // Remove any empty entries.
+    const redundantEntries: ChainID[] = [];
+    for (const [chainId, chainAddresses] of sorted.entries()) {
+      chainAddresses.length === 0 && redundantEntries.push(chainId);
+    }
+
+    redundantEntries.forEach((chainId) => {
+      sorted.delete(chainId);
+    });
+
     return sorted;
   };
 
-  // Active accordion indices for account subscription tasks categories.
+  /// Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
     number[]
   >(
@@ -80,14 +90,14 @@ export const Accounts = ({
     )
   );
 
-  // Utility to copy tasks.
+  /// Utility to copy tasks.
   const copyTasks = (tasks: SubscriptionTask[]) =>
     tasks.map((t) => ({
       ...t,
       actionArgs: t.actionArgs ? [...t.actionArgs] : undefined,
     }));
 
-  // Set parent subscription tasks state when a chain is clicked.
+  /// Set parent subscription tasks state when a chain is clicked.
   const handleClickChain = (chain: string) => {
     const tasks = getChainSubscriptions(chain as ChainID);
     const copy = copyTasks(tasks);
@@ -101,7 +111,7 @@ export const Accounts = ({
     setSection(1);
   };
 
-  // Set account subscription tasks state when an account is clicked.
+  /// Set account subscription tasks state when an account is clicked.
   const handleClickAccount = (accountName: string, address: string) => {
     const tasks = getAccountSubscriptions(address);
     const copy = copyTasks(tasks);
@@ -125,76 +135,82 @@ export const Accounts = ({
         setExternalIndices={setAccordionActiveIndices}
       >
         {/* Manage Accounts */}
-        {Array.from(getSortedAddresses().entries()).map(
-          ([chainId, chainAddresses], i) => (
-            <AccordionItem key={`${chainId}_accounts`}>
-              <HeadingWrapper>
-                <AccordionHeader>
-                  <div className="flex">
-                    <div className="left">
-                      <div className="icon-wrapper">
-                        {accordionActiveIndices.includes(i) ? (
-                          <FontAwesomeIcon
-                            icon={faCaretDown}
-                            transform={'shrink-1'}
-                          />
-                        ) : (
-                          <FontAwesomeIcon
-                            icon={faCaretRight}
-                            transform={'shrink-1'}
-                          />
-                        )}
+        {addresses.length === 0 ? (
+          <div style={{ padding: '0 0.5rem' }}>
+            <NoAccounts />
+          </div>
+        ) : (
+          <>
+            {Array.from(getSortedAddresses().entries()).map(
+              ([chainId, chainAddresses], i) => (
+                <AccordionItem key={`${chainId}_accounts`}>
+                  <HeadingWrapper>
+                    <AccordionHeader>
+                      <div className="flex">
+                        <div className="left">
+                          <div className="icon-wrapper">
+                            {accordionActiveIndices.includes(i) ? (
+                              <FontAwesomeIcon
+                                icon={faCaretDown}
+                                transform={'shrink-1'}
+                              />
+                            ) : (
+                              <FontAwesomeIcon
+                                icon={faCaretRight}
+                                transform={'shrink-1'}
+                              />
+                            )}
+                          </div>
+                          <h5>{chainId} Accounts</h5>
+                        </div>
                       </div>
-                      <h5>{chainId} Accounts</h5>
-                    </div>
-                  </div>
-                </AccordionHeader>
-              </HeadingWrapper>
-              <AccordionPanel>
-                <div style={{ padding: '0 0.75rem' }}>
-                  {addresses.length ? (
-                    <div className="flex-column">
-                      {chainAddresses.map(
-                        (
-                          { address, name }: FlattenedAccountData,
-                          j: number
-                        ) => (
-                          <AccountWrapper
-                            whileHover={{ scale: 1.01 }}
-                            key={`manage_account_${j}`}
-                          >
-                            <button
-                              type="button"
-                              onClick={() => handleClickAccount(name, address)}
-                            ></button>
-                            <div className="inner">
-                              <div>
-                                <span className="icon">
-                                  <Identicon value={address} size={26} />
-                                </span>
-                                <div className="content">
-                                  <h3>{name}</h3>
+                    </AccordionHeader>
+                  </HeadingWrapper>
+                  <AccordionPanel>
+                    <div style={{ padding: '0 0.75rem' }}>
+                      <div className="flex-column">
+                        {chainAddresses.map(
+                          (
+                            { address, name }: FlattenedAccountData,
+                            j: number
+                          ) => (
+                            <AccountWrapper
+                              whileHover={{ scale: 1.01 }}
+                              key={`manage_account_${j}`}
+                            >
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  handleClickAccount(name, address)
+                                }
+                              ></button>
+                              <div className="inner">
+                                <div>
+                                  <span className="icon">
+                                    <Identicon value={address} size={26} />
+                                  </span>
+                                  <div className="content">
+                                    <h3>{name}</h3>
+                                  </div>
+                                </div>
+                                <div>
+                                  <ButtonText
+                                    text=""
+                                    iconRight={faChevronRight}
+                                    iconTransform="shrink-3"
+                                  />
                                 </div>
                               </div>
-                              <div>
-                                <ButtonText
-                                  text=""
-                                  iconRight={faChevronRight}
-                                  iconTransform="shrink-3"
-                                />
-                              </div>
-                            </div>
-                          </AccountWrapper>
-                        )
-                      )}
+                            </AccountWrapper>
+                          )
+                        )}
+                      </div>
                     </div>
-                  ) : (
-                    <NoAccounts />
-                  )}
-                </div>
-              </AccordionPanel>
-            </AccordionItem>
-          )
+                  </AccordionPanel>
+                </AccordionItem>
+              )
+            )}
+          </>
         )}
 
         {/* Manage Chains */}


### PR DESCRIPTION
# Summary

- [x] Fix click handlers on event item dismiss buttons.
The click handler has been defined on the parent icon container to catch every click in the dismiss icon's region.

- [x] `NoAccounts` component is rendered once if no accounts are imported.
This component was being rendered in each accordion item if no accounts were imported. Fixed to only render once outside of the accordion when no accounts are imported.

- [x] Fetched API instances are always connected.
Previously an error would be thrown if a requested API instance was in `'connecting'` status, and another part of the application requested that instance. Now, the subsequent API instance request waits until the instance is fully connected before receiving it.