### PR TITLE
chore: header styling iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "react-error-boundary": "^4.0.12",
     "react-router-dom": "^6.22.2",
     "react-toastify": "^10.0.5",
-    "react-tooltip": "^5.26.3",
     "styled-components": "^6.1.8",
     "svg-inline-loader": "^0.8.2"
   },

--- a/src/renderer/library/Footer/index.tsx
+++ b/src/renderer/library/Footer/index.tsx
@@ -17,7 +17,7 @@ import { SelectRpc } from './RpcSelect';
 
 export const Footer = () => {
   const { chains } = useChains();
-  const { online: isOnline } = useBootstrapping();
+  const { online: isOnline, isConnecting, isAborting } = useBootstrapping();
 
   const [expanded, setExpanded] = useState<boolean>(false);
 
@@ -29,7 +29,7 @@ export const Footer = () => {
 
   /// Get header text.
   const getHeadingText = () =>
-    isOnline
+    isOnline && !isConnecting && !isAborting
       ? `Connected to ${totalActiveConnections()} network${chains.size === 1 ? '' : 's'}`
       : 'Offline';
 

--- a/src/renderer/library/Header/Wrapper.ts
+++ b/src/renderer/library/Header/Wrapper.ts
@@ -63,6 +63,19 @@ export const HeaderWrapper = styled.div`
             }
           }
         }
+        .dock-btn {
+          border: 1px solid var(--border-mid-color);
+          min-width: 96px;
+          font-size: 0.85rem;
+          max-height: 18px;
+          user-select: none;
+          transition: background-color 0.2s ease-out;
+
+          &:hover {
+            background-color: inherit;
+            border: 1px solid var(--border-secondary-color) !important;
+          }
+        }
         .connect-btn {
           border: 1px solid var(--border-mid-color);
           min-width: 96px;

--- a/src/renderer/library/Header/Wrapper.ts
+++ b/src/renderer/library/Header/Wrapper.ts
@@ -63,19 +63,6 @@ export const HeaderWrapper = styled.div`
             }
           }
         }
-        .dock-btn {
-          border: 1px solid var(--border-mid-color);
-          min-width: 96px;
-          font-size: 0.85rem;
-          max-height: 18px;
-          user-select: none;
-          transition: background-color 0.2s ease-out;
-
-          &:hover {
-            background-color: inherit;
-            border: 1px solid var(--border-secondary-color) !important;
-          }
-        }
         .connect-btn {
           border: 1px solid var(--border-mid-color);
           min-width: 96px;

--- a/src/renderer/library/Header/Wrapper.ts
+++ b/src/renderer/library/Header/Wrapper.ts
@@ -46,23 +46,6 @@ export const HeaderWrapper = styled.div`
         .hide-text {
           color: rgba(0, 0, 0, 0);
         }
-        .connect-wrapper {
-          position: relative;
-
-          .abort-x {
-            position: absolute;
-            user-select: none;
-            left: 45px;
-            bottom: 3px;
-            cursor: pointer;
-
-            .icon-sm {
-              width: 0.75rem;
-              height: 0.75rem;
-              z-index: 10;
-            }
-          }
-        }
         .dock-btn {
           border: 1px solid var(--border-mid-color);
           min-width: 96px;
@@ -70,43 +53,14 @@ export const HeaderWrapper = styled.div`
           max-height: 18px;
           user-select: none;
           transition: background-color 0.2s ease-out;
+          transition: opacity 0.2s ease-out;
+          opacity: 0.4;
 
           &:hover {
             background-color: inherit;
             border: 1px solid var(--border-secondary-color) !important;
+            opacity: 0.8;
           }
-        }
-        .connect-btn {
-          border: 1px solid var(--border-mid-color);
-          min-width: 96px;
-          font-size: 0.85rem;
-          max-height: 18px;
-          user-select: none;
-          transition: background-color 0.2s ease-out;
-
-          &:hover {
-            background-color: inherit;
-            border: 1px solid var(--border-secondary-color) !important;
-          }
-        }
-        .do-pulse {
-          animation: pulse 3s infinite ease-in-out;
-        }
-
-        @keyframes pulse {
-          0% {
-            opacity: 1;
-          }
-          50% {
-            opacity: 0.5;
-          }
-          100% {
-            opacity: 1;
-          }
-        }
-
-        .doPulse {
-          animation: 'pulse 3s infinite ease-in-out';
         }
       }
       > button {

--- a/src/renderer/library/Header/index.tsx
+++ b/src/renderer/library/Header/index.tsx
@@ -6,13 +6,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Menu } from '@app/library/Menu';
 import { useLocation } from 'react-router-dom';
 import { HeaderWrapper } from './Wrapper';
