### PR TITLE
feat: export and import account data

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -145,16 +145,18 @@ export const HelpConfig: HelpItems = [
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [
-      'Coming soon.',
-      'Import data from another Polkadot Live installation to restore your accounts, events and subscription.',
+      'Import a data file that was exported from another Polkadot Live installation to restore your accounts.',
+      'Accounts in the data file that do not currently exist in Polkadot Live will be added to the import window. From there, you can import the account and turn on subscriptions in the normal manner.',
+      'This feature currently supports Vault and Read-Only accounts.',
     ],
   },
   {
     key: 'help:settings:exportData',
     title: 'Export Data',
     definition: [
-      'Coming soon.',
-      'Export your Polkadot Live data to a file, allowing you to restore your accounts, events and subscriptions on another computer.',
+      'Export account data to a text file, allowing you to backup your accounts managed by Polkadot Live.',
+      'Use the corresponding "Import" button in the settings window to read the exported data file and restore your accounts in Polkadot Live.',
+      'This feature currently supports Vault and Read-Only accounts.',
     ],
   },
 ];

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -28,6 +28,9 @@ export class Config {
   // Cache Electron objects.
   private static _appTray: Tray | null = null;
 
+  // Flags to handle data processes.
+  private static _exportingData = false;
+
   // Instantiate message port pairs to facilitate communication between the
   // main renderer and another renderer.
   static initialize = (): void => {
@@ -149,6 +152,14 @@ export class Config {
 
   static set childWidth(width: number) {
     Config._childWidth = width;
+  }
+
+  static get exportingData(): boolean {
+    return Config._exportingData;
+  }
+
+  static set exportingData(flag: boolean) {
+    Config._exportingData = flag;
   }
 
   // Setter for app's tray object.

--- a/src/main.ts
+++ b/src/main.ts
@@ -418,7 +418,7 @@ app.whenReady().then(async () => {
    * Data
    */
 
-  ipcMain.handle('app:data:export', async () => {
+  ipcMain.handle('app:data:export', async (_, serialized) => {
     // TODO: Receive data to write to file.
 
     if (!ConfigMain.exportingData) {
@@ -438,14 +438,13 @@ app.whenReady().then(async () => {
       });
 
       // Handle save or cancel.
-      // TODO: Handle empty filepath.
+      // TODO: Handle empty filepath (error messages).
       if (!canceled && filePath) {
-        const data = 'some temp data...';
-
-        fs.writeFile(filePath, data, { encoding: 'utf8' }, (err) => {
+        fs.writeFile(filePath, serialized, { encoding: 'utf8' }, (err) => {
           if (err) {
             console.log(err);
           } else {
+            // TODO: Return true and render success message in settings window.
             console.log('File written successfully.');
             console.log(fs.readFileSync(filePath, 'utf8'));
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -466,8 +466,7 @@ app.whenReady().then(async () => {
   ipcMain.handle('app:data:import', async () => {
     const window = WindowsController.get('settings');
     if (!window) {
-      // TODO: Send error response and handle in main renderer.
-      return;
+      return { result: false, msg: 'error' };
     }
 
     const { canceled, filePaths } = await dialog.showOpenDialog(window, {
@@ -486,15 +485,12 @@ app.whenReady().then(async () => {
         const serialized = await fsPromises.readFile(filePaths[0], {
           encoding: 'utf-8',
         });
-
-        // TODO: Send serialized text to main rendere for parsing.
-        console.log(serialized);
+        return { result: true, msg: 'success', data: { serialized } };
       } catch (err) {
-        // TODO: Send error response and handle in main renderer.
-        console.log(err);
+        return { result: false, msg: 'error' };
       }
     } else {
-      // TODO: Dialog was canceled.
+      return { result: false, msg: 'canceled' };
     }
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,7 +433,7 @@ app.whenReady().then(async () => {
         defaultPath: 'polkadot-live-data.txt',
         filters: [
           {
-            name: 'Text File',
+            name: 'Text Files',
             extensions: ['txt'],
           },
         ],
@@ -464,6 +464,37 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.handle('app:data:import', async () => {
-    console.log('TODO: Import data.');
+    const window = WindowsController.get('settings');
+    if (!window) {
+      // TODO: Send error response and handle in main renderer.
+      return;
+    }
+
+    const { canceled, filePaths } = await dialog.showOpenDialog(window, {
+      title: 'Import Data',
+      filters: [
+        {
+          name: 'Text Files',
+          extensions: ['txt'],
+        },
+      ],
+      properties: ['openFile'],
+    });
+
+    if (!canceled && filePaths.length) {
+      try {
+        const serialized = await fsPromises.readFile(filePaths[0], {
+          encoding: 'utf-8',
+        });
+
+        // TODO: Send serialized text to main rendere for parsing.
+        console.log(serialized);
+      } catch (err) {
+        // TODO: Send error response and handle in main renderer.
+        console.log(err);
+      }
+    } else {
+      // TODO: Dialog was canceled.
+    }
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -423,7 +423,12 @@ app.whenReady().then(async () => {
       ConfigMain.exportingData = true;
 
       // Get response from dialog.
-      const { canceled, filePath } = await dialog.showSaveDialog({
+      const window = WindowsController.get('settings');
+      if (!window) {
+        return { result: false, msg: 'error' };
+      }
+
+      const { canceled, filePath } = await dialog.showSaveDialog(window, {
         title: 'Export Data',
         defaultPath: 'polkadot-live-data.txt',
         filters: [

--- a/src/main.ts
+++ b/src/main.ts
@@ -411,4 +411,16 @@ app.whenReady().then(async () => {
       });
     }
   });
+
+  /**
+   * Data
+   */
+
+  ipcMain.handle('app:data:export', async () => {
+    console.log('TODO: Export data.');
+  });
+
+  ipcMain.handle('app:data:import', async () => {
+    console.log('TODO: Import data.');
+  });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 
 import {
   app,
+  dialog,
   ipcMain,
   powerMonitor,
   protocol,
@@ -14,6 +15,7 @@ import { executeLedgerLoop } from './ledger';
 import Store from 'electron-store';
 import AutoLaunch from 'auto-launch';
 import unhandled from 'electron-unhandled';
+import fs from 'fs';
 import { AppOrchestrator } from '@/orchestrators/AppOrchestrator';
 import { EventsController } from '@/controller/main/EventsController';
 import { OnlineStatusController } from '@/controller/main/OnlineStatusController';
@@ -417,7 +419,43 @@ app.whenReady().then(async () => {
    */
 
   ipcMain.handle('app:data:export', async () => {
-    console.log('TODO: Export data.');
+    // TODO: Receive data to write to file.
+
+    if (!ConfigMain.exportingData) {
+      ConfigMain.exportingData = true;
+
+      // Get response from dialog.
+      const { canceled, filePath } = await dialog.showSaveDialog({
+        title: 'Export Data',
+        defaultPath: 'polkadot-live-data.txt',
+        filters: [
+          {
+            name: 'Text File',
+            extensions: ['txt'],
+          },
+        ],
+        properties: [],
+      });
+
+      // Handle save or cancel.
+      // TODO: Handle empty filepath.
+      if (!canceled && filePath) {
+        const data = 'some temp data...';
+
+        fs.writeFile(filePath, data, { encoding: 'utf8' }, (err) => {
+          if (err) {
+            console.log(err);
+          } else {
+            console.log('File written successfully.');
+            console.log(fs.readFileSync(filePath, 'utf8'));
+          }
+
+          ConfigMain.exportingData = false;
+        });
+      } else {
+        ConfigMain.exportingData = false;
+      }
+    }
   });
 
   ipcMain.handle('app:data:import', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -418,6 +418,7 @@ app.whenReady().then(async () => {
    * Data
    */
 
+  // Export a data-file.
   ipcMain.handle('app:data:export', async (_, serialized) => {
     if (!ConfigMain.exportingData) {
       ConfigMain.exportingData = true;
@@ -463,6 +464,7 @@ app.whenReady().then(async () => {
     return { result: false, msg: 'executing' };
   });
 
+  // Import a data-file.
   ipcMain.handle('app:data:import', async () => {
     const window = WindowsController.get('settings');
     if (!window) {

--- a/src/model/Account.ts
+++ b/src/model/Account.ts
@@ -80,10 +80,10 @@ export class Account {
     }) as FlattenedAccountData;
 
   toJSON = () => ({
-    _source: this._source,
     _address: this._address,
-    _name: this._name,
     _chain: this._chain,
+    _name: this._name,
+    _source: this._source,
   });
 
   get chain() {

--- a/src/model/Account.ts
+++ b/src/model/Account.ts
@@ -11,6 +11,7 @@ import type {
   FlattenedAccountData,
   AccountNominationPoolData,
   AccountNominatingData,
+  AccountJson,
 } from '@/types/accounts';
 
 /**
@@ -79,12 +80,13 @@ export class Account {
       source: this.source,
     }) as FlattenedAccountData;
 
-  toJSON = () => ({
-    _address: this._address,
-    _chain: this._chain,
-    _name: this._name,
-    _source: this._source,
-  });
+  toJSON = () =>
+    ({
+      _address: this._address,
+      _chain: this._chain,
+      _name: this._name,
+      _source: this._source,
+    }) as AccountJson;
 
   get chain() {
     return this._chain;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -36,6 +36,14 @@ ipcRenderer.on('port', (e: AnyJson, msg: AnyJson) => {
 
 export const API: PreloadAPI = {
   /**
+   * File import and export
+   */
+
+  exportAppData: async () => await ipcRenderer.invoke('app:data:export'),
+
+  importAppData: async () => await ipcRenderer.invoke('app:data:import'),
+
+  /**
    * New handlers
    */
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -39,7 +39,8 @@ export const API: PreloadAPI = {
    * File import and export
    */
 
-  exportAppData: async () => await ipcRenderer.invoke('app:data:export'),
+  exportAppData: async (serialized: string) =>
+    await ipcRenderer.invoke('app:data:export', serialized),
 
   importAppData: async () => await ipcRenderer.invoke('app:data:import'),
 

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -13,8 +13,9 @@ import { TooltipProvider } from '@app/contexts/Tooltip';
 import { TxMetaProvider } from '@app/contexts/TxMeta';
 import { withProviders } from '@app/library/Hooks/withProviders';
 // Import window contexts
-import { AccountStatusesProvider } from './contexts/import/AccountStatuses';
-import { ConnectionsProvider } from './contexts/import/Connections';
+import { AccountStatusesProvider as ImportAccountStatusesProvider } from './contexts/import/AccountStatuses';
+import { ConnectionsProvider as ImportConnectionsProvider } from './contexts/import/Connections';
+import { AddressesProvider as ImportAddressesProvider } from './contexts/import/Addresses';
 // Settings window contexts
 import { SettingFlagsProvider } from './contexts/settings/SettingFlags';
 import { Theme } from './Theme';
@@ -29,8 +30,10 @@ export const Providers = withProviders(
   EventsProvider,
   TxMetaProvider,
   TooltipProvider,
-  AccountStatusesProvider,
-  ConnectionsProvider,
+  // Settings window
+  ImportAddressesProvider,
+  ImportAccountStatusesProvider,
+  ImportConnectionsProvider,
   // Online status provider relies on other contexts being initialized.
   BootstrappingProvider,
   // Settings window

--- a/src/renderer/contexts/import/AccountStatuses/index.tsx
+++ b/src/renderer/contexts/import/AccountStatuses/index.tsx
@@ -16,6 +16,15 @@ export const AccountStatusesContext =
     defaults.defaultAccountStatusesContext
   );
 
+/**
+ * @name useAccountStatuses
+ * @summary An account status of `true` means it is processing, while `false` means
+ * it's not processing.
+ *
+ * When an account is being imported, it may take several seconds to initialize
+ * and sync its data with the state on its blockchain network. During this processing
+ * time, its status is set to `true`.
+ */
 export const useAccountStatuses = () => useContext(AccountStatusesContext);
 
 export const AccountStatusesProvider = ({

--- a/src/renderer/contexts/import/Addresses/defaults.ts
+++ b/src/renderer/contexts/import/Addresses/defaults.ts
@@ -11,4 +11,5 @@ export const defaultAddressesContext: AddressesContextInterface = {
   setLedgerAddresses: (a) => {},
   setReadOnlyAddresses: (a) => {},
   setVaultAddresses: (a) => {},
+  importAccountJson: (a) => {},
 };

--- a/src/renderer/contexts/import/Addresses/defaults.ts
+++ b/src/renderer/contexts/import/Addresses/defaults.ts
@@ -1,0 +1,14 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { AddressesContextInterface } from './types';
+
+export const defaultAddressesContext: AddressesContextInterface = {
+  ledgerAddresses: [],
+  readOnlyAddresses: [],
+  vaultAddresses: [],
+  setLedgerAddresses: (a) => {},
+  setReadOnlyAddresses: (a) => {},
+  setVaultAddresses: (a) => {},
+};

--- a/src/renderer/contexts/import/Addresses/index.tsx
+++ b/src/renderer/contexts/import/Addresses/index.tsx
@@ -1,0 +1,69 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Config as ConfigImport } from '@/config/processes/import';
+import { createContext, useContext, useState } from 'react';
+import * as defaults from './defaults';
+import type { AddressesContextInterface } from './types';
+import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
+
+export const AddressesContext = createContext<AddressesContextInterface>(
+  defaults.defaultAddressesContext
+);
+
+/**
+ * @name useAddresses
+ * @summary Manages state of addresses for the `import` child window.
+ */
+export const useAddresses = () => useContext(AddressesContext);
+
+export const AddressesProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  /// Ledger addresses state.
+  const [ledgerAddresses, setLedgerAddresses] = useState<LedgerLocalAddress[]>(
+    () => {
+      const key = ConfigImport.getStorageKey('ledger');
+      const fetched: string | null = localStorage.getItem(key);
+      const parsed: LedgerLocalAddress[] =
+        fetched !== null ? JSON.parse(fetched) : [];
+      return parsed;
+    }
+  );
+
+  /// Read-only addresses state.
+  const [readOnlyAddresses, setReadOnlyAddresses] = useState<LocalAddress[]>(
+    () => {
+      const key = ConfigImport.getStorageKey('read-only');
+      const fetched: string | null = localStorage.getItem(key);
+      const parsed: LocalAddress[] =
+        fetched !== null ? JSON.parse(fetched) : [];
+      return parsed;
+    }
+  );
+
+  /// Vault addresses state.
+  const [vaultAddresses, setVaultAddresses] = useState<LocalAddress[]>(() => {
+    const key = ConfigImport.getStorageKey('vault');
+    const fetched: string | null = localStorage.getItem(key);
+    const parsed: LocalAddress[] = fetched !== null ? JSON.parse(fetched) : [];
+    return parsed;
+  });
+
+  return (
+    <AddressesContext.Provider
+      value={{
+        ledgerAddresses,
+        readOnlyAddresses,
+        vaultAddresses,
+        setLedgerAddresses,
+        setReadOnlyAddresses,
+        setVaultAddresses,
+      }}
+    >
+      {children}
+    </AddressesContext.Provider>
+  );
+};

--- a/src/renderer/contexts/import/Addresses/types.ts
+++ b/src/renderer/contexts/import/Addresses/types.ts
@@ -1,7 +1,11 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
+import type {
+  AccountJson,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
 
 export interface AddressesContextInterface {
   ledgerAddresses: LedgerLocalAddress[];
@@ -10,4 +14,5 @@ export interface AddressesContextInterface {
   setLedgerAddresses: (a: LedgerLocalAddress[]) => void;
   setReadOnlyAddresses: (a: LocalAddress[]) => void;
   setVaultAddresses: (a: LocalAddress[]) => void;
+  importAccountJson: (a: AccountJson) => void;
 }

--- a/src/renderer/contexts/import/Addresses/types.ts
+++ b/src/renderer/contexts/import/Addresses/types.ts
@@ -1,0 +1,13 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
+
+export interface AddressesContextInterface {
+  ledgerAddresses: LedgerLocalAddress[];
+  readOnlyAddresses: LocalAddress[];
+  vaultAddresses: LocalAddress[];
+  setLedgerAddresses: (a: LedgerLocalAddress[]) => void;
+  setReadOnlyAddresses: (a: LocalAddress[]) => void;
+  setVaultAddresses: (a: LocalAddress[]) => void;
+}

--- a/src/renderer/contexts/settings/SettingFlags/defaults.ts
+++ b/src/renderer/contexts/settings/SettingFlags/defaults.ts
@@ -10,4 +10,5 @@ export const defaultSettingFlagsContext: SettingFlagsContextInterface = {
   setWindowDocked: (b) => {},
   setSilenceOsNotifications: (b) => {},
   setShowOnAllWorkspaces: (b) => {},
+  renderToastify: (s, t) => {},
 };

--- a/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -3,6 +3,7 @@
 
 import * as defaults from './defaults';
 import { createContext, useContext, useEffect, useState } from 'react';
+import { Flip, toast } from 'react-toastify';
 import type { SettingFlagsContextInterface } from './types';
 import type { SettingItem } from '@/renderer/screens/Settings/types';
 
@@ -79,6 +80,43 @@ export const SettingFlagsProvider = ({
     }
   };
 
+  /// Render a toastify message.
+  const renderToastify = (success: boolean, text: string) => {
+    const toastId = `toast-export-data-${success}`;
+    const position = 'top-center';
+    const autoClose = 3000;
+
+    if (success) {
+      toast.success(text, {
+        position,
+        autoClose,
+        hideProgressBar: true,
+        closeOnClick: false,
+        closeButton: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark',
+        transition: Flip,
+        toastId,
+      });
+    } else {
+      toast.error(text, {
+        position,
+        autoClose,
+        hideProgressBar: true,
+        closeOnClick: false,
+        closeButton: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark',
+        transition: Flip,
+        toastId,
+      });
+    }
+  };
+
   return (
     <SettingFlagsContext.Provider
       value={{
@@ -87,6 +125,7 @@ export const SettingFlagsProvider = ({
         setShowOnAllWorkspaces,
         getSwitchState,
         handleSwitchToggle,
+        renderToastify,
       }}
     >
       {children}

--- a/src/renderer/contexts/settings/SettingFlags/types.ts
+++ b/src/renderer/contexts/settings/SettingFlags/types.ts
@@ -9,4 +9,5 @@ export interface SettingFlagsContextInterface {
   setWindowDocked: (flag: boolean) => void;
   setSilenceOsNotifications: (flag: boolean) => void;
   setShowOnAllWorkspaces: (flag: boolean) => void;
+  renderToastify: (success: boolean, text: string) => void;
 }

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -45,7 +45,8 @@ export const useMessagePorts = () => {
   const { setStatusForAccount } = useAccountStatuses();
 
   // Settings renderer contexts.
-  const { setWindowDocked, setSilenceOsNotifications } = useSettingFlags();
+  const { setWindowDocked, setSilenceOsNotifications, renderToastify } =
+    useSettingFlags();
 
   /// Action window specific.
   const {
@@ -477,9 +478,8 @@ export const useMessagePorts = () => {
                 break;
               }
               case 'settings:render:toast': {
-                // TODO: Render toastify message.
                 const { success, text } = ev.data.data;
-                console.log(`Render message: ${success} - ${text}`);
+                renderToastify(success, text);
                 break;
               }
               default: {

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -286,7 +286,7 @@ export const useMessagePorts = () => {
           break;
         }
         case 'canceled': {
-          postToSettings(result, 'Data export was canceled.');
+          // Don't do anything on cancel.
           break;
         }
         case 'executing': {

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -372,7 +372,7 @@ export const useMessagePorts = () => {
 
           break;
         }
-        case 'canceld': {
+        case 'canceled': {
           // Don't do anything on cancel.
           break;
         }

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -27,6 +27,7 @@ import { useSettingFlags } from '../contexts/settings/SettingFlags';
 import { useSubscriptions } from '@app/contexts/Subscriptions';
 import { useTxMeta } from '../contexts/TxMeta';
 import type { ActionMeta } from '@/types/tx';
+import type { AnyJson } from '@w3ux/utils/types';
 
 export const useMessagePorts = () => {
   /// Main renderer contexts.
@@ -251,6 +252,18 @@ export const useMessagePorts = () => {
     };
 
     /**
+     * @name handleDataExport
+     * @summary Write Polkadot Live data to a file.
+     */
+    const handleDataExport = async () => {
+      const accountsJson: AnyJson[] = [];
+      for (const chainAccounts of AccountsController.accounts.values()) {
+        chainAccounts.forEach((a) => accountsJson.push(a.toJSON()));
+      }
+      await window.myAPI.exportAppData(JSON.stringify(accountsJson));
+    };
+
+    /**
      * @name handleReceivedPort
      * @summary Determines whether the received port is for the `main` or `import` window and
      * sets up message handlers accordingly.
@@ -396,7 +409,7 @@ export const useMessagePorts = () => {
                 break;
               }
               case 'settings:execute:exportData': {
-                await window.myAPI.exportAppData();
+                await handleDataExport();
                 break;
               }
               case 'settings:execute:importData': {

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -395,12 +395,12 @@ export const useMessagePorts = () => {
                 handleToggleSilenceOsNotifications();
                 break;
               }
-              case 'settings:execute:importData': {
-                console.log('todo: handle importData');
+              case 'settings:execute:exportData': {
+                await window.myAPI.exportAppData();
                 break;
               }
-              case 'settings:execute:exportData': {
-                console.log('todo: handle exportData');
+              case 'settings:execute:importData': {
+                await window.myAPI.importAppData();
                 break;
               }
               default: {

--- a/src/renderer/hooks/useMessagePorts.ts
+++ b/src/renderer/hooks/useMessagePorts.ts
@@ -260,7 +260,9 @@ export const useMessagePorts = () => {
       for (const chainAccounts of AccountsController.accounts.values()) {
         chainAccounts.forEach((a) => accountsJson.push(a.toJSON()));
       }
-      await window.myAPI.exportAppData(JSON.stringify(accountsJson));
+      const serialized = JSON.stringify(accountsJson);
+      const result = await window.myAPI.exportAppData(serialized);
+      console.log(result);
     };
 
     /**

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -212,7 +212,7 @@ export const HardwareAddress = ({
               iconLeft={faDownFromDottedLine}
               iconTransform="grow-2"
               text={''}
-              onClick={() => openConfirmHandler()}
+              onClick={() => !isProcessing && openConfirmHandler()}
               className={
                 isProcessing
                   ? 'account-action-btn processing'

--- a/src/renderer/screens/Import/Ledger/index.tsx
+++ b/src/renderer/screens/Import/Ledger/index.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@/types/ledger';
 import type { LedgerLocalAddress } from '@/types/accounts';
 import type { IpcRendererEvent } from 'electron';
+import { useAddresses } from '@/renderer/contexts/import/Addresses';
 
 const TOTAL_ALLOWED_STATUS_CODES = 50;
 
@@ -31,17 +32,8 @@ export const ImportLedger = ({
 
   // Status entry is added for a newly imported account.
   const { insertAccountStatus } = useAccountStatuses();
-
-  // Store addresses retreived from Ledger device. Defaults to addresses saved in local storage.
-  const [addresses, setAddresses] = useState<LedgerLocalAddress[]>(() => {
-    const key = ConfigImport.getStorageKey('ledger');
-    const fetched: string | null = localStorage.getItem(key);
-    const parsed: LedgerLocalAddress[] =
-      fetched !== null ? JSON.parse(fetched) : [];
-    return parsed;
-  });
-
-  //const addressesRef = useRef(addresses);
+  const { ledgerAddresses: addresses, setLedgerAddresses: setAddresses } =
+    useAddresses();
 
   // Store status codes received from Ledger device.
   const [statusCodes, setStatusCodes] = useState<LedgerResponse[]>([]);
@@ -114,7 +106,6 @@ export const ImportLedger = ({
       localStorage.setItem(storageKey, JSON.stringify(newAddresses));
       setStateWithRef(false, setIsImporting, isImportingRef);
       setAddresses(newAddresses);
-      //setStateWithRef(newAddresses, setAddresses, addressesRef);
       setStateWithRef([], setStatusCodes, statusCodesRef);
 
       // Insert account status entry.

--- a/src/renderer/screens/Import/ReadOnly/index.tsx
+++ b/src/renderer/screens/Import/ReadOnly/index.tsx
@@ -1,11 +1,9 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { Config as ConfigImport } from '@/config/processes/import';
 import { Manage } from './Manage';
-import { useState } from 'react';
+import { useAddresses } from '@/renderer/contexts/import/Addresses';
 import type { AnyFunction } from '@w3ux/utils/types';
-import type { LocalAddress } from '@/types/accounts';
 
 export const ImportReadOnly = ({
   section,
@@ -15,19 +13,14 @@ export const ImportReadOnly = ({
   setSection: AnyFunction;
 }) => {
   // Get read-only addresses from local storage.
-  const [addresses, setAddressesState] = useState<LocalAddress[]>(() => {
-    const key = ConfigImport.getStorageKey('read-only');
-    const fetched: string | null = localStorage.getItem(key);
-    const parsed: LocalAddress[] = fetched !== null ? JSON.parse(fetched) : [];
-    return parsed;
-  });
+  const { readOnlyAddresses, setReadOnlyAddresses } = useAddresses();
 
   return (
     <Manage
       section={section}
       setSection={setSection}
-      addresses={addresses}
-      setAddresses={setAddressesState}
+      addresses={readOnlyAddresses}
+      setAddresses={setReadOnlyAddresses}
     />
   );
 };

--- a/src/renderer/screens/Import/Vault/index.tsx
+++ b/src/renderer/screens/Import/Vault/index.tsx
@@ -1,12 +1,10 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useState } from 'react';
 import { Manage } from './Manage';
 import { Splash } from './Splash';
+import { useAddresses } from '@/renderer/contexts/import/Addresses';
 import type { AnyFunction } from '@/types/misc';
-import type { LocalAddress } from '@/types/accounts';
-import { Config as ConfigImport } from '@/config/processes/import';
 
 export const ImportVault = ({
   section,
@@ -15,26 +13,20 @@ export const ImportVault = ({
   section: number;
   setSection: AnyFunction;
 }) => {
-  // Get vault addresses from local storage.
-  const [addresses, setAddressesState] = useState<LocalAddress[]>(() => {
-    const key = ConfigImport.getStorageKey('vault');
-    const fetched: string | null = localStorage.getItem(key);
-    const parsed: LocalAddress[] = fetched !== null ? JSON.parse(fetched) : [];
-    return parsed;
-  });
+  const { vaultAddresses, setVaultAddresses } = useAddresses();
 
-  return !addresses.length ? (
+  return !vaultAddresses.length ? (
     <Splash
-      addresses={addresses}
-      setAddresses={setAddressesState}
+      addresses={vaultAddresses}
+      setAddresses={setVaultAddresses}
       setSection={setSection}
     />
   ) : (
     <Manage
       section={section}
       setSection={setSection}
-      addresses={addresses}
-      setAddresses={setAddressesState}
+      addresses={vaultAddresses}
+      setAddresses={setVaultAddresses}
     />
   );
 };

--- a/src/renderer/screens/Settings/Setting.tsx
+++ b/src/renderer/screens/Settings/Setting.tsx
@@ -49,7 +49,6 @@ export const Setting = ({ setting, handleSetting }: SettingProps) => {
             text={setting.buttonText || ''}
             iconTransform="shrink-2"
             onClick={() => handleButtonClick()}
-            disabled={true}
           />
         )}
       </div>

--- a/src/renderer/screens/Settings/Setting.tsx
+++ b/src/renderer/screens/Settings/Setting.tsx
@@ -49,7 +49,6 @@ export const Setting = ({ setting, handleSetting }: SettingProps) => {
             text={setting.buttonText || ''}
             iconTransform="shrink-2"
             onClick={() => handleButtonClick()}
-            disabled={setting.action === 'settings:execute:importData'}
           />
         )}
       </div>

--- a/src/renderer/screens/Settings/Setting.tsx
+++ b/src/renderer/screens/Settings/Setting.tsx
@@ -49,6 +49,7 @@ export const Setting = ({ setting, handleSetting }: SettingProps) => {
             text={setting.buttonText || ''}
             iconTransform="shrink-2"
             onClick={() => handleButtonClick()}
+            disabled={setting.action === 'settings:execute:importData'}
           />
         )}
       </div>

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -80,6 +80,16 @@ export interface StoredAccount {
   _name: string;
 }
 
+/**
+ * Account JSON representation.
+ */
+export interface AccountJson {
+  _address: string;
+  _chain: ChainID;
+  _name: string;
+  _source: AccountSource;
+}
+
 /*
  * Type storing essential data for an account.
  */

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -112,7 +112,7 @@ type ApiOpenBrowserWindow = (url: string) => void;
 /**
  * New types
  */
-type ApiExportAppData = () => Promise<void>;
+type ApiExportAppData = (serialized: string) => Promise<void>;
 type ApiImportAppData = () => Promise<void>;
 
 type ApiToggleWorkspaceVisibility = () => void;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -116,7 +116,11 @@ type ApiExportAppData = (
   serialized: string
 ) => Promise<{ result: boolean; msg: string }>;
 
-type ApiImportAppData = () => Promise<void>;
+type ApiImportAppData = () => Promise<{
+  result: boolean;
+  msg: string;
+  data?: AnyJson;
+}>;
 
 type ApiToggleWorkspaceVisibility = () => void;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -112,7 +112,10 @@ type ApiOpenBrowserWindow = (url: string) => void;
 /**
  * New types
  */
-type ApiExportAppData = (serialized: string) => Promise<void>;
+type ApiExportAppData = (
+  serialized: string
+) => Promise<{ result: boolean; msg: string }>;
+
 type ApiImportAppData = () => Promise<void>;
 
 type ApiToggleWorkspaceVisibility = () => void;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -11,6 +11,9 @@ import type { SubscriptionTask } from './subscriptions';
 import type { PersistedSettings } from '@/renderer/screens/Settings/types';
 
 export interface PreloadAPI {
+  exportAppData: ApiExportAppData;
+  importAppData: ApiImportAppData;
+
   getAppSettings: ApiGetAppSettings;
   getDockedFlag: ApiGetDockedFlag;
   setDockedFlag: ApiSetDockedFlag;
@@ -109,6 +112,8 @@ type ApiOpenBrowserWindow = (url: string) => void;
 /**
  * New types
  */
+type ApiExportAppData = () => Promise<void>;
+type ApiImportAppData = () => Promise<void>;
 
 type ApiToggleWorkspaceVisibility = () => void;
 


### PR DESCRIPTION
# Summary

Initial implementation of the settings window `Import` and `Export` buttons.

When the `Export` button is clicked, the user can save their vault and read-only account data to a text file to a location on their disk. This data file will comprise of stringified JSON that represents the user's vault and read-only addresses they've added in Polkadot Live.

When the `Import` button is clicked, the user can select a text file previously exported from Polkadot Live. The application will read the data file and parse the stringified JSON into account objects. From there, these objects will be used to add the addresses to local storage and the import window's address state.

## Notes

- If an address in an exported data file is already imported in Polkadot Live, it is skipped during the import process. This means only new addresses found in a data file are imported.  
- After importing a data file, addresses not yet imported in Polkadot Live will be added to the import window. The user can then follow the normal process of adding the account to the main window and start subscription tasks.
- Since ledger addresses house different data compared to vault and read-only addresses, exporting and importing ledger addresses is not currently supported, and is a task for a future PR. This PR supports exporting and importing vault and read-only addresses only. 