### PR TITLE
feat: open gov ui additions

### DIFF
--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -19,6 +19,7 @@ import type { AnyData } from '@/types/misc';
 import type { EventCallback } from '@/types/reporter';
 import type { QueryMultiWrapper } from '@/model/QueryMultiWrapper';
 import type { AccountBalance, ValidatorData } from '@/types/accounts';
+import { rmCommas } from '@w3ux/utils';
 
 export class Callbacks {
   /**
@@ -128,10 +129,10 @@ export class Callbacks {
 
       // Get the received balance.
       const received: AccountBalance = {
-        free: new BigNumber(data.data.free),
-        reserved: new BigNumber(data.data.reserved),
-        frozen: new BigNumber(data.data.frozen),
-        nonce: new BigNumber(data.nonce),
+        free: new BigNumber(rmCommas(String(data.data.free))),
+        reserved: new BigNumber(rmCommas(String(data.data.reserved))),
+        frozen: new BigNumber(rmCommas(String(data.data.frozen))),
+        nonce: new BigNumber(rmCommas(String(data.nonce))),
       };
 
       let isSame = false;

--- a/src/renderer/contexts/openGov/Treasury/default.ts
+++ b/src/renderer/contexts/openGov/Treasury/default.ts
@@ -5,7 +5,8 @@
 import type { TreasuryContextInterface } from './types';
 
 export const defaultTreasuryContext: TreasuryContextInterface = {
-  initTreasury: () => {},
+  initTreasury: (c) => {},
+  treasuryChainId: 'Polkadot',
   treasuryU8Pk: null,
   fetchingTreasuryData: false,
   getFormattedNextBurn: () => '',

--- a/src/renderer/contexts/openGov/Treasury/index.tsx
+++ b/src/renderer/contexts/openGov/Treasury/index.tsx
@@ -91,7 +91,7 @@ export const TreasuryProvider = ({
   const getFormattedFreeBalance = (): string => {
     const formatted = treasuryFreeBalance
       .dividedBy(1_000_000)
-      .decimalPlaces(1)
+      .decimalPlaces(2)
       .toString()
       .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 

--- a/src/renderer/contexts/openGov/Treasury/types.ts
+++ b/src/renderer/contexts/openGov/Treasury/types.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { AnyData } from '@/types/misc';
+import type { ChainID } from '@/types/chains';
 
 export interface TreasuryContextInterface {
-  initTreasury: () => void;
+  initTreasury: (chainId: ChainID) => void;
+  treasuryChainId: ChainID;
   treasuryU8Pk: Uint8Array | null;
   fetchingTreasuryData: boolean;
   getFormattedNextBurn: () => string;

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -391,8 +391,8 @@ export const useMainMessagePorts = () => {
     ).subarray(0, 32);
 
     // Get free balance.
-    // TODO: Dynamic SS58 prefix.
-    const encoded = encodeAddress(publicKey, 0);
+    const prefix: number = chainId === 'Polkadot' ? 0 : 2; // Kusama prefix 2
+    const encoded = encodeAddress(publicKey, prefix);
     const result: AnyData = (await api.query.system.account(encoded)).toHuman();
     const { free } = result.data;
     const freeBalance: string = planckToUnit(

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -208,7 +208,16 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
       </Scrollable>
       <OpenGovFooter $chainId={chainId}>
         <div>
-          <section className="left"></section>
+          <section className="left">
+            <div className="footer-stat">
+              <h2>Chain ID:</h2>
+              <span>{chainId}</span>
+            </div>
+            <div className="footer-stat">
+              <h2>Active Referenda:</h2>
+              <span>{fetchingReferenda ? '-' : referenda.length}</span>
+            </div>
+          </section>
           <section className="right">
             <ButtonPrimaryInvert
               text={'Back'}

--- a/src/renderer/screens/OpenGov/Tracks/index.tsx
+++ b/src/renderer/screens/OpenGov/Tracks/index.tsx
@@ -3,15 +3,24 @@
 
 import { useHelp } from '@/renderer/contexts/common/Help';
 import { useTracks } from '@/renderer/contexts/openGov/Tracks';
+import { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCaretLeft, faInfo } from '@fortawesome/pro-solid-svg-icons';
+import {
+  faArrowDownShortWide,
+  faCaretLeft,
+  faInfo,
+} from '@fortawesome/pro-solid-svg-icons';
 import { ContentWrapper, HeaderWrapper } from '@app/screens/Wrappers';
 import { DragClose } from '@/renderer/library/DragClose';
 import { OpenGovFooter, Scrollable } from '../Wrappers';
 import { TrackGroup } from './Wrappers';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import { TrackRow } from './TrackRow';
-import { renderPlaceholders } from '@/renderer/utils/common';
+import {
+  ControlsWrapper,
+  SortControlButton,
+  renderPlaceholders,
+} from '@/renderer/utils/common';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
 import type { TracksProps } from '../types';
 
@@ -19,6 +28,9 @@ export const Tracks = ({ setSection, chainId }: TracksProps) => {
   /// Context data.
   const { tracks, fetchingTracks } = useTracks();
   const { openHelp } = useHelp();
+
+  /// Controls state.
+  const [sortIdAscending, setSortIdAscending] = useState(true);
 
   /// Utility to render help icon.
   const renderHelpIcon = (key: HelpItemKey) => (
@@ -37,13 +49,30 @@ export const Tracks = ({ setSection, chainId }: TracksProps) => {
       </HeaderWrapper>
       <Scrollable>
         <ContentWrapper>
+          {/* Sorting controls */}
+          <ControlsWrapper>
+            <SortControlButton
+              isActive={sortIdAscending}
+              isDisabled={fetchingTracks}
+              faIcon={faArrowDownShortWide}
+              onClick={() => setSortIdAscending(!sortIdAscending)}
+              onLabel="ID Ascend"
+              offLabel="ID Descend"
+            />
+          </ControlsWrapper>
           {fetchingTracks ? (
             <>{renderPlaceholders(4)}</>
           ) : (
             <TrackGroup>
-              {tracks.map((track) => (
-                <TrackRow key={track.trackId} track={track} />
-              ))}
+              {tracks
+                .sort((a, b) =>
+                  sortIdAscending
+                    ? a.trackId - b.trackId
+                    : b.trackId - a.trackId
+                )
+                .map((track) => (
+                  <TrackRow key={track.trackId} track={track} />
+                ))}
             </TrackGroup>
           )}
         </ContentWrapper>