-import { Tooltip } from 'react-tooltip';
 import type { HeaderProps } from './types';
 import { ButtonSecondary } from '@/renderer/kits/Buttons/ButtonSecondary';
 import { useBootstrapping } from '@/renderer/contexts/Bootstrapping';
 import { Config as RendererConfig } from '@/config/processes/renderer';
-import { faLock, faUnlock } from '@fortawesome/pro-solid-svg-icons';
-
+import { faUnlock, faLock } from '@fortawesome/pro-solid-svg-icons';
 export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
   const { pathname } = useLocation();
 
@@ -69,7 +67,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
               <FontAwesomeIcon icon={faTimes} transform="shrink-1" />
             </button>
           )}
-          <Tooltip id="silence-notifications-tooltip" />
         </div>
       </div>
     </HeaderWrapper>

--- a/src/renderer/library/Header/index.tsx
+++ b/src/renderer/library/Header/index.tsx
@@ -7,13 +7,11 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Menu } from '@app/library/Menu';
 import { useLocation } from 'react-router-dom';
 import { HeaderWrapper } from './Wrapper';
-import { Switch } from '../Switch';
 import { Tooltip } from 'react-tooltip';
 import { ButtonSecondary } from '@/renderer/kits/Buttons/ButtonSecondary';
 import { useBootstrapping } from '@/renderer/contexts/Bootstrapping';
 import { Flip, toast } from 'react-toastify';
 import type { HeaderProps } from './types';
-import { faLock, faUnlock } from '@fortawesome/pro-solid-svg-icons';
 
 export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
   const { pathname } = useLocation();
@@ -25,14 +23,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
     setIsConnecting,
     handleInitializeAppOffline,
     handleInitializeAppOnline,
-  } = useBootstrapping();
-
-  /// App settings.
-  const {
-    dockToggled,
-    silenceOsNotifications,
-    handleDockedToggle,
-    handleToggleSilenceOsNotifications,
   } = useBootstrapping();
 
   /// Determine active window by pathname.
@@ -97,32 +87,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
     RendererConfig.abortConnecting = true;
   };
 
-  /// Handle clicking the docked button.
-  const handleDocked = () => {
-    handleDockedToggle();
-
-    // Post message to settings window to update switch.
-    RendererConfig.portToSettings.postMessage({
-      task: 'settings:set:dockedWindow',
-      data: {
-        docked: !dockToggled,
-      },
-    });
-  };
-
-  /// Handle clicking the silence OS notifications button.
-  const handleSilenceOsNotifications = () => {
-    handleToggleSilenceOsNotifications();
-
-    // Post message to settings window to update switch.
-    RendererConfig.portToSettings.postMessage({
-      task: 'settings:set:silenceOsNotifications',
-      data: {
-        silenced: !silenceOsNotifications,
-      },
-    });
-  };
-
   return (
     <HeaderWrapper>
       <div className="content-wrapper">
@@ -130,23 +94,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
         <div className="right">
           {showMenu || activeWindow === 'menu' ? (
             <div className="controls-wrapper">
-              {/* Docked button */}
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  columnGap: '1rem',
-                }}
-              >
-                <ButtonSecondary
-                  className="dock-btn"
-                  text={dockToggled ? 'Detach' : 'Dock'}
-                  iconLeft={dockToggled ? faUnlock : faLock}
-                  iconTransform="shrink-2"
-                  onClick={() => handleDocked()}
-                />
-              </div>
-
               {/* Connection button */}
               <div className="connect-wrapper">
                 <ButtonSecondary
@@ -174,21 +121,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
                   </div>
                 )}
               </div>
-
-              {/* Silence OS notifications switch */}
-              <a
-                data-tooltip-id="silence-notifications-tooltip"
-                data-tooltip-content="Silence OS Notifications"
-                data-tooltip-place="left"
-              >
-                <Switch
-                  size="sm"
-                  type="mono"
-                  isOn={silenceOsNotifications}
-                  disabled={appLoading}
-                  handleToggle={() => handleSilenceOsNotifications()}
-                />
-              </a>
 
               {/* Cog menu*/}
               <Menu />

