### PR TITLE
chore: debugging iteration

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -120,26 +120,41 @@ export const HelpConfig: HelpItems = [
   {
     key: 'help:settings:dockedWindow',
     title: 'Docked Window',
-    definition: ['Help text for docked window.'],
+    definition: [
+      "Enabling this setting will display the main window below the app's tray icon with a fixed size and position.",
+      'Turn off this setting to position and size the main window freely.',
+    ],
   },
   {
     key: 'help:settings:showOnAllWorkspaces',
     title: 'Show on All Workspaces',
-    definition: ['Help text for workspaces setting.'],
+    definition: [
+      'Displays Polkadot Live windows on all workspaces. Switching to a different workspace will still show your Polkadot Live windows.',
+      'Turn off this setting to display Polkadot Live on a single workspace.',
+    ],
   },
   {
     key: 'help:settings:silenceOsNotifications',
     title: 'Silence OS Notifications',
-    definition: ['Help text for silencing OS notifications.'],
+    definition: [
+      'Enable to silence (not display) native OS notifications application wide.',
+      'This setting is global and will override OS notification settings for individual subscriptions.',
+    ],
   },
   {
     key: 'help:settings:importData',
     title: 'Import Data',
-    definition: ['Help text for importing data.'],
+    definition: [
+      'Coming soon.',
+      'Import data from another Polkadot Live installation to restore your accounts, events and subscription.',
+    ],
   },
   {
     key: 'help:settings:exportData',
     title: 'Export Data',
-    definition: ['Help text for exporting data.'],
+    definition: [
+      'Coming soon.',
+      'Export your Polkadot Live data to a file, allowing you to restore your accounts, events and subscriptions on another computer.',
+    ],
   },
 ];

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -31,7 +31,7 @@ export class Config {
   // Instantiate message port pairs to facilitate communication between the
   // main renderer and another renderer.
   static initialize = (): void => {
-    const ids: PortPairID[] = ['main-import', 'main-action'];
+    const ids: PortPairID[] = ['main-import', 'main-action', 'main-settings'];
 
     for (const id of ids) {
       Config.initPorts(id);

--- a/src/config/processes/renderer.ts
+++ b/src/config/processes/renderer.ts
@@ -20,6 +20,9 @@ export class Config {
   // Flag set to `true` when app wants to abort connection processing.
   private static _abortConnecting = false;
 
+  // Time in seconds app should wait for processing a one-shot and API connection.
+  private static _processingTimeout = 10;
+
   // Accessors for `import` port.
   static get portToImport(): MessagePort {
     if (!Config._portToImport) {
@@ -84,5 +87,9 @@ export class Config {
 
   static set abortConnecting(flag: boolean) {
     Config._abortConnecting = flag;
+  }
+
+  static get processingTimeout(): number {
+    return Config._processingTimeout;
   }
 }

--- a/src/controller/main/OnlineStatusController.ts
+++ b/src/controller/main/OnlineStatusController.ts
@@ -35,12 +35,18 @@ export class OnlineStatusController {
 
     if (status !== this.onlineStatus) {
       this.onlineStatus = status;
-
       console.log(`Online status changed to ${status}`);
 
       await AppOrchestrator.next({
         task: `app:initialize:${status ? 'online' : 'offline'}`,
       });
+
+      // Re-initialize class if app goes offline to prevent stalling
+      // upon calling `isConnected`.
+      if (!status && this.intervalId) {
+        this.stopPollLoop();
+        await this.initialize();
+      }
     }
   };
 

--- a/src/controller/main/OnlineStatusController.ts
+++ b/src/controller/main/OnlineStatusController.ts
@@ -73,4 +73,37 @@ export class OnlineStatusController {
    */
   private static isConnected = async () =>
     !!(await dns.promises.resolve('google.com').catch(() => false));
+
+  /**
+   * @name handleSuspend
+   * @summary Called when the system is suspended. Stops the poll loop and
+   * sets the app to offline mode.
+   */
+  static handleSuspend = async () => {
+    this.stopPollLoop();
+    this.onlineStatus = false;
+
+    await AppOrchestrator.next({
+      task: 'app:initialize:offline',
+    });
+  };
+
+  /**
+   * @name handleResume
+   * @summary Called when the system is resumed from being suspended.
+   * Starts the poll and initializes the app based on its online status.
+   */
+  static handleResume = async () => {
+    const status = await this.isConnected();
+    this.onlineStatus = status;
+
+    // Initialize app in the correct mode.
+    await AppOrchestrator.next({
+      task: `app:initialize:${status ? 'online' : 'offline'}`,
+    });
+
+    // Start a new polling interval.
+    this.stopPollLoop();
+    await this.initialize();
+  };
 }

--- a/src/controller/renderer/APIsController.ts
+++ b/src/controller/renderer/APIsController.ts
@@ -3,6 +3,7 @@
 
 import { Api } from '@/model/Api';
 import { ChainList } from '@/config/chains';
+import { Config as ConfigRenderer } from '@/config/processes/renderer';
 import type { ChainID } from '@/types/chains';
 import type { FlattenedAPIData } from '@/types/apis';
 
@@ -127,9 +128,10 @@ export class APIsController {
         if (newInstance?.status === 'connected' && newInstance.api !== null) {
           console.log(`${chainId} connected, waited ${secondsWaited} seconds.`);
           return newInstance;
-        } else if (secondsWaited > 16) {
-          // If we have waited for more than 16 seconds, return null.
-          console.log('Waited over 16 seconds to connect, return null.');
+        } else if (secondsWaited > ConfigRenderer.processingTimeout) {
+          // If we have waited for more than 10 seconds, return null.
+          const seconds = ConfigRenderer.processingTimeout;
+          console.log(`Waited ${seconds} seconds to connect, return null.`);
           return null;
         }
       }

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -96,12 +96,11 @@ export class AccountsController {
 
     // Resubscribe to the each account's persisted tasks.
     for (const account of chainAccounts) {
-      const stored = await window.myAPI.getPersistedAccountTasks(
-        account.flatten()
+      const tasks = (account.getSubscriptionTasks() || []).filter(
+        (t) => t.chainId === chainId
       );
 
-      const tasks: SubscriptionTask[] = stored !== '' ? JSON.parse(stored) : [];
-      if (account.queryMulti !== null) {
+      if (tasks.length && account.queryMulti) {
         await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
       }
     }

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -118,8 +118,8 @@ export class AccountsController {
       for (const account of accounts) {
         const tasks = account.getSubscriptionTasks() || [];
 
-        for (const task of tasks) {
-          await account.subscribeToTask(task);
+        if (tasks.length && account.queryMulti) {
+          await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
         }
       }
     }

--- a/src/controller/renderer/ExtrinsicsController.ts
+++ b/src/controller/renderer/ExtrinsicsController.ts
@@ -5,7 +5,7 @@ import { planckToUnit } from '@w3ux/utils';
 import BigNumber from 'bignumber.js';
 import { chainUnits } from '@/config/chains';
 import { Config as ConfigRenderer } from '@/config/processes/renderer';
-import { getApiInstance } from '@/utils/ApiUtils';
+import { getApiInstanceOrThrow } from '@/utils/ApiUtils';
 import type { AnyJson } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
 import type { TxStatus } from '@/types/tx';
@@ -39,7 +39,8 @@ export class ExtrinsicsController {
     eventUid: string
   ) => {
     try {
-      const { api } = await getApiInstance(chainId);
+      const origin = 'ExtrinsicsController.new';
+      const { api } = await getApiInstanceOrThrow(chainId, origin);
 
       console.log(`📝 New extrinsic: ${from}, ${pallet}, ${method}, ${args}`);
 
@@ -89,7 +90,8 @@ export class ExtrinsicsController {
     accountNonce: number
   ) => {
     // build and set payload of the transaction and store it in TxMetaContext.
-    const { api } = await getApiInstance(chainId);
+    const origin = 'ExtrinsicsController.buildPayload';
+    const { api } = await getApiInstanceOrThrow(chainId, origin);
 
     const lastHeader = await api.rpc.chain.getHeader();
     const blockNumber = api.registry.createType(

--- a/src/controller/renderer/SubscriptionsController.ts
+++ b/src/controller/renderer/SubscriptionsController.ts
@@ -63,7 +63,10 @@ export class SubscriptionsController {
 
     // Get subscription task array and subscribe to batched tasks.
     const tasks = this.chainSubscriptions?.getSubscriptionTasks() || [];
-    await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
+
+    if (tasks.length) {
+      await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
+    }
   }
 
   /**
@@ -80,7 +83,7 @@ export class SubscriptionsController {
       .getSubscriptionTasks()
       .filter((task) => task.chainId === chainId);
 
-    tasks.length > 0 &&
+    tasks.length &&
       (await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions));
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,14 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { app, ipcMain, protocol, shell, systemPreferences } from 'electron';
+import {
+  app,
+  ipcMain,
+  powerMonitor,
+  protocol,
+  shell,
+  systemPreferences,
+} from 'electron';
 import { Config as ConfigMain } from './config/processes/main';
 import { executeLedgerLoop } from './ledger';
 import Store from 'electron-store';
@@ -111,6 +118,22 @@ app.whenReady().then(async () => {
       })
       .catch((err) => console.error(err));
   }
+
+  // ------------------------------
+  // Handle Power Changes
+  // ------------------------------
+
+  // Emitted when the system is suspending.
+  powerMonitor.on('suspend', async () => {
+    console.log('Suspending...');
+    //await OnlineStatusController.handleSuspend();
+  });
+
+  // Emitted when system is resuming.
+  powerMonitor.on('resume', async () => {
+    console.log('Resuming...');
+    //await OnlineStatusController.handleResume();
+  });
 
   // ------------------------------
   // Create windows

--- a/src/main.ts
+++ b/src/main.ts
@@ -278,8 +278,8 @@ app.whenReady().then(async () => {
   });
 
   // Handle switching between online and offline.
-  ipcMain.on('app:connection:status', () => {
-    OnlineStatusController.handleStatusChange();
+  ipcMain.on('app:connection:status', async () => {
+    await OnlineStatusController.handleStatusChange();
   });
 
   // Send connection status to frontend.

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,22 +120,6 @@ app.whenReady().then(async () => {
   }
 
   // ------------------------------
-  // Handle Power Changes
-  // ------------------------------
-
-  // Emitted when the system is suspending.
-  powerMonitor.on('suspend', async () => {
-    console.log('Suspending...');
-    //await OnlineStatusController.handleSuspend();
-  });
-
-  // Emitted when system is resuming.
-  powerMonitor.on('resume', async () => {
-    console.log('Resuming...');
-    //await OnlineStatusController.handleResume();
-  });
-
-  // ------------------------------
   // Create windows
   // ------------------------------
 
@@ -155,6 +139,21 @@ app.whenReady().then(async () => {
 
   // Handle settings window.
   WindowUtils.handleWindowOnIPC('settings', isTest);
+
+  // ------------------------------
+  // Handle Power Changes
+  // ------------------------------
+
+  // Emitted when the system is suspending.
+  powerMonitor.on('suspend', async () => {
+    await OnlineStatusController.handleSuspend();
+  });
+
+  // Emitted when system is resuming.
+  powerMonitor.on('resume', async () => {
+    console.log('Resuming...');
+    await OnlineStatusController.handleResume();
+  });
 
   // ------------------------------
   // WDIO Custom Electron API

--- a/src/model/QueryMultiWrapper.ts
+++ b/src/model/QueryMultiWrapper.ts
@@ -243,7 +243,8 @@ export class QueryMultiWrapper {
 
     // Construct the argument for new queryMulti call.
     const finalArg: AnyData = await this.buildQueryMultiArg(chainId);
-    const instance = await ApiUtils.getApiInstance(chainId);
+    const origin = 'QueryMultiWrapper.build';
+    const instance = await ApiUtils.getApiInstanceOrThrow(chainId, origin);
 
     // Call queryMulti api.
     const unsub = await instance.api.queryMulti(

--- a/src/orchestrators/TaskOrchestrator.ts
+++ b/src/orchestrators/TaskOrchestrator.ts
@@ -168,7 +168,8 @@ export class TaskOrchestrator {
 
   static async getApiCall(task: SubscriptionTask) {
     const { action, chainId } = task;
-    const instance = await ApiUtils.getApiInstance(chainId);
+    const origin = 'TaskOrchestrator.getApiCall';
+    const instance = await ApiUtils.getApiInstanceOrThrow(chainId, origin);
 
     switch (action) {
       case 'subscribe:chain:timestamp':

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -193,7 +193,8 @@ export class Callbacks {
     try {
       const account = checkAccountWithProperties(entry, ['nominationPoolData']);
       const chainId = account.chain;
-      const { api } = await ApiUtils.getApiInstance(chainId);
+      const origin = 'callback_nomination_pool_rewards';
+      const { api } = await ApiUtils.getApiInstanceOrThrow(chainId, origin);
 
       // Fetch pending rewards for the account.
       const pendingRewardsPlanck: BigNumber =
@@ -470,7 +471,11 @@ export class Callbacks {
     try {
       // Check if account has any nominating rewards from the previous era (current era - 1).
       const account = checkAccountWithProperties(entry, ['nominatingData']);
-      const { api } = await ApiUtils.getApiInstance(account.chain);
+      const origin = 'callback_nomination_pending_payouts';
+      const { api } = await ApiUtils.getApiInstanceOrThrow(
+        account.chain,
+        origin
+      );
 
       // Map<era: string, Map<validator: string, payout: [number, string]>>
       const unclaimed = await getUnclaimedPayouts(
@@ -544,7 +549,11 @@ export class Callbacks {
       }
 
       // Otherwise get exposure.
-      const { api } = await ApiUtils.getApiInstance(account.chain);
+      const origin = 'callback_nominating_exposure';
+      const { api } = await ApiUtils.getApiInstanceOrThrow(
+        account.chain,
+        origin
+      );
       const exposed = await getAccountExposed(api, era, account);
 
       // Update account data.
@@ -595,7 +604,11 @@ export class Callbacks {
         return;
       }
 
-      const { api } = await ApiUtils.getApiInstance(account.chain);
+      const origin = 'callback_nominating_exposure_westend';
+      const { api } = await ApiUtils.getApiInstanceOrThrow(
+        account.chain,
+        origin
+      );
       const vs = account.nominatingData!.validators;
       const exposed = await getAccountExposedWestend(api, era, account, vs);
 
@@ -651,7 +664,12 @@ export class Callbacks {
       }
 
       // Get live nominator data and check to see if it has changed.
-      const { api } = await ApiUtils.getApiInstance(account.chain);
+      const origin = 'callback_nominating_commission';
+      const { api } = await ApiUtils.getApiInstanceOrThrow(
+        account.chain,
+        origin
+      );
+
       const nominatorData: AnyData = (
         await api.query.staking.nominators(account.address)
       ).toHuman();

--- a/src/renderer/callbacks/nominating.ts
+++ b/src/renderer/callbacks/nominating.ts
@@ -14,8 +14,8 @@ const MaxSupportedPayoutEras = 7;
 const NetworksWithPagedRewards: ChainID[] = ['Westend'];
 
 const PagedRewardsStartEra = new Map<ChainID, BigNumber | null>([
-  ['Polkadot', null],
-  ['Kusama', null],
+  ['Polkadot', new BigNumber(1420)],
+  ['Kusama', new BigNumber(6514)],
   ['Westend', new BigNumber(7167)],
 ]);
 
@@ -57,7 +57,7 @@ const getErasInterval = (era: BigNumber) => {
  * @name getEraValidators
  * @summary Get list of validators that an account nominated during an era.
  */
-const getEraValidators = async (
+const getEraValidatorsLegacy = async (
   api: ApiPromise,
   era: BigNumber,
   accountAddress: string
@@ -92,7 +92,7 @@ const getEraValidators = async (
  * @name getEraValidatorsWestend
  * @summary Get list of validators that an account nominated during an era using new paged API.
  */
-const getEraValidatorsWestend = async (
+const getEraValidatorsPaged = async (
   api: ApiPromise,
   era: BigNumber,
   accountAddress: string
@@ -242,8 +242,8 @@ export const getUnclaimedPayouts = async (
 
   while (currentEra.isGreaterThanOrEqualTo(endEra)) {
     const validators = pagedRewardsActive
-      ? await getEraValidatorsWestend(api, currentEra, address)
-      : await getEraValidators(api, currentEra, address);
+      ? await getEraValidatorsPaged(api, currentEra, address)
+      : await getEraValidatorsLegacy(api, currentEra, address);
 
     erasValidators.push(...validators);
     erasToCheck.push(currentEra.toString());

--- a/src/renderer/callbacks/oneshots.ts
+++ b/src/renderer/callbacks/oneshots.ts
@@ -8,43 +8,43 @@ import { Callbacks } from '.';
 export const executeOneShot = async (task: SubscriptionTask) => {
   switch (task.action) {
     case 'subscribe:account:balance': {
-      await oneShot_query_system_account(task);
-      break;
+      const result = await oneShot_query_system_account(task);
+      return result;
     }
     case 'subscribe:account:nominationPools:rewards': {
-      await oneShot_nomination_pool_rewards(task);
-      break;
+      const result = await oneShot_nomination_pool_rewards(task);
+      return result;
     }
     case 'subscribe:account:nominationPools:state': {
-      await oneShot_nomination_pool_state(task);
-      break;
+      const result = await oneShot_nomination_pool_state(task);
+      return result;
     }
     case 'subscribe:account:nominationPools:renamed': {
-      await oneShot_nomination_pool_renamed(task);
-      break;
+      const result = await oneShot_nomination_pool_renamed(task);
+      return result;
     }
     case 'subscribe:account:nominationPools:roles': {
-      await oneShot_nomination_pool_roles(task);
-      break;
+      const result = await oneShot_nomination_pool_roles(task);
+      return result;
     }
     case 'subscribe:account:nominationPools:commission': {
-      await oneShot_nomination_pool_commission(task);
-      break;
+      const result = await oneShot_nomination_pool_commission(task);
+      return result;
     }
     case 'subscribe:account:nominating:pendingPayouts': {
-      await oneShot_nominating_pending_payouts(task);
-      break;
+      const result = await oneShot_nominating_pending_payouts(task);
+      return result;
     }
     case 'subscribe:account:nominating:exposure': {
-      await oneShot_nominating_exposure(task);
-      break;
+      const result = await oneShot_nominating_exposure(task);
+      return result;
     }
     case 'subscribe:account:nominating:commission': {
-      await oneShot_nominating_commission(task);
-      break;
+      const result = await oneShot_nominating_commission(task);
+      return result;
     }
     default: {
-      break;
+      return false;
     }
   }
 };
@@ -54,10 +54,16 @@ export const executeOneShot = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's balance.
  */
 const oneShot_query_system_account = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.system.account(task.account!.address);
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_query_system_account(data, entry, true);
+  return true;
 };
 
 /**
@@ -67,6 +73,7 @@ const oneShot_query_system_account = async (task: SubscriptionTask) => {
 const oneShot_nomination_pool_rewards = async (task: SubscriptionTask) => {
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nomination_pool_rewards(entry, true);
+  return true;
 };
 
 /**
@@ -74,10 +81,16 @@ const oneShot_nomination_pool_rewards = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's nominating pool state.
  */
 const oneShot_nomination_pool_state = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.nominationPools.bondedPools(task.actionArgs!);
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nomination_pool_state(data, entry, true);
+  return true;
 };
 
 /**
@@ -85,10 +98,16 @@ const oneShot_nomination_pool_state = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's nominating pool name.
  */
 const oneShot_nomination_pool_renamed = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.nominationPools.metadata(task.actionArgs!);
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nomination_pool_renamed(data, entry, true);
+  return true;
 };
 
 /**
@@ -96,10 +115,16 @@ const oneShot_nomination_pool_renamed = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's nominating pool roles.
  */
 const oneShot_nomination_pool_roles = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.nominationPools.bondedPools(task.actionArgs!);
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nomination_pool_roles(data, entry, true);
+  return true;
 };
 
 /**
@@ -107,10 +132,16 @@ const oneShot_nomination_pool_roles = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's nominating pool commission.
  */
 const oneShot_nomination_pool_commission = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.nominationPools.bondedPools(task.actionArgs!);
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nomination_pool_commission(data, entry, true);
+  return true;
 };
 
 /**
@@ -118,10 +149,16 @@ const oneShot_nomination_pool_commission = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's nominating pending paypouts.
  */
 const oneShot_nominating_pending_payouts = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.staking.activeEra();
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nominating_pending_payouts(data, entry, true);
+  return true;
 };
 
 /**
@@ -129,8 +166,13 @@ const oneShot_nominating_pending_payouts = async (task: SubscriptionTask) => {
  * @summary One-shot call to fetch an account's nominating exposure.
  */
 const oneShot_nominating_exposure = async (task: SubscriptionTask) => {
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const { chainId } = task;
-  const { api } = await getApiInstance(chainId);
   const entry: ApiCallEntry = { curVal: null, task };
   const data = await api.query.staking.activeEra();
 
@@ -145,6 +187,8 @@ const oneShot_nominating_exposure = async (task: SubscriptionTask) => {
       break;
     }
   }
+
+  return true;
 };
 
 /**
@@ -152,8 +196,14 @@ const oneShot_nominating_exposure = async (task: SubscriptionTask) => {
  * @summary One-shot call to see a change in commission.
  */
 const oneShot_nominating_commission = async (task: SubscriptionTask) => {
-  const { api } = await getApiInstance(task.chainId);
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
   const data = await api.query.staking.activeEra();
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nominating_commission(data, entry, true);
+  return true;
 };

--- a/src/renderer/contexts/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/Bootstrapping/index.tsx
@@ -37,7 +37,7 @@ export const BootstrappingProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [appLoading, setAppLoading] = useState(true);
+  const [appLoading, setAppLoading] = useState(false);
   const [isAborting, setIsAborting] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [online, setOnline] = useState<boolean>(false);
@@ -104,6 +104,8 @@ export const BootstrappingProvider = ({
   /// Handle app initialization.
   const handleInitializeApp = async () => {
     if (!refAppInitialized.current) {
+      setAppLoading(true);
+
       let aborted = false;
       let intervalRunning = true;
 

--- a/src/renderer/library/Footer/Wrapper.ts
+++ b/src/renderer/library/Footer/Wrapper.ts
@@ -32,7 +32,7 @@ export const FooterWrapper = styled.div`
     padding: 0 1rem;
     transition: height 0.2s;
 
-    > div {
+    > div:first-of-type {
       flex-grow: 1;
     }
 

--- a/src/renderer/library/Footer/Wrapper.ts
+++ b/src/renderer/library/Footer/Wrapper.ts
@@ -149,6 +149,12 @@ export const SelectRpcWrapper = styled.div`
       color: #afafaf;
       font-size: 1rem;
       position: relative;
+      cursor: pointer;
+      transition: background-color 0.1s ease-out;
+
+      &:hover {
+        background-color: var(--background-default);
+      }
     }
   }
 `;

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -20,6 +20,7 @@ import {
   faCaretDown,
   faCaretRight,
 } from '@fortawesome/free-solid-svg-icons';
+import { Flip, toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PermissionRow } from './PermissionRow';
 import { Switch } from '@/renderer/library/Switch';
@@ -159,14 +160,32 @@ export const Permissions = ({
     nativeChecked: boolean
   ) => {
     setOneShotProcessing(true);
-
     task.enableOsNotifications = nativeChecked;
-    await executeOneShot(task);
+    const result = await executeOneShot(task);
 
-    // Wait some time to avoid the spinner snapping.
-    setTimeout(() => {
+    if (!result) {
       setOneShotProcessing(false);
-    }, 550);
+
+      // Render error alert.
+      toast.error('API timed out.', {
+        position: 'bottom-center',
+        autoClose: 3000,
+        hideProgressBar: true,
+        closeOnClick: false,
+        closeButton: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark',
+        transition: Flip,
+        toastId: 'toast-connection',
+      });
+    } else {
+      // Wait some time to avoid the spinner snapping.
+      setTimeout(() => {
+        setOneShotProcessing(false);
+      }, 550);
+    }
   };
 
   /// Handle clicking the native checkbox.

--- a/src/utils/AccountUtils.ts
+++ b/src/utils/AccountUtils.ts
@@ -49,7 +49,8 @@ export const fetchBalanceForAccount = async (account: Account) => {
     return;
   }
 
-  const { api } = await ApiUtils.getApiInstance(account.chain);
+  const origin = 'fetchBalanceForAccount';
+  const { api } = await ApiUtils.getApiInstanceOrThrow(account.chain, origin);
   const result: AnyJson = await api.query.system.account(account.address);
 
   account.balance = {
@@ -91,7 +92,8 @@ export const setNominatingDataForAccount = async (account: Account) => {
     return;
   }
 
-  const { api } = await ApiUtils.getApiInstance(account.chain);
+  const origin = 'setNominatingDataForAccount';
+  const { api } = await ApiUtils.getApiInstanceOrThrow(account.chain, origin);
 
   // Check if account is currently nominating.
   const nominatorData: AnyData = await api.query.staking.nominators(
@@ -170,8 +172,8 @@ const setNominationPoolDataForAccount = async (account: Account) => {
     return;
   }
 
-  const { api } = await ApiUtils.getApiInstance(account.chain);
-
+  const origin = 'setNominationPoolDataForAccount';
+  const { api } = await ApiUtils.getApiInstanceOrThrow(account.chain, origin);
   const result: AnyJson = (
     await api.query.nominationPools.poolMembers(account.address)
   ).toJSON();
@@ -258,7 +260,8 @@ const getPoolAccounts = (poolId: number, api: ApiPromise) => {
  * @summary Get the live nonce for an address.
  */
 export const getAddressNonce = async (address: string, chainId: ChainID) => {
-  const instance = await ApiUtils.getApiInstance(chainId);
+  const origin = 'getAddressNonce';
+  const instance = await ApiUtils.getApiInstanceOrThrow(chainId, origin);
   const result: AnyData = await instance.api.query.system.account(address);
   return new BigNumber(result.nonce);
 };

--- a/src/utils/ApiUtils.ts
+++ b/src/utils/ApiUtils.ts
@@ -20,14 +20,21 @@ const debug = MainDebug.extend('ApiUtils');
  */
 export const getApiInstance = async (chainId: ChainID) => {
   const instance = await APIsController.fetchConnectedInstance(chainId);
+  return instance ? instance : null;
+};
 
+/**
+ * @name getApiInstanceOrThrow
+ * @summary Same as `getApiInstance` but throws an error if the endpoint fails to connect.
+ */
+export const getApiInstanceOrThrow = async (
+  chainId: ChainID,
+  error: string
+) => {
+  const instance = await getApiInstance(chainId);
   if (!instance) {
-    throw new Error(
-      `ensureApiConnected: ${chainId} API instance couldn't be fetched.`
-    );
+    throw new Error(`${error} - Could not get API instance.`);
   }
-
-  debug('🔷 Fetched API instance for chain: %o', chainId);
   return instance;
 };
 

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -22,6 +22,7 @@ import { WindowsController } from '@/controller/main/WindowsController';
 import { Config as ConfigMain } from '@/config/processes/main';
 import { MainDebug } from './DebugUtils';
 import type { AnyJson } from '@/types/misc';
+import type { PortPairID } from '@/types/communication';
 
 const debug = MainDebug.extend('WindowUtils');
 
@@ -50,6 +51,47 @@ export const createTray = () => {
 
   // Cache tray in main process config.
   ConfigMain.appTray = tray;
+};
+
+/**
+ * @name sendMainWindowPorts
+ * @summary Send ports to main window to facilitate communication with other windows.
+ */
+export const sendMainWindowPorts = (mainWindow: BrowserWindow) => {
+  mainWindow.webContents.postMessage('port', { target: 'main-import:main' }, [
+    ConfigMain.getPortPair('main-import').port1,
+  ]);
+
+  mainWindow.webContents.postMessage('port', { target: 'main-action:main' }, [
+    ConfigMain.getPortPair('main-action').port1,
+  ]);
+
+  mainWindow.webContents.postMessage('port', { target: 'main-settings:main' }, [
+    ConfigMain.getPortPair('main-settings').port1,
+  ]);
+};
+
+/**
+ * @name sendMainWindowPorts
+ * @summary Send ports to child windows to facilitate communication with the main window.
+ *
+ * Currently unused.
+ */
+export const sendChildWindowPorts = () => {
+  const childWindowIds = ['import', 'action', 'main'];
+
+  for (const windowId of childWindowIds) {
+    const childWindow = WindowsController.get(windowId);
+
+    if (childWindow) {
+      const target = `main-${windowId}:${windowId}`;
+      const portId = `main-${windowId}` as PortPairID;
+
+      childWindow.webContents.postMessage('port', { target }, [
+        ConfigMain.getPortPair(portId).port2,
+      ]);
+    }
+  }
 };
 
 /**
@@ -99,19 +141,7 @@ export const createMainWindow = (isTest: boolean) => {
 
   mainWindow.once('ready-to-show', () => {
     // Send ports to main window to facilitate communication with other windows.
-    mainWindow.webContents.postMessage('port', { target: 'main-import:main' }, [
-      ConfigMain.getPortPair('main-import').port1,
-    ]);
-
-    mainWindow.webContents.postMessage('port', { target: 'main-action:main' }, [
-      ConfigMain.getPortPair('main-action').port1,
-    ]);
-
-    mainWindow.webContents.postMessage(
-      'port',
-      { target: 'main-settings:main' },
-      [ConfigMain.getPortPair('main-settings').port1]
-    );
+    sendMainWindowPorts(mainWindow);
 
     // Set window bounds.
     setMainWindowPosition(mainWindow);

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -113,8 +113,8 @@ export const createMainWindow = (isTest: boolean) => {
   const mainWindow = new BrowserWindow({
     alwaysOnTop: true,
     frame: false,
-    x: initialMenuBounds?.x || undefined,
-    y: initialMenuBounds?.y || undefined,
+    x: initialMenuBounds?.x || ConfigMain.dockedWidth,
+    y: initialMenuBounds?.y || 0,
     width: initialMenuBounds?.height || ConfigMain.dockedWidth,
     height: initialMenuBounds?.height || ConfigMain.dockedHeight,
     minWidth: 420,


### PR DESCRIPTION
# Summary

Debugging iteration after implementing footer RPC select boxes. 

## Notable Fixes

- [x] Re-connect app when switching networks.
There was a problem when switching internet networks where the `OnlineStatusController` couldn't retrieve the online status after the new network was connected. To resolve this problem, the controller's polling loop is stopped and a new one is initialised when the app goes offline.

- [x] One-shot processing doesn't stall upon API connection failure.
The one-shot machinery has been tweaked where the `executeOneShot` function returns a boolean value signalling success or failure. The one-shot fails when the required API instance fails to establish a connection to an endpoint after a certain period of time. This time period is defined in the renderer configuration file as 10 seconds at the time of this PR.

- [x] Active paged rewards API for Polkadot + Kusama
Paged rewards start block added for Polkadot and Kusama. The new API is now used to calculate nominating pending payouts.