### PR TITLE
chore: data backup iteration

### DIFF
--- a/src/renderer/contexts/import/Addresses/types.ts
+++ b/src/renderer/contexts/import/Addresses/types.ts
@@ -1,11 +1,7 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type {
-  AccountJson,
-  LedgerLocalAddress,
-  LocalAddress,
-} from '@/types/accounts';
+import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
 
 export interface AddressesContextInterface {
   ledgerAddresses: LedgerLocalAddress[];
@@ -14,5 +10,5 @@ export interface AddressesContextInterface {
   setLedgerAddresses: (a: LedgerLocalAddress[]) => void;
   setReadOnlyAddresses: (a: LocalAddress[]) => void;
   setVaultAddresses: (a: LocalAddress[]) => void;
-  importAccountJson: (a: AccountJson) => void;
+  importAccountJson: (a: LocalAddress) => void;
 }

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -42,7 +42,7 @@ export const Confirm = ({
   const handleLedgerImport = () => {
     // Update import window's managed address state and local storage.
     setAddresses((prevState: LedgerLocalAddress[]) => {
-      const newAddresses = prevState.map((a: LocalAddress) =>
+      const newAddresses = prevState.map((a: LedgerLocalAddress) =>
         a.address === address ? { ...a, isImported: true } : a
       );
 

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -137,6 +137,7 @@ export const Manage = ({
         address: trimmed,
         isImported: false,
         name: ellipsisFn(trimmed),
+        source: 'read-only',
       });
 
     const storageKey = ConfigImport.getStorageKey('read-only');

--- a/src/renderer/screens/Import/Vault/Reader.tsx
+++ b/src/renderer/screens/Import/Vault/Reader.tsx
@@ -85,6 +85,7 @@ export const Reader = ({ addresses, setAddresses }: ReaderVaultProps) => {
         address,
         isImported: false,
         name: ellipsisFn(address),
+        source: 'vault',
       });
 
     const storageKey = ConfigImport.getStorageKey('vault');

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -110,6 +110,7 @@ export interface LocalAddress {
   isImported: boolean;
   index: number;
   name: string;
+  source: AccountSource;
 }
 
 /**


### PR DESCRIPTION
# Summary

Serialises and parses the `LocalAddress` type instead of the `AccountJson` type when exporting and importing addresses. This type change simplifies some logic and integrates more nicely with the import window.