--- a/src/renderer/library/Menu/Wrapper.tsx
+++ b/src/renderer/library/Menu/Wrapper.tsx
@@ -14,7 +14,7 @@ export const MenuWrapper = styled.div`
   justify-content: flex-start;
   width: 175px;
   height: auto;
-  padding: 0.45rem 0;
+  padding: 0.75rem 0 0;
 
   box-shadow: -1px 3px 5px 0px var(--card-shadow-color);
   border: 1px solid var(--border-mid-color);
@@ -43,6 +43,39 @@ export const MenuWrapper = styled.div`
     color: #636363;
     &:hover {
       background: inherit;
+    }
+  }
+
+  // Controls
+  .controls {
+    .controls-wrapper {
+      margin-top: 0.75rem;
+      border-top: 1px solid #282828;
+      border-bottom-left-radius: 0.75rem;
+      border-bottom-right-radius: 0.75rem;
+      background-color: #1b1b1b;
+
+      padding: 1rem;
+      display: flex;
+      flex-direction: column;
+      row-gap: 1rem;
+      width: 100%;
+
+      .dock-btn {
+        background-color: var(--background-menu);
+        border: 1px solid var(--border-mid-color);
+        font-size: 1rem;
+        font-family: InterSemiBold, sans-serif;
+        user-select: none;
+        transition: background-color 0.2s ease-out;
+        width: 100%;
+        color: var(--text-color-secondary);
+
+        &:hover {
+          background-color: inherit;
+          border: 1px solid var(--border-secondary-color) !important;
+        }
+      }
     }
   }
 `;

--- a/src/renderer/library/Menu/Wrapper.tsx
+++ b/src/renderer/library/Menu/Wrapper.tsx
@@ -61,7 +61,7 @@ export const MenuWrapper = styled.div`
       row-gap: 1rem;
       width: 100%;
 