--- a/src/renderer/screens/OpenGov/Wrappers.ts
+++ b/src/renderer/screens/OpenGov/Wrappers.ts
@@ -189,10 +189,10 @@ export const OpenGovFooter = styled.section<{ $chainId: ChainID }>`
   }
 `;
 
-export const TreasuryStats = styled.div`
+export const TreasuryStats = styled.div<{ $chainId: ChainID }>`
   width: 100%;
   position: relative;
-  padding: 1.75rem 1.5rem;
+  padding: 1.75rem 1.5rem 1rem;
 
   .loading-wrapper {
     display: flex;
@@ -240,7 +240,10 @@ export const TreasuryStats = styled.div`
         display: flex;
         align-items: center;
         font-size: 1.05rem;
-        color: var(--accent-color-primary);
+        color: ${(props) =>
+          props.$chainId === 'Polkadot'
+            ? 'var(--accent-color-primary)'
+            : '#fbfbfb'};
       }
       // Stat text.
       h4 {

--- a/src/renderer/screens/OpenGov/Wrappers.ts
+++ b/src/renderer/screens/OpenGov/Wrappers.ts
@@ -126,7 +126,7 @@ export const OpenGovFooter = styled.section<{ $chainId: ChainID }>`
   > div:first-of-type {
     display: flex;
     column-gap: 1rem;
-    align-items: baseline;
+    align-items: center;
   }
 
   // Left and right.

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -15,13 +15,17 @@ import { useTracks } from '@/renderer/contexts/openGov/Tracks';
 import { Referenda } from './Referenda';
 import { useReferenda } from '@/renderer/contexts/openGov/Referenda';
 import { useTreasury } from '@/renderer/contexts/openGov/Treasury';
-import { OpenGovCard, TreasuryStats } from './Wrappers';
+import { OpenGovCard, OpenGovFooter, TreasuryStats } from './Wrappers';
 import { faInfo } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import type { ChainID } from '@/types/chains';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
-import { renderPlaceholders } from '@/renderer/utils/common';
+import {
+  ControlsWrapper,
+  SortControlButton,
+  renderPlaceholders,
+} from '@/renderer/utils/common';
 
 export const OpenGov: React.FC = () => {
   /// Set up port communication for `openGov` window.
@@ -30,6 +34,7 @@ export const OpenGov: React.FC = () => {
   /// Treasury context.
   const {
     fetchingTreasuryData,
+    treasuryChainId,
     initTreasury,
     getFormattedFreeBalance,
     getFormattedNextBurn,
@@ -60,11 +65,11 @@ export const OpenGov: React.FC = () => {
       const intervalId = setInterval(() => {
         if (ConfigOpenGov.portExists()) {
           clearInterval(intervalId);
-          initTreasury();
+          initTreasury(treasuryChainId);
         }
       }, 1_000);
     } else {
-      initTreasury();
+      initTreasury(treasuryChainId);
     }
   }, []);
 
@@ -111,6 +116,12 @@ export const OpenGov: React.FC = () => {
     </span>
   );
 
+  /// Handle changing treasury stats.
+  const handleChangeStats = () => {
+    const target = treasuryChainId === 'Polkadot' ? 'Kusama' : 'Polkadot';
+    initTreasury(target);
+  };
+
   return (
     <ModalSection type="carousel">
       <ModalMotionTwoSection
@@ -138,7 +149,7 @@ export const OpenGov: React.FC = () => {
             </div>
           </HeaderWrapper>
 
-          <TreasuryStats>
+          <TreasuryStats $chainId={treasuryChainId}>
             {fetchingTreasuryData ? (
               <div className="loading-wrapper">
                 {renderPlaceholders(0, '68.47px', '0.5rem')}
@@ -219,6 +230,34 @@ export const OpenGov: React.FC = () => {
               </OpenGovCard>
             </div>
           </ContentWrapper>
+
+          <OpenGovFooter $chainId={'Polkadot'}>
+            <div>
+              <section className="left">
+                <div className="footer-stat">
+                  <h2>Treasury Stats:</h2>
+                  <span style={{ marginLeft: '1rem' }}>
+                    <ControlsWrapper style={{ marginBottom: '0' }}>
+                      <SortControlButton
+                        isActive={treasuryChainId === 'Polkadot'}
+                        isDisabled={treasuryChainId === 'Polkadot'}
+                        onClick={() => handleChangeStats()}
+                        onLabel="Polkadot"
+                        offLabel="Polkadot"
+                      />
+                      <SortControlButton
+                        isActive={treasuryChainId === 'Kusama'}
+                        isDisabled={treasuryChainId === 'Kusama'}
+                        onClick={() => handleChangeStats()}
+                        onLabel="Kusama"
+                        offLabel="Kusama"
+                      />
+                    </ControlsWrapper>
+                  </span>
+                </div>
+              </section>
+            </div>
+          </OpenGovFooter>
         </section>
 
         {/* Section 2 */}

--- a/src/renderer/utils/common.tsx
+++ b/src/renderer/utils/common.tsx
@@ -88,10 +88,10 @@ const LoadingPlaceholderWrapper = styled.div<{
 interface SortControlsButtonProps {
   isActive: boolean;
   isDisabled: boolean;
-  faIcon: IconDefinition;
   onLabel: string;
   offLabel: string;
   onClick?: AnyFunction;
+  faIcon?: IconDefinition;
 }
 
 export const SortControlButton: React.FC<SortControlsButtonProps> = ({
@@ -112,17 +112,21 @@ export const SortControlButton: React.FC<SortControlsButtonProps> = ({
 
   /// Click handler that executes if the button is not disabled.
   const handleClick = () => {
-    if (onClick) {
+    if (onClick && !isDisabled) {
       onClick();
     }
   };
 
   return (
     <div className={getButtonClass()} onClick={() => handleClick()}>
-      <div className="icon">
-        <FontAwesomeIcon icon={faIcon} />
-      </div>
-      <span>{isActive ? onLabel : offLabel}</span>
+      {faIcon && (
+        <div className="icon">
+          <FontAwesomeIcon icon={faIcon} />
+        </div>
+      )}
+      <span style={{ width: '100%', textAlign: faIcon ? 'left' : 'center' }}>
+        {isActive ? onLabel : offLabel}
+      </span>
     </div>
   );
 };

--- a/src/utils/AccountUtils.ts
+++ b/src/utils/AccountUtils.ts
@@ -15,6 +15,7 @@ import {
   getAccountExposed,
   getAccountExposedWestend,
 } from '@/renderer/callbacks/nominating';
+import { rmCommas } from '@w3ux/utils';
 import type {
   AccountBalance,
   FlattenedAccountData,
@@ -54,10 +55,10 @@ export const fetchBalanceForAccount = async (account: Account) => {
   const result: AnyJson = await api.query.system.account(account.address);
 
   account.balance = {
-    nonce: new BigNumber(result.nonce),
-    free: new BigNumber(result.data.free),
-    reserved: new BigNumber(result.data.reserved),
-    frozen: new BigNumber(result.data.frozen),
+    nonce: new BigNumber(rmCommas(String(result.nonce))),
+    free: new BigNumber(rmCommas(String(result.data.free))),
+    reserved: new BigNumber(rmCommas(String(result.data.reserved))),
+    frozen: new BigNumber(rmCommas(String(result.data.frozen))),
   } as AccountBalance;
 
   await AccountsController.set(account.chain, account);
@@ -189,7 +190,9 @@ const setNominationPoolDataForAccount = async (account: Account) => {
   // Get pending rewards for the account.
   const pendingRewardsResult: AnyJson =
     await api.call.nominationPoolsApi.pendingRewards(account.address);
-  const poolPendingRewards = new BigNumber(pendingRewardsResult);
+  const poolPendingRewards = new BigNumber(
+    rmCommas(String(pendingRewardsResult))
+  );
 
   // Get nomination pool data.
   const npResult: AnyData = (
@@ -263,7 +266,7 @@ export const getAddressNonce = async (address: string, chainId: ChainID) => {
   const origin = 'getAddressNonce';
   const instance = await ApiUtils.getApiInstanceOrThrow(chainId, origin);
   const result: AnyData = await instance.api.query.system.account(address);
-  return new BigNumber(result.nonce);
+  return new BigNumber(rmCommas(String(result.nonce)));
 };
 
 /**


### PR DESCRIPTION
# Summary

- [x] Total active referenda + chain ID rendered on referenda listing page.
- [x] Control button added to sort origin & track data by track ID ascending or descending.
- [x] Treasury context stores respective chain ID, dynamically rendering stats for the respective network.
- [x] Switch between rendering Polkadot and Kusama treasury stats via button in the open gov window footer.  