-      .dock-btn {
+      .menu-btn {
         background-color: var(--background-menu);
         border: 1px solid var(--border-mid-color);
         font-size: 1rem;
@@ -74,6 +74,27 @@ export const MenuWrapper = styled.div`
         &:hover {
           background-color: inherit;
           border: 1px solid var(--border-secondary-color) !important;
+        }
+      }
+
+      // Connect button
+      .connect-wrapper {
+        position: relative;
+        width: 100%;
+
+        .do-pulse {
+          animation: pulse 3s infinite ease-in-out;
+        }
+        @keyframes pulse {
+          0% {
+            opacity: 1;
+          }
+          50% {
+            opacity: 0.5;
+          }
+          100% {
+            opacity: 1;
+          }
         }
       }
     }

--- a/src/renderer/library/Menu/Wrapper.tsx
+++ b/src/renderer/library/Menu/Wrapper.tsx
@@ -5,8 +5,8 @@ import styled from 'styled-components';
 
 export const MenuWrapper = styled.div`
   position: absolute;
-  right: 0.75rem;
-  top: 2.75rem;
+  right: 0;
+  top: 2.25rem;
   z-index: 10;
 
   display: flex;

--- a/src/renderer/library/Menu/index.tsx
+++ b/src/renderer/library/Menu/index.tsx
@@ -19,7 +19,7 @@ import { Config as RendererConfig } from '@/config/processes/renderer';
 import { Flip, toast } from 'react-toastify';
 
 export const Menu = () => {
-  const [menuOpen, setMenuOpen] = useState<boolean>(true);
+  const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const menuOpenRef = useRef(menuOpen);
 
   /// App settings.

--- a/src/renderer/library/Menu/index.tsx
+++ b/src/renderer/library/Menu/index.tsx
@@ -1,16 +1,33 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { faCog } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { setStateWithRef } from '@w3ux/utils';
 import { useOutsideAlerter } from '@app/library/Hooks/useOutsideAlerter';
 import { useRef, useState } from 'react';
-import { MenuWrapper, Separator } from './Wrapper';
+import { MenuWrapper } from './Wrapper';
+import { ButtonSecondary } from '@/renderer/kits/Buttons/ButtonSecondary';
+import { useBootstrapping } from '@/renderer/contexts/Bootstrapping';
+import {
+  faBell,
+  faBellSlash,
+  faCog,
+  faLock,
+  faUnlock,
+} from '@fortawesome/pro-solid-svg-icons';
+import { Config as RendererConfig } from '@/config/processes/renderer';
 
 export const Menu = () => {
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const menuOpenRef = useRef(menuOpen);
+
+  /// App settings.
+  const {
+    dockToggled,
+    handleDockedToggle,
+    silenceOsNotifications,
+    handleToggleSilenceOsNotifications,
+  } = useBootstrapping();
 
   const toggleMenu = (val: boolean) => {
     setStateWithRef(val, setMenuOpen, menuOpenRef);
@@ -25,6 +42,32 @@ export const Menu = () => {
     },
     ['dropdown-toggle']
   );
+
+  /// Handle clicking the docked button.
+  const handleDocked = () => {
+    handleDockedToggle();
+
+    // Post message to settings window to update switch.
+    RendererConfig.portToSettings.postMessage({
+      task: 'settings:set:dockedWindow',
+      data: {
+        docked: !dockToggled,
+      },
+    });
+  };
+
+  /// Handle clicking the silence OS notifications button.
+  const handleSilenceOsNotifications = () => {
+    handleToggleSilenceOsNotifications();
+
+    // Post message to settings window to update switch.
+    RendererConfig.portToSettings.postMessage({
+      task: 'settings:set:silenceOsNotifications',
+      data: {
+        silenced: !silenceOsNotifications,
+      },
+    });
+  };
 
   return (
     <>
@@ -58,7 +101,8 @@ export const Menu = () => {
           >
             Settings
           </button>
-          <Separator />
+
+          {/* Exit */}
           <button
             type="button"
             onClick={async () => await window.myAPI.quitApp()}
@@ -66,6 +110,29 @@ export const Menu = () => {
           >
             Exit
           </button>
+
+          {/* Controls */}
+          <section className="controls" style={{ width: '100%' }}>
+            <div className="controls-wrapper">
+              {/* Dock window */}
+              <ButtonSecondary
+                className="dock-btn"
+                text={dockToggled ? 'Detach' : 'Dock'}
+                iconLeft={dockToggled ? faUnlock : faLock}
+                iconTransform="shrink-5"
+                onClick={() => handleDocked()}
+              />
+
+              {/* Silence notifications */}
+              <ButtonSecondary
+                className="dock-btn"
+                text={silenceOsNotifications ? 'Unsilence' : 'Silence'}
+                iconLeft={silenceOsNotifications ? faBellSlash : faBell}
+                iconTransform="shrink-3"
+                onClick={() => handleSilenceOsNotifications()}
+              />
+            </div>
+          </section>
         </MenuWrapper>
       ) : null}
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,32 +957,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
-  dependencies:
-    "@floating-ui/utils": "npm:^0.2.1"
-  checksum: 667a68036f7dd5ed19442c7792a6002ca02d1799221c4396691bbe0b6008b48f6ccad581225e81fa266bb91232f6c66838a5f825f554217e1ec886178b93381b
-  languageName: node
-  linkType: hard
-
-"@floating-ui/dom@npm:^1.6.1":
-  version: 1.6.3
-  resolution: "@floating-ui/dom@npm:1.6.3"
-  dependencies:
-    "@floating-ui/core": "npm:^1.0.0"
-    "@floating-ui/utils": "npm:^0.2.0"
-  checksum: d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
-  languageName: node
-  linkType: hard
-
-"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@floating-ui/utils@npm:0.2.1"
-  checksum: ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
-  languageName: node
-  linkType: hard
-
 "@fortawesome/fontawesome-common-types@npm:6.5.1":
   version: 6.5.1
   resolution: "@fortawesome/fontawesome-common-types@npm:6.5.1"
@@ -4225,13 +4199,6 @@ __metadata:
     inherits: "npm:^2.0.1"
     safe-buffer: "npm:^5.0.1"
   checksum: d8d005f8b64d8a77b3d3ce531301ae7b45902c9cab4ec8b66bdbd2bf2a1d9fceb9a2133c293eb3c060b2d964da0f14c47fb740366081338aa3795dd1faa8984b
-  languageName: node
-  linkType: hard
-
-"classnames@npm:^2.3.0":
-  version: 2.5.1
-  resolution: "classnames@npm:2.5.1"
-  checksum: afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 
@@ -9777,7 +9744,6 @@ __metadata:
     react-error-boundary: "npm:^4.0.12"
     react-router-dom: "npm:^6.22.2"
     react-toastify: "npm:^10.0.5"
-    react-tooltip: "npm:^5.26.3"
     sass: "npm:^1.71.1"
     sass-loader: "npm:^14.1.1"
     styled-components: "npm:^6.1.8"
@@ -10227,19 +10193,6 @@ __metadata:
     react: ">=18"
     react-dom: ">=18"
   checksum: 66c68ec3d6c017d9f32652d73bb925224921c6a80b629b9d481430d5b4fd504abb7a99995a64b9aef0fc31326c74f3cbe088b3287b978dd0c355079c4bbf4158
-  languageName: node
-  linkType: hard
-
-"react-tooltip@npm:^5.26.3":
-  version: 5.26.3
-  resolution: "react-tooltip@npm:5.26.3"
-  dependencies:
-    "@floating-ui/dom": "npm:^1.6.1"
-    classnames: "npm:^2.3.0"
-  peerDependencies:
-    react: ">=16.14.0"
-    react-dom: ">=16.14.0"
-  checksum: fcce843ebfda0a74ddaf90b7d322879c9070bd180e490ae4634ff02052b1cd39158a0af3a27621a9ffe62a1a8ad246633908a1d214998aea0403ec7aeca874fb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary

- [x] Dock button opacity adjusted to be less intrusive.
- [x] Header connection and silence buttons moved to cog menu.
- [x] Render connected network count after connection established (not immediately when connection button clicked)

## Notes

- Hover effect on window drag area. 
Cannot add a hover effect on an element with `-webkit-app-region: drag;`.