### PR TITLE
feat: render open gov subscriptions under manage tab 

### DIFF
--- a/src/config/subscriptions/interval.ts
+++ b/src/config/subscriptions/interval.ts
@@ -6,7 +6,7 @@ import type { IntervalSubscription } from '@/controller/renderer/IntervalsContro
 export const intervalTasks: IntervalSubscription[] = [
   // Polkadot
   {
-    action: 'subscribe:interval:openGov:referendaVotes',
+    action: 'subscribe:interval:openGov:referendumVotes',
     ticksToWait: 1,
     tickCounter: 0,
     category: 'Open Gov',

--- a/src/controller/renderer/IntervalsController.ts
+++ b/src/controller/renderer/IntervalsController.ts
@@ -184,7 +184,7 @@ export class IntervalsController {
     console.log(`Execute: ${action}`);
 
     switch (action) {
-      case 'subscribe:interval:openGov:referendaVotes': {
+      case 'subscribe:interval:openGov:referendumVotes': {
         // TODO: Call one-shot.
         break;
       }

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -11,7 +11,7 @@ import { AddressesProvider } from '@/renderer/contexts/main/Addresses';
 import { BootstrappingProvider } from '@app/contexts/main/Bootstrapping';
 import { ChainsProvider } from '@/renderer/contexts/main/Chains';
 import { EventsProvider } from '@/renderer/contexts/main/Events';
-import { ManageProvider } from './screens/Home/Manage/provider';
+import { ManageProvider } from '@/renderer/contexts/main/Manage';
 import { SubscriptionsProvider } from '@app/contexts/main/Subscriptions';
 import { IntervalSubscriptionsProvider } from './contexts/main/IntervalSubscriptions';
 

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -13,6 +13,7 @@ import { ChainsProvider } from '@/renderer/contexts/main/Chains';
 import { EventsProvider } from '@/renderer/contexts/main/Events';
 import { ManageProvider } from './screens/Home/Manage/provider';
 import { SubscriptionsProvider } from '@app/contexts/main/Subscriptions';
+import { IntervalSubscriptionsProvider } from './contexts/main/IntervalSubscriptions';
 
 // Import window contexts.
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
@@ -47,6 +48,7 @@ const getProvidersForWindow = () => {
         AddressesProvider,
         ChainsProvider,
         SubscriptionsProvider,
+        IntervalSubscriptionsProvider,
         ManageProvider,
         EventsProvider,
         // Online status relies on other contexts being initialized.

--- a/src/renderer/contexts/main/IntervalSubscriptions/defaults.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/defaults.ts
@@ -1,0 +1,11 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { IntervalSubscriptionsContextInterface } from './types';
+
+export const defaultIntervalSubscriptionsContext: IntervalSubscriptionsContextInterface =
+  {
+    subscriptions: new Map(),
+    setSubscriptions: () => {},
+  };

--- a/src/renderer/contexts/main/IntervalSubscriptions/defaults.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/defaults.ts
@@ -8,4 +8,6 @@ export const defaultIntervalSubscriptionsContext: IntervalSubscriptionsContextIn
   {
     subscriptions: new Map(),
     setSubscriptions: () => {},
+    addIntervalSubscription: () => {},
+    removeIntervalSubscription: () => {},
   };

--- a/src/renderer/contexts/main/IntervalSubscriptions/defaults.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/defaults.ts
@@ -10,4 +10,5 @@ export const defaultIntervalSubscriptionsContext: IntervalSubscriptionsContextIn
     setSubscriptions: () => {},
     addIntervalSubscription: () => {},
     removeIntervalSubscription: () => {},
+    getIntervalSubscriptionsForChain: () => [],
   };

--- a/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
+++ b/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
@@ -25,9 +25,46 @@ export const IntervalSubscriptionsProvider = ({
     Map<ChainID, IntervalSubscription[]>
   >(new Map());
 
+  /// Add an interval subscription to the context state.
+  const addIntervalSubscription = (task: IntervalSubscription) => {
+    setSubscriptions((prev) => {
+      const { chainId } = task;
+      const cloned = new Map(prev);
+
+      cloned.has(chainId)
+        ? cloned.set(chainId, [...cloned.get(chainId)!, { ...task }])
+        : cloned.set(chainId, [{ ...task }]);
+
+      return cloned;
+    });
+  };
+
+  /// Remove an interval subscription from the context state.
+  const removeIntervalSubscription = (task: IntervalSubscription) => {
+    setSubscriptions((prev) => {
+      // NOTE: Relies on referendum ID to filter task for now.
+      const { chainId, action, referendumId } = task;
+      const cloned = new Map(prev);
+
+      const updated = cloned
+        .get(chainId)!
+        .filter(
+          (t) => !(t.action === action && t.referendumId === referendumId)
+        );
+
+      updated.length ? cloned.set(chainId, updated) : cloned.delete(chainId);
+      return cloned;
+    });
+  };
+
   return (
     <IntervalSubscriptionsContext.Provider
-      value={{ subscriptions, setSubscriptions }}
+      value={{
+        subscriptions,
+        setSubscriptions,
+        addIntervalSubscription,
+        removeIntervalSubscription,
+      }}
     >
       {children}
     </IntervalSubscriptionsContext.Provider>

--- a/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
+++ b/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
@@ -1,0 +1,35 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { createContext, useContext, useState } from 'react';
+import type { ChainID } from '@/types/chains';
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscriptionsContextInterface } from './types';
+
+export const IntervalSubscriptionsContext =
+  createContext<IntervalSubscriptionsContextInterface>(
+    defaults.defaultIntervalSubscriptionsContext
+  );
+
+export const useIntervalSubscriptions = () =>
+  useContext(IntervalSubscriptionsContext);
+
+export const IntervalSubscriptionsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  /// Active interval subscriptions.
+  const [subscriptions, setSubscriptions] = useState<
+    Map<ChainID, IntervalSubscription[]>
+  >(new Map());
+
+  return (
+    <IntervalSubscriptionsContext.Provider
+      value={{ subscriptions, setSubscriptions }}
+    >
+      {children}
+    </IntervalSubscriptionsContext.Provider>
+  );
+};

--- a/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
+++ b/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
@@ -57,6 +57,17 @@ export const IntervalSubscriptionsProvider = ({
     });
   };
 
+  /// Get interval subscriptions for a specific chain.
+  const getIntervalSubscriptionsForChain = (chainId: ChainID) => {
+    const tasks = subscriptions.get(chainId);
+
+    if (!tasks) {
+      throw new Error(`No interval subscription state for ${chainId}`);
+    }
+
+    return tasks;
+  };
+
   return (
     <IntervalSubscriptionsContext.Provider
       value={{
@@ -64,6 +75,7 @@ export const IntervalSubscriptionsProvider = ({
         setSubscriptions,
         addIntervalSubscription,
         removeIntervalSubscription,
+        getIntervalSubscriptionsForChain,
       }}
     >
       {children}

--- a/src/renderer/contexts/main/IntervalSubscriptions/types.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/types.ts
@@ -1,0 +1,12 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { ChainID } from '@/types/chains';
+
+export interface IntervalSubscriptionsContextInterface {
+  subscriptions: Map<ChainID, IntervalSubscription[]>;
+  setSubscriptions: (
+    subscriptions: Map<ChainID, IntervalSubscription[]>
+  ) => void;
+}

--- a/src/renderer/contexts/main/IntervalSubscriptions/types.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/types.ts
@@ -9,4 +9,6 @@ export interface IntervalSubscriptionsContextInterface {
   setSubscriptions: (
     subscriptions: Map<ChainID, IntervalSubscription[]>
   ) => void;
+  addIntervalSubscription: (task: IntervalSubscription) => void;
+  removeIntervalSubscription: (task: IntervalSubscription) => void;
 }

--- a/src/renderer/contexts/main/IntervalSubscriptions/types.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/types.ts
@@ -11,4 +11,7 @@ export interface IntervalSubscriptionsContextInterface {
   ) => void;
   addIntervalSubscription: (task: IntervalSubscription) => void;
   removeIntervalSubscription: (task: IntervalSubscription) => void;
+  getIntervalSubscriptionsForChain: (
+    chainId: ChainID
+  ) => IntervalSubscription[];
 }

--- a/src/renderer/contexts/main/Manage/defaults.ts
+++ b/src/renderer/contexts/main/Manage/defaults.ts
@@ -16,4 +16,5 @@ export const defaultManageContext: ManageContextInterface = {
   setActiveChainId: () => {},
   tryAddIntervalSubscription: (t) => {},
   tryRemoveIntervalSubscription: (t) => {},
+  getCategorizedDynamicIntervals: () => new Map(),
 };

--- a/src/renderer/contexts/main/Manage/defaults.ts
+++ b/src/renderer/contexts/main/Manage/defaults.ts
@@ -1,0 +1,15 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { ManageContextInterface } from './types';
+
+// Default context value.
+export const defaultManageContext: ManageContextInterface = {
+  renderedSubscriptions: { type: '', tasks: [] },
+  intervalTasksState: [],
+  setIntervalTasks: () => {},
+  setRenderedSubscriptions: () => {},
+  updateRenderedSubscriptions: () => {},
+  updateIntervalTask: () => {},
+};

--- a/src/renderer/contexts/main/Manage/defaults.ts
+++ b/src/renderer/contexts/main/Manage/defaults.ts
@@ -8,8 +8,12 @@ import type { ManageContextInterface } from './types';
 export const defaultManageContext: ManageContextInterface = {
   renderedSubscriptions: { type: '', tasks: [] },
   intervalTasksState: [],
+  activeChainId: 'Polkadot',
   setIntervalTasks: () => {},
   setRenderedSubscriptions: () => {},
   updateRenderedSubscriptions: () => {},
   updateIntervalTask: () => {},
+  setActiveChainId: () => {},
+  tryAddIntervalSubscription: (t) => {},
+  tryRemoveIntervalSubscription: (t) => {},
 };

--- a/src/renderer/contexts/main/Manage/defaults.ts
+++ b/src/renderer/contexts/main/Manage/defaults.ts
@@ -7,12 +7,12 @@ import type { ManageContextInterface } from './types';
 // Default context value.
 export const defaultManageContext: ManageContextInterface = {
   renderedSubscriptions: { type: '', tasks: [] },
-  intervalTasksState: [],
+  dynamicIntervalTasksState: [],
   activeChainId: 'Polkadot',
-  setIntervalTasks: () => {},
+  setDynamicIntervalTasks: () => {},
   setRenderedSubscriptions: () => {},
   updateRenderedSubscriptions: () => {},
-  updateIntervalTask: () => {},
+  updateDynamicIntervalTask: () => {},
   setActiveChainId: () => {},
   tryAddIntervalSubscription: (t) => {},
   tryRemoveIntervalSubscription: (t) => {},

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -1,48 +1,23 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import * as defaults from './defaults';
 import { useState, createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
 import type {
   SubscriptionTask,
   WrappedSubscriptionTasks,
 } from '@/types/subscriptions';
+import type { ManageContextInterface } from './types';
 import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
-
-// Context interface.
-interface ManageContextInterface {
-  renderedSubscriptions: WrappedSubscriptionTasks;
-  intervalTasksState: IntervalSubscription[];
-  setIntervalTasks: (tasks: IntervalSubscription[]) => void;
-  setRenderedSubscriptions: (a: WrappedSubscriptionTasks) => void;
-  updateRenderedSubscriptions: (a: SubscriptionTask) => void;
-  updateIntervalTask: (task: IntervalSubscription) => void;
-}
-
-// Default context value.
-const defaultManageContext: ManageContextInterface = {
-  renderedSubscriptions: { type: '', tasks: [] },
-  intervalTasksState: [],
-  setIntervalTasks: () => {
-    // do nothing
-  },
-  setRenderedSubscriptions: () => {
-    // do nothing
-  },
-  updateRenderedSubscriptions: () => {
-    // do nothing
-  },
-  updateIntervalTask: () => {
-    // do nothing
-  },
-};
 
 // Hook to manage context.
 export const useManage = () => useContext(ManageContext);
 
 // Manage context.
-export const ManageContext =
-  createContext<ManageContextInterface>(defaultManageContext);
+export const ManageContext = createContext<ManageContextInterface>(
+  defaults.defaultManageContext
+);
 
 // Manage context provider.
 export const ManageProvider = ({ children }: { children: ReactNode }) => {

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -26,7 +26,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
   const [renderedSubscriptionsState, setRenderedSubscriptionsState] =
     useState<WrappedSubscriptionTasks>({ type: '', tasks: [] });
 
-  const [intervalTasksState, setIntervalTasksState] = useState<
+  const [dynamicIntervalTasksState, setDynamicIntervalTasksState] = useState<
     IntervalSubscription[]
   >([]);
 
@@ -46,13 +46,13 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
   };
 
   /// Set intervaled subscriptions with new tasks array.
-  const setIntervalTasks = (tasks: IntervalSubscription[]) => {
-    setIntervalTasksState([...tasks]);
+  const setDynamicIntervalTasks = (tasks: IntervalSubscription[]) => {
+    setDynamicIntervalTasksState([...tasks]);
   };
 
   /// Update a task in the interval subscriptions state.
-  const updateIntervalTask = (task: IntervalSubscription) => {
-    setIntervalTasksState((prev) =>
+  const updateDynamicIntervalTask = (task: IntervalSubscription) => {
+    setDynamicIntervalTasksState((prev) =>
       prev.map((t) =>
         t.action === task.action && t.referendumId === task.referendumId
           ? task
@@ -64,7 +64,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
   /// Add an interval task to state if it should be rendered.
   const tryAddIntervalSubscription = (task: IntervalSubscription) => {
     if (activeChainId === task.chainId) {
-      setIntervalTasksState((prev) => [...prev, { ...task }]);
+      setDynamicIntervalTasksState((prev) => [...prev, { ...task }]);
     }
   };
 
@@ -73,7 +73,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     action: string,
     referendumId: number
   ) => {
-    setIntervalTasksState((prev) =>
+    setDynamicIntervalTasksState((prev) =>
       prev.filter(
         (t) => !(t.action === action && t.referendumId === referendumId)
       )
@@ -84,11 +84,11 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     <ManageContext.Provider
       value={{
         renderedSubscriptions: renderedSubscriptionsState,
-        intervalTasksState,
-        setIntervalTasks,
+        dynamicIntervalTasksState,
+        setDynamicIntervalTasks,
         setRenderedSubscriptions,
         updateRenderedSubscriptions,
-        updateIntervalTask,
+        updateDynamicIntervalTask,
         tryAddIntervalSubscription,
         tryRemoveIntervalSubscription,
         activeChainId,

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -80,6 +80,46 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
+  /// Get dynamic interval subscriptions categorized by referendum ID.
+  const getCategorizedDynamicIntervals = (): Map<
+    number,
+    IntervalSubscription[]
+  > => {
+    const map = new Map<number, IntervalSubscription[]>();
+
+    // Construct an array of sorted referendum IDs.
+    const referendumIds = new Set(
+      dynamicIntervalTasksState
+        .map(({ referendumId }) => referendumId || -1)
+        .sort()
+        .reverse()
+    );
+
+    // Insert IDs as map keys in order.
+    for (const rid of referendumIds) {
+      map.set(rid, []);
+    }
+
+    // Insert subscriptions into map.
+    for (const task of dynamicIntervalTasksState) {
+      if (!task.referendumId) {
+        continue;
+      }
+
+      const { referendumId: rid } = task;
+      map.has(rid)
+        ? map.set(rid, [...map.get(rid)!, { ...task }])
+        : map.set(rid, [{ ...task }]);
+    }
+
+    // Remove any empty keys in the map.
+    for (const [rid, tasks] of map.entries()) {
+      tasks.length === 0 && map.delete(rid);
+    }
+
+    return map;
+  };
+
   return (
     <ManageContext.Provider
       value={{
@@ -93,6 +133,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
         tryRemoveIntervalSubscription,
         activeChainId,
         setActiveChainId,
+        getCategorizedDynamicIntervals,
       }}
     >
       {children}

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -8,8 +8,9 @@ import type {
   SubscriptionTask,
   WrappedSubscriptionTasks,
 } from '@/types/subscriptions';
-import type { ManageContextInterface } from './types';
+import type { ChainID } from '@/types/chains';
 import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { ManageContextInterface } from './types';
 
 // Hook to manage context.
 export const useManage = () => useContext(ManageContext);
@@ -28,6 +29,8 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
   const [intervalTasksState, setIntervalTasksState] = useState<
     IntervalSubscription[]
   >([]);
+
+  const [activeChainId, setActiveChainId] = useState<ChainID>('Polkadot');
 
   /// Set rendered subscriptions.
   const setRenderedSubscriptions = (wrapped: WrappedSubscriptionTasks) => {
@@ -58,6 +61,25 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     );
   };
 
+  /// Add an interval task to state if it should be rendered.
+  const tryAddIntervalSubscription = (task: IntervalSubscription) => {
+    if (activeChainId === task.chainId) {
+      setIntervalTasksState((prev) => [...prev, { ...task }]);
+    }
+  };
+
+  /// Remove an interval task from state if it should be removed.
+  const tryRemoveIntervalSubscription = (
+    action: string,
+    referendumId: number
+  ) => {
+    setIntervalTasksState((prev) =>
+      prev.filter(
+        (t) => !(t.action === action && t.referendumId === referendumId)
+      )
+    );
+  };
+
   return (
     <ManageContext.Provider
       value={{
@@ -67,6 +89,10 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
         setRenderedSubscriptions,
         updateRenderedSubscriptions,
         updateIntervalTask,
+        tryAddIntervalSubscription,
+        tryRemoveIntervalSubscription,
+        activeChainId,
+        setActiveChainId,
       }}
     >
       {children}

--- a/src/renderer/contexts/main/Manage/types.ts
+++ b/src/renderer/contexts/main/Manage/types.ts
@@ -20,4 +20,5 @@ export interface ManageContextInterface {
   tryRemoveIntervalSubscription: (action: string, referendumId: number) => void;
   activeChainId: ChainID;
   setActiveChainId: (cid: ChainID) => void;
+  getCategorizedDynamicIntervals: () => Map<number, IntervalSubscription[]>;
 }

--- a/src/renderer/contexts/main/Manage/types.ts
+++ b/src/renderer/contexts/main/Manage/types.ts
@@ -11,11 +11,11 @@ import type {
 // Context interface.
 export interface ManageContextInterface {
   renderedSubscriptions: WrappedSubscriptionTasks;
-  intervalTasksState: IntervalSubscription[];
-  setIntervalTasks: (tasks: IntervalSubscription[]) => void;
+  dynamicIntervalTasksState: IntervalSubscription[];
+  setDynamicIntervalTasks: (tasks: IntervalSubscription[]) => void;
   setRenderedSubscriptions: (a: WrappedSubscriptionTasks) => void;
   updateRenderedSubscriptions: (a: SubscriptionTask) => void;
-  updateIntervalTask: (task: IntervalSubscription) => void;
+  updateDynamicIntervalTask: (task: IntervalSubscription) => void;
   tryAddIntervalSubscription: (task: IntervalSubscription) => void;
   tryRemoveIntervalSubscription: (action: string, referendumId: number) => void;
   activeChainId: ChainID;

--- a/src/renderer/contexts/main/Manage/types.ts
+++ b/src/renderer/contexts/main/Manage/types.ts
@@ -1,6 +1,7 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { ChainID } from '@/types/chains';
 import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type {
   SubscriptionTask,
@@ -15,4 +16,8 @@ export interface ManageContextInterface {
   setRenderedSubscriptions: (a: WrappedSubscriptionTasks) => void;
   updateRenderedSubscriptions: (a: SubscriptionTask) => void;
   updateIntervalTask: (task: IntervalSubscription) => void;
+  tryAddIntervalSubscription: (task: IntervalSubscription) => void;
+  tryRemoveIntervalSubscription: (action: string, referendumId: number) => void;
+  activeChainId: ChainID;
+  setActiveChainId: (cid: ChainID) => void;
 }

--- a/src/renderer/contexts/main/Manage/types.ts
+++ b/src/renderer/contexts/main/Manage/types.ts
@@ -1,0 +1,18 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type {
+  SubscriptionTask,
+  WrappedSubscriptionTasks,
+} from '@/types/subscriptions';
+
+// Context interface.
+export interface ManageContextInterface {
+  renderedSubscriptions: WrappedSubscriptionTasks;
+  intervalTasksState: IntervalSubscription[];
+  setIntervalTasks: (tasks: IntervalSubscription[]) => void;
+  setRenderedSubscriptions: (a: WrappedSubscriptionTasks) => void;
+  updateRenderedSubscriptions: (a: SubscriptionTask) => void;
+  updateIntervalTask: (task: IntervalSubscription) => void;
+}

--- a/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
+++ b/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
@@ -61,17 +61,10 @@ export const ReferendaSubscriptionsProvider = ({
   };
 
   /// Remove a task from the context.
-  const removeReferendaSubscription = (
-    task: IntervalSubscription,
-    referendumId: number
-  ) => {
-    console.log(
-      `Remove task ${task.action} for referendum with ID ${referendumId}`
-    );
-
+  const removeReferendaSubscription = (task: IntervalSubscription) => {
     // Update subscriptions map.
     setSubscriptions((prev) => {
-      const { chainId, action, referendumId: refId } = { ...task };
+      const { chainId, action, referendumId } = task;
       const cloned = new Map(prev);
 
       if (cloned.has(chainId)) {
@@ -84,7 +77,8 @@ export const ReferendaSubscriptionsProvider = ({
               cloned
                 .get(chainId)!
                 .filter(
-                  (t) => !(t.action === action && t.referendumId === refId)
+                  (t) =>
+                    !(t.action === action && t.referendumId === referendumId)
                 )
             );
       }
@@ -94,11 +88,10 @@ export const ReferendaSubscriptionsProvider = ({
 
     // Update active tasks map.
     setActiveTasksMap((prev) => {
-      const { action } = { ...task };
-      const key = referendumId;
+      const { action, referendumId: key } = task;
       const cloned = new Map(prev);
 
-      if (cloned.has(key)) {
+      if (key && cloned.has(key)) {
         const cached = cloned.get(key)!;
 
         cached.length === 1

--- a/src/renderer/contexts/openGov/ReferendaSubscriptions/types.ts
+++ b/src/renderer/contexts/openGov/ReferendaSubscriptions/types.ts
@@ -13,10 +13,7 @@ export interface ReferendaSubscriptionsContextInterface {
   activeTasksMap: Map<number, string[]>;
   setActiveTasksMap: (activeTasks: Map<number, string[]>) => void;
   addReferendaSubscription: (task: IntervalSubscription) => void;
-  removeReferendaSubscription: (
-    task: IntervalSubscription,
-    referendumId: number
-  ) => void;
+  removeReferendaSubscription: (task: IntervalSubscription) => void;
   isSubscribedToTask: (
     referendum: ActiveReferendaInfo,
     task: IntervalSubscription

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -28,6 +28,7 @@ import { useEffect } from 'react';
 import { useEvents } from '@app/contexts/main/Events';
 import { useManage } from '@app/screens/Home/Manage/provider';
 import { useSubscriptions } from '@app/contexts/main/Subscriptions';
+import { useIntervalSubscriptions } from '../contexts/main/IntervalSubscriptions';
 
 /// Type imports.
 import type { AccountSource, LocalAddress } from '@/types/accounts';
@@ -45,6 +46,8 @@ export const useMainMessagePorts = () => {
   const { setRenderedSubscriptions } = useManage();
   const { setAccountSubscriptions, updateAccountNameInTasks } =
     useSubscriptions();
+  const { addIntervalSubscription, removeIntervalSubscription } =
+    useIntervalSubscriptions();
 
   /**
    * @name handleImportAddress
@@ -463,9 +466,14 @@ export const useMainMessagePorts = () => {
   const handleAddInterval = (ev: MessageEvent) => {
     const { task: serialized } = ev.data.data;
     const task: IntervalSubscription = JSON.parse(serialized);
+
+    // Add task to interval controller.
     IntervalsController.stopInterval();
-    IntervalsController.insertSubscription(task);
+    IntervalsController.insertSubscription({ ...task });
     IntervalsController.initClock();
+
+    // Add task to React state for rendering.
+    addIntervalSubscription({ ...task });
   };
 
   /**
@@ -475,9 +483,14 @@ export const useMainMessagePorts = () => {
   const handleRemoveInterval = (ev: MessageEvent) => {
     const { task: serialized } = ev.data.data;
     const task: IntervalSubscription = JSON.parse(serialized);
+
+    // Remove task from interval controller.
     IntervalsController.stopInterval();
-    IntervalsController.removeSubscription(task);
+    IntervalsController.removeSubscription({ ...task });
     IntervalsController.initClock();
+
+    // Remove task from React state for rendering.
+    removeIntervalSubscription({ ...task });
   };
 
   /**

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -41,7 +41,12 @@ export const useMainMessagePorts = () => {
   const { importAddress, removeAddress, setAddresses } = useAddresses();
   const { addChain } = useChains();
   const { updateEventsOnAccountRename } = useEvents();
-  const { setRenderedSubscriptions } = useManage();
+
+  const {
+    setRenderedSubscriptions,
+    tryAddIntervalSubscription,
+    tryRemoveIntervalSubscription,
+  } = useManage();
 
   const { handleDockedToggle, handleToggleSilenceOsNotifications } =
     useBootstrapping();
@@ -475,6 +480,9 @@ export const useMainMessagePorts = () => {
     IntervalsController.insertSubscription({ ...task });
     IntervalsController.initClock();
 
+    // Add task to dynamic manage state if necessary.
+    tryAddIntervalSubscription({ ...task });
+
     // Add task to React state for rendering.
     addIntervalSubscription({ ...task });
   };
@@ -491,6 +499,9 @@ export const useMainMessagePorts = () => {
     IntervalsController.stopInterval();
     IntervalsController.removeSubscription({ ...task });
     IntervalsController.initClock();
+
+    // Remove task from dynamic manage state if necessary.
+    tryRemoveIntervalSubscription(task.action, task.referendumId!);
 
     // Remove task from React state for rendering.
     removeIntervalSubscription({ ...task });

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -26,7 +26,7 @@ import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { useChains } from '@app/contexts/main/Chains';
 import { useEffect } from 'react';
 import { useEvents } from '@app/contexts/main/Events';
-import { useManage } from '@app/screens/Home/Manage/provider';
+import { useManage } from '@app/contexts/main/Manage';
 import { useSubscriptions } from '@app/contexts/main/Subscriptions';
 import { useIntervalSubscriptions } from '../contexts/main/IntervalSubscriptions';
 
@@ -39,13 +39,16 @@ import type { IntervalSubscription } from '@/controller/renderer/IntervalsContro
 export const useMainMessagePorts = () => {
   /// Main renderer contexts.
   const { importAddress, removeAddress, setAddresses } = useAddresses();
-  const { handleDockedToggle, handleToggleSilenceOsNotifications } =
-    useBootstrapping();
   const { addChain } = useChains();
   const { updateEventsOnAccountRename } = useEvents();
   const { setRenderedSubscriptions } = useManage();
+
+  const { handleDockedToggle, handleToggleSilenceOsNotifications } =
+    useBootstrapping();
+
   const { setAccountSubscriptions, updateAccountNameInTasks } =
     useSubscriptions();
+
   const { addIntervalSubscription, removeIntervalSubscription } =
     useIntervalSubscriptions();
 

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -17,10 +17,11 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getIcon } from '@/renderer/Utils';
 import { Identicon } from '@app/library/Identicon';
-import { NoAccounts } from '../NoAccounts';
+import { NoAccounts, NoOpenGov } from '../NoAccounts';
 import { useManage } from './provider';
 import { useSubscriptions } from '@/renderer/contexts/main/Subscriptions';
 import { useState } from 'react';
+import { useIntervalSubscriptions } from '@/renderer/contexts/main/IntervalSubscriptions';
 import type { AccountsProps } from './types';
 import type { ChainID } from '@/types/chains';
 import type { FlattenedAccountData } from '@/types/accounts';
@@ -38,6 +39,7 @@ export const Accounts = ({
   const { getChainSubscriptions, getAccountSubscriptions, chainSubscriptions } =
     useSubscriptions();
   const { setRenderedSubscriptions } = useManage();
+  const { subscriptions: intervalSubscriptions } = useIntervalSubscriptions();
 
   /// Categorise addresses by their chain ID, sort by name.
   const getSortedAddresses = () => {
@@ -85,7 +87,7 @@ export const Accounts = ({
     number[]
   >(
     Array.from(
-      { length: Array.from(getSortedAddresses().keys()).length + 1 },
+      { length: Array.from(getSortedAddresses().keys()).length + 2 },
       (_, index) => index
     )
   );
@@ -212,6 +214,74 @@ export const Accounts = ({
             )
           )}
 
+          {/* Manage OpenGov Subscriptions*/}
+          <AccordionItem key={'openGov_accounts'}>
+            <HeadingWrapper>
+              <AccordionHeader>
+                <div className="flex">
+                  <div className="left">
+                    <div className="icon-wrapper">
+                      {accordionActiveIndices.includes(
+                        Array.from(getSortedAddresses().keys()).length + 1
+                      ) ? (
+                        <FontAwesomeIcon
+                          icon={faCaretDown}
+                          transform={'shrink-1'}
+                        />
+                      ) : (
+                        <FontAwesomeIcon
+                          icon={faCaretRight}
+                          transform={'shrink-1'}
+                        />
+                      )}
+                    </div>
+                    <h5>OpenGov</h5>
+                  </div>
+                </div>
+              </AccordionHeader>
+            </HeadingWrapper>
+            <AccordionPanel>
+              <div style={{ padding: '0 0.75rem' }}>
+                <div className="flex-column">
+                  {intervalSubscriptions.size === 0 ? (
+                    <NoOpenGov />
+                  ) : (
+                    <>
+                      {Array.from(intervalSubscriptions.keys()).map(
+                        (chain, i) => (
+                          <AccountWrapper
+                            whileHover={{ scale: 1.01 }}
+                            key={`manage_chain_${i}`}
+                          >
+                            <button
+                              type="button"
+                              onClick={() => console.log('TODO')}
+                            ></button>
+                            <div className="inner">
+                              <div>
+                                <span>{getIcon(chain, 'chain-icon')}</span>
+                                <div className="content">
+                                  <h3>{chain}</h3>
+                                </div>
+                              </div>
+                              <div>
+                                <ButtonText
+                                  text=""
+                                  iconRight={faChevronRight}
+                                  iconTransform="shrink-3"
+                                />
+                              </div>
+                            </div>
+                          </AccountWrapper>
+                        )
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            </AccordionPanel>
+          </AccordionItem>
+
           {/* Manage Chains */}
           <AccordionItem key={'chain_accounts'}>
             <HeadingWrapper>
@@ -219,7 +289,9 @@ export const Accounts = ({
                 <div className="flex">
                   <div className="left">
                     <div className="icon-wrapper">
-                      {accordionActiveIndices.includes(3) ? (
+                      {accordionActiveIndices.includes(
+                        Array.from(getSortedAddresses().keys()).length + 2
+                      ) ? (
                         <FontAwesomeIcon
                           icon={faCaretDown}
                           transform={'shrink-1'}

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -38,8 +38,11 @@ export const Accounts = ({
 }: AccountsProps) => {
   const { getChainSubscriptions, getAccountSubscriptions, chainSubscriptions } =
     useSubscriptions();
-  const { setRenderedSubscriptions } = useManage();
-  const { subscriptions: intervalSubscriptions } = useIntervalSubscriptions();
+  const { setRenderedSubscriptions, setIntervalTasks } = useManage();
+  const {
+    subscriptions: intervalSubscriptions,
+    getIntervalSubscriptionsForChain,
+  } = useIntervalSubscriptions();
 
   /// Categorise addresses by their chain ID, sort by name.
   const getSortedAddresses = () => {
@@ -126,6 +129,16 @@ export const Accounts = ({
     } as WrappedSubscriptionTasks);
 
     setBreadcrumb(accountName);
+    setSection(1);
+  };
+
+  /// Set interval subscription tasks state when chain is clicked.
+  const handleClickOpenGovChain = (chainId: ChainID) => {
+    const tasks = getIntervalSubscriptionsForChain(chainId);
+
+    setTypeClicked('interval');
+    setIntervalTasks(tasks);
+    setBreadcrumb(`${chainId} OpenGov`);
     setSection(1);
   };
 
@@ -248,20 +261,20 @@ export const Accounts = ({
                   ) : (
                     <>
                       {Array.from(intervalSubscriptions.keys()).map(
-                        (chain, i) => (
+                        (chainId, i) => (
                           <AccountWrapper
                             whileHover={{ scale: 1.01 }}
                             key={`manage_chain_${i}`}
                           >
                             <button
                               type="button"
-                              onClick={() => console.log('TODO')}
+                              onClick={() => handleClickOpenGovChain(chainId)}
                             ></button>
                             <div className="inner">
                               <div>
-                                <span>{getIcon(chain, 'chain-icon')}</span>
+                                <span>{getIcon(chainId, 'chain-icon')}</span>
                                 <div className="content">
-                                  <h3>{chain}</h3>
+                                  <h3>{chainId}</h3>
                                 </div>
                               </div>
                               <div>

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -38,7 +38,8 @@ export const Accounts = ({
 }: AccountsProps) => {
   const { getChainSubscriptions, getAccountSubscriptions, chainSubscriptions } =
     useSubscriptions();
-  const { setRenderedSubscriptions, setIntervalTasks } = useManage();
+  const { setRenderedSubscriptions, setIntervalTasks, setActiveChainId } =
+    useManage();
   const {
     subscriptions: intervalSubscriptions,
     getIntervalSubscriptionsForChain,
@@ -138,6 +139,7 @@ export const Accounts = ({
 
     setTypeClicked('interval');
     setIntervalTasks(tasks);
+    setActiveChainId(chainId);
     setBreadcrumb(`${chainId} OpenGov`);
     setSection(1);
   };

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -18,7 +18,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { getIcon } from '@/renderer/Utils';
 import { Identicon } from '@app/library/Identicon';
 import { NoAccounts, NoOpenGov } from '../NoAccounts';
-import { useManage } from './provider';
+import { useManage } from '@/renderer/contexts/main/Manage';
 import { useSubscriptions } from '@/renderer/contexts/main/Subscriptions';
 import { useState } from 'react';
 import { useIntervalSubscriptions } from '@/renderer/contexts/main/IntervalSubscriptions';

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -38,8 +38,11 @@ export const Accounts = ({
 }: AccountsProps) => {
   const { getChainSubscriptions, getAccountSubscriptions, chainSubscriptions } =
     useSubscriptions();
-  const { setRenderedSubscriptions, setIntervalTasks, setActiveChainId } =
-    useManage();
+  const {
+    setRenderedSubscriptions,
+    setDynamicIntervalTasks,
+    setActiveChainId,
+  } = useManage();
   const {
     subscriptions: intervalSubscriptions,
     getIntervalSubscriptionsForChain,
@@ -138,7 +141,7 @@ export const Accounts = ({
     const tasks = getIntervalSubscriptionsForChain(chainId);
 
     setTypeClicked('interval');
-    setIntervalTasks(tasks);
+    setDynamicIntervalTasks(tasks);
     setActiveChainId(chainId);
     setBreadcrumb(`${chainId} OpenGov`);
     setSection(1);

--- a/src/renderer/screens/Home/Manage/IntervalRow.tsx
+++ b/src/renderer/screens/Home/Manage/IntervalRow.tsx
@@ -1,0 +1,130 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useHelp } from '@/renderer/contexts/common/Help';
+import { useTooltip } from '@/renderer/contexts/common/Tooltip';
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import { AccountWrapper } from './Wrappers';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faInfo } from '@fortawesome/pro-solid-svg-icons';
+import { useState } from 'react';
+import {
+  faArrowDownFromDottedLine,
+  faListRadio,
+} from '@fortawesome/pro-light-svg-icons';
+import { Switch } from '@app/library/Switch';
+
+interface IntervalRowProps {
+  task: IntervalSubscription;
+}
+
+export const IntervalRow = ({ task }: IntervalRowProps) => {
+  const { openHelp } = useHelp();
+  const { setTooltipTextAndOpen } = useTooltip();
+
+  const [isToggled, setIsToggled] = useState<boolean>(task.status === 'enable');
+  const [oneShotProcessing, setOneShotProcessing] = useState(false);
+  const [nativeChecked, setNativeChecked] = useState(
+    task.enableOsNotifications
+  );
+
+  const { action } = task;
+  console.log(`task action: ${action}`);
+  console.log(openHelp);
+  console.log(setTooltipTextAndOpen);
+
+  return (
+    <AccountWrapper whileHover={{ scale: 1.01 }}>
+      <div className="inner">
+        <div>
+          <div className="content">
+            <h3>
+              <div
+                className="icon-wrapper"
+                onClick={() => openHelp(task.helpKey)}
+              >
+                <FontAwesomeIcon
+                  className="info-icon"
+                  icon={faInfo}
+                  transform={'shrink-1'}
+                />
+              </div>
+              {task.label}
+            </h3>
+          </div>
+        </div>
+        <div>
+          {/* One Shot Button */}
+          <div
+            className={`one-shot-wrapper ${!oneShotProcessing ? 'tooltip-trigger-element' : ''}`}
+            data-tooltip-text={'Execute Once'}
+            onMouseMove={() => setTooltipTextAndOpen('Execute Once')}
+          >
+            {/* One-shot is not processing. */}
+            {!oneShotProcessing && (
+              <FontAwesomeIcon
+                className="enabled"
+                icon={faArrowDownFromDottedLine}
+                transform={'grow-8'}
+                onClick={() => {
+                  setOneShotProcessing(!oneShotProcessing);
+                  console.log('TODO: handle one-shot');
+                }}
+              />
+            )}
+
+            {/* One-shot is processing */}
+            {oneShotProcessing && (
+              <FontAwesomeIcon
+                className="processing"
+                fade
+                icon={faArrowDownFromDottedLine}
+                transform={'grow-8'}
+              />
+            )}
+          </div>
+
+          {/* Native OS Notification Checkbox */}
+          <div
+            className={'native-wrapper tooltip-trigger-element'}
+            data-tooltip-text={'Toggle OS Notifications'}
+            onMouseMove={() => setTooltipTextAndOpen('Toggle OS Notifications')}
+          >
+            {/* Nativ checkbox enabled */}
+            {task.status === 'enable' && (
+              <FontAwesomeIcon
+                className={nativeChecked ? 'checked' : 'unchecked'}
+                icon={faListRadio}
+                transform={'grow-8'}
+                onClick={() => {
+                  setNativeChecked(!nativeChecked);
+                  console.log('TODO: handle native checkbox');
+                }}
+              />
+            )}
+
+            {/* Native checkbox disabled */}
+            {task.status === 'disable' && (
+              <FontAwesomeIcon
+                className="disabled"
+                icon={faListRadio}
+                transform={'grow-8'}
+              />
+            )}
+          </div>
+
+          {/* Toggle Switch */}
+          <Switch
+            size="sm"
+            type="secondary"
+            isOn={isToggled}
+            handleToggle={() => {
+              console.log('TODO: handle switch toggle');
+              setIsToggled(!isToggled);
+            }}
+          />
+        </div>
+      </div>
+    </AccountWrapper>
+  );
+};

--- a/src/renderer/screens/Home/Manage/IntervalRow.tsx
+++ b/src/renderer/screens/Home/Manage/IntervalRow.tsx
@@ -28,11 +28,6 @@ export const IntervalRow = ({ task }: IntervalRowProps) => {
     task.enableOsNotifications
   );
 
-  const { action } = task;
-  console.log(`task action: ${action}`);
-  console.log(openHelp);
-  console.log(setTooltipTextAndOpen);
-
   return (
     <AccountWrapper whileHover={{ scale: 1.01 }}>
       <div className="inner">

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -51,7 +51,7 @@ export const Permissions = ({
   const {
     updateRenderedSubscriptions,
     renderedSubscriptions,
-    intervalTasksState,
+    dynamicIntervalTasksState,
   } = useManage();
 
   /// Active accordion indices for account subscription tasks categories.
@@ -75,10 +75,10 @@ export const Permissions = ({
 
   /// Go to section zero if all interval subscriptions have been removed.
   useEffect(() => {
-    if (typeClicked === 'interval' && intervalTasksState.length === 0) {
+    if (typeClicked === 'interval' && dynamicIntervalTasksState.length === 0) {
       setSection(0);
     }
-  }, [intervalTasksState]);
+  }, [dynamicIntervalTasksState]);
 
   /// Handle a toggle and update rendered subscription state.
   const handleToggle = async (
@@ -361,12 +361,14 @@ export const Permissions = ({
         </HeadingWrapper>
         <AccordionPanel>
           <div className="flex-column" style={{ padding: '0 0.75rem' }}>
-            {intervalTasksState.map((task: IntervalSubscription, i: number) => (
-              <IntervalRow
-                key={`${i}_${task.referendumId}_${task.action}`}
-                task={task}
-              />
-            ))}
+            {dynamicIntervalTasksState.map(
+              (task: IntervalSubscription, i: number) => (
+                <IntervalRow
+                  key={`${i}_${task.referendumId}_${task.action}`}
+                  task={task}
+                />
+              )
+            )}
           </div>
         </AccordionPanel>
       </AccordionItem>

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -49,9 +49,10 @@ export const Permissions = ({
     useSubscriptions();
 
   const {
-    updateRenderedSubscriptions,
     renderedSubscriptions,
     dynamicIntervalTasksState,
+    updateRenderedSubscriptions,
+    getCategorizedDynamicIntervals,
   } = useManage();
 
   /// Active accordion indices for account subscription tasks categories.
@@ -334,44 +335,46 @@ export const Permissions = ({
       defaultIndex={accordionActiveIntervalIndices}
       setExternalIndices={setAccordionActiveIntervalIndices}
     >
-      <AccordionItem>
-        <HeadingWrapper>
-          <AccordionHeader>
-            <div className="flex">
-              <div className="left">
-                <div className="icon-wrapper">
-                  {accordionActiveIntervalIndices.includes(0) ? (
-                    <FontAwesomeIcon
-                      icon={faCaretDown}
-                      transform={'shrink-1'}
-                    />
-                  ) : (
-                    <FontAwesomeIcon
-                      icon={faCaretRight}
-                      transform={'shrink-1'}
-                    />
-                  )}
+      {Array.from(getCategorizedDynamicIntervals().entries()).map(
+        ([referendumId, intervalTasks]) => (
+          <AccordionItem key={`${referendumId}_interval_subscriptions`}>
+            <HeadingWrapper>
+              <AccordionHeader>
+                <div className="flex">
+                  <div className="left">
+                    <div className="icon-wrapper">
+                      {accordionActiveIntervalIndices.includes(0) ? (
+                        <FontAwesomeIcon
+                          icon={faCaretDown}
+                          transform={'shrink-1'}
+                        />
+                      ) : (
+                        <FontAwesomeIcon
+                          icon={faCaretRight}
+                          transform={'shrink-1'}
+                        />
+                      )}
+                    </div>
+                    <h5>
+                      <span>Referendum {referendumId}</span>
+                    </h5>
+                  </div>
                 </div>
-                <h5>
-                  <span>OpenGov</span>
-                </h5>
+              </AccordionHeader>
+            </HeadingWrapper>
+            <AccordionPanel>
+              <div className="flex-column" style={{ padding: '0 0.75rem' }}>
+                {intervalTasks.map((task: IntervalSubscription, i: number) => (
+                  <IntervalRow
+                    key={`${i}_${task.referendumId}_${task.action}`}
+                    task={task}
+                  />
+                ))}
               </div>
-            </div>
-          </AccordionHeader>
-        </HeadingWrapper>
-        <AccordionPanel>
-          <div className="flex-column" style={{ padding: '0 0.75rem' }}>
-            {dynamicIntervalTasksState.map(
-              (task: IntervalSubscription, i: number) => (
-                <IntervalRow
-                  key={`${i}_${task.referendumId}_${task.action}`}
-                  task={task}
-                />
-              )
-            )}
-          </div>
-        </AccordionPanel>
-      </AccordionItem>
+            </AccordionPanel>
+          </AccordionItem>
+        )
+      )}
     </Accordion>
   );
 

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -354,11 +354,12 @@ export const Permissions = ({
         </HeadingWrapper>
         <AccordionPanel>
           <div className="flex-column" style={{ padding: '0 0.75rem' }}>
-            {intervalTasksState
-              .sort((a, b) => a.label.localeCompare(b.label))
-              .map((task: IntervalSubscription, i: number) => (
-                <IntervalRow key={`${i}_${task.action}`} task={task} />
-              ))}
+            {intervalTasksState.map((task: IntervalSubscription, i: number) => (
+              <IntervalRow
+                key={`${i}_${task.referendumId}_${task.action}`}
+                task={task}
+              />
+            ))}
           </div>
         </AccordionPanel>
       </AccordionItem>

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -73,6 +73,13 @@ export const Permissions = ({
     }
   }, [renderedSubscriptions]);
 
+  /// Go to section zero if all interval subscriptions have been removed.
+  useEffect(() => {
+    if (typeClicked === 'interval' && intervalTasksState.length === 0) {
+      setSection(0);
+    }
+  }, [intervalTasksState]);
+
   /// Handle a toggle and update rendered subscription state.
   const handleToggle = async (
     cached: WrappedSubscriptionTasks,

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -27,7 +27,7 @@ import { Switch } from '@/renderer/library/Switch';
 import { useSubscriptions } from '@app/contexts/main/Subscriptions';
 import { useEffect, useState } from 'react';
 import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
-import { useManage } from './provider';
+import { useManage } from '@/renderer/contexts/main/Manage';
 import type { AnyFunction } from '@w3ux/utils/types';
 import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type { PermissionsProps } from './types';

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -23,6 +23,7 @@ import {
 import { Flip, toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { PermissionRow } from './PermissionRow';
+import { IntervalRow } from './IntervalRow';
 import { Switch } from '@/renderer/library/Switch';
 import { useSubscriptions } from '@app/contexts/main/Subscriptions';
 import { useEffect, useState } from 'react';
@@ -356,11 +357,7 @@ export const Permissions = ({
             {intervalTasksState
               .sort((a, b) => a.label.localeCompare(b.label))
               .map((task: IntervalSubscription, i: number) => (
-                <div key={i} style={{ display: 'flex', columnGap: '1rem' }}>
-                  <span>{task.label}</span>
-                  <span>{task.chainId}</span>
-                  <span>{task.ticksToWait}</span>
-                </div>
+                <IntervalRow key={`${i}_${task.action}`} task={task} />
               ))}
           </div>
         </AccordionPanel>

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -26,7 +26,7 @@ import { PermissionRow } from './PermissionRow';
 import { IntervalRow } from './IntervalRow';
 import { Switch } from '@/renderer/library/Switch';
 import { useSubscriptions } from '@app/contexts/main/Subscriptions';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { useManage } from '@/renderer/contexts/main/Manage';
 import type { AnyFunction } from '@w3ux/utils/types';
@@ -66,7 +66,12 @@ export const Permissions = ({
 
   /// Active accordion indices for interval subscription task categories.
   const [accordionActiveIntervalIndices, setAccordionActiveIntervalIndices] =
-    useState<number[]>([0]);
+    useState<number[]>([]);
+
+  /// Ref to keep track of number of interval categories being rendered.
+  const numIntervalCategoresRef = useRef(
+    Array.from(getCategorizedDynamicIntervals().keys()).length
+  );
 
   useEffect(() => {
     if (section === 1 && renderedSubscriptions.type == '') {
@@ -78,6 +83,18 @@ export const Permissions = ({
   useEffect(() => {
     if (typeClicked === 'interval' && dynamicIntervalTasksState.length === 0) {
       setSection(0);
+    }
+
+    // Close all accordion panels if new category has been added.
+    if (typeClicked === 'interval') {
+      const newLength = Array.from(
+        getCategorizedDynamicIntervals().keys()
+      ).length;
+
+      if (newLength !== numIntervalCategoresRef.current) {
+        numIntervalCategoresRef.current = newLength;
+        setAccordionActiveIntervalIndices([]);
+      }
     }
   }, [dynamicIntervalTasksState]);
 
@@ -336,14 +353,14 @@ export const Permissions = ({
       setExternalIndices={setAccordionActiveIntervalIndices}
     >
       {Array.from(getCategorizedDynamicIntervals().entries()).map(
-        ([referendumId, intervalTasks]) => (
+        ([referendumId, intervalTasks], i) => (
           <AccordionItem key={`${referendumId}_interval_subscriptions`}>
             <HeadingWrapper>
               <AccordionHeader>
                 <div className="flex">
                   <div className="left">
                     <div className="icon-wrapper">
-                      {accordionActiveIntervalIndices.includes(0) ? (
+                      {accordionActiveIntervalIndices.includes(i) ? (
                         <FontAwesomeIcon
                           icon={faCaretDown}
                           transform={'shrink-1'}
@@ -364,9 +381,9 @@ export const Permissions = ({
             </HeadingWrapper>
             <AccordionPanel>
               <div className="flex-column" style={{ padding: '0 0.75rem' }}>
-                {intervalTasks.map((task: IntervalSubscription, i: number) => (
+                {intervalTasks.map((task: IntervalSubscription, j: number) => (
                   <IntervalRow
-                    key={`${i}_${task.referendumId}_${task.action}`}
+                    key={`${j}_${task.referendumId}_${task.action}`}
                     task={task}
                   />
                 ))}

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -29,6 +29,7 @@ import { useEffect, useState } from 'react';
 import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { useManage } from './provider';
 import type { AnyFunction } from '@w3ux/utils/types';
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type { PermissionsProps } from './types';
 import type {
   SubscriptionTask,
@@ -42,9 +43,15 @@ export const Permissions = ({
   setSection,
 }: PermissionsProps) => {
   const { online: isOnline, isConnecting } = useBootstrapping();
-  const { updateRenderedSubscriptions, renderedSubscriptions } = useManage();
+
   const { updateTask, handleQueuedToggle, toggleCategoryTasks, getTaskType } =
     useSubscriptions();
+
+  const {
+    updateRenderedSubscriptions,
+    renderedSubscriptions,
+    intervalTasksState,
+  } = useManage();
 
   /// Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
@@ -53,6 +60,10 @@ export const Permissions = ({
 
   /// Active accordion indices for chain subscription tasks categories.
   const [accordionActiveChainIndices, setAccordionActiveChainIndices] =
+    useState<number[]>([0]);
+
+  /// Active accordion indices for interval subscription task categories.
+  const [accordionActiveIntervalIndices, setAccordionActiveIntervalIndices] =
     useState<number[]>([0]);
 
   useEffect(() => {
@@ -308,6 +319,55 @@ export const Permissions = ({
     </Accordion>
   );
 
+  /// Render a list of interval subscription tasks that can be toggled.
+  const renderIntervalSubscriptionTasks = () => (
+    <Accordion
+      multiple
+      defaultIndex={accordionActiveIntervalIndices}
+      setExternalIndices={setAccordionActiveIntervalIndices}
+    >
+      <AccordionItem>
+        <HeadingWrapper>
+          <AccordionHeader>
+            <div className="flex">
+              <div className="left">
+                <div className="icon-wrapper">
+                  {accordionActiveIntervalIndices.includes(0) ? (
+                    <FontAwesomeIcon
+                      icon={faCaretDown}
+                      transform={'shrink-1'}
+                    />
+                  ) : (
+                    <FontAwesomeIcon
+                      icon={faCaretRight}
+                      transform={'shrink-1'}
+                    />
+                  )}
+                </div>
+                <h5>
+                  <span>OpenGov</span>
+                </h5>
+              </div>
+            </div>
+          </AccordionHeader>
+        </HeadingWrapper>
+        <AccordionPanel>
+          <div className="flex-column" style={{ padding: '0 0.75rem' }}>
+            {intervalTasksState
+              .sort((a, b) => a.label.localeCompare(b.label))
+              .map((task: IntervalSubscription, i: number) => (
+                <div key={i} style={{ display: 'flex', columnGap: '1rem' }}>
+                  <span>{task.label}</span>
+                  <span>{task.chainId}</span>
+                  <span>{task.ticksToWait}</span>
+                </div>
+              ))}
+          </div>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+
   return (
     <>
       <BreadcrumbsWrapper>
@@ -328,6 +388,7 @@ export const Permissions = ({
         {/* Render separate accordions for account and chain subscription tasks. */}
         {typeClicked === 'account' && renderSubscriptionTasks()}
         {typeClicked === 'chain' && renderSubscriptionTasks()}
+        {typeClicked === 'interval' && renderIntervalSubscriptionTasks()}
       </AccountsWrapper>
     </>
   );

--- a/src/renderer/screens/Home/Manage/provider.tsx
+++ b/src/renderer/screens/Home/Manage/provider.tsx
@@ -7,21 +7,32 @@ import type {
   SubscriptionTask,
   WrappedSubscriptionTasks,
 } from '@/types/subscriptions';
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 
 // Context interface.
 interface ManageContextInterface {
   renderedSubscriptions: WrappedSubscriptionTasks;
+  intervalTasksState: IntervalSubscription[];
+  setIntervalTasks: (tasks: IntervalSubscription[]) => void;
   setRenderedSubscriptions: (a: WrappedSubscriptionTasks) => void;
   updateRenderedSubscriptions: (a: SubscriptionTask) => void;
+  updateIntervalTask: (task: IntervalSubscription) => void;
 }
 
 // Default context value.
 const defaultManageContext: ManageContextInterface = {
   renderedSubscriptions: { type: '', tasks: [] },
+  intervalTasksState: [],
+  setIntervalTasks: () => {
+    // do nothing
+  },
   setRenderedSubscriptions: () => {
     // do nothing
   },
   updateRenderedSubscriptions: () => {
+    // do nothing
+  },
+  updateIntervalTask: () => {
     // do nothing
   },
 };
@@ -35,16 +46,20 @@ export const ManageContext =
 
 // Manage context provider.
 export const ManageProvider = ({ children }: { children: ReactNode }) => {
-  // Subscription tasks being rendered under the Manage tab.
+  /// Subscription tasks being rendered under the Manage tab.
   const [renderedSubscriptionsState, setRenderedSubscriptionsState] =
     useState<WrappedSubscriptionTasks>({ type: '', tasks: [] });
 
-  // Set rendered subscriptions.
+  const [intervalTasksState, setIntervalTasksState] = useState<
+    IntervalSubscription[]
+  >([]);
+
+  /// Set rendered subscriptions.
   const setRenderedSubscriptions = (wrapped: WrappedSubscriptionTasks) => {
     setRenderedSubscriptionsState({ ...wrapped });
   };
 
-  // Update a task in the the rendered subscription tasks state.
+  /// Update a task in the the rendered subscription tasks state.
   const updateRenderedSubscriptions = (task: SubscriptionTask) => {
     setRenderedSubscriptionsState((prev) => ({
       ...prev,
@@ -52,12 +67,31 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     }));
   };
 
+  /// Set intervaled subscriptions with new tasks array.
+  const setIntervalTasks = (tasks: IntervalSubscription[]) => {
+    setIntervalTasksState([...tasks]);
+  };
+
+  /// Update a task in the interval subscriptions state.
+  const updateIntervalTask = (task: IntervalSubscription) => {
+    setIntervalTasksState((prev) =>
+      prev.map((t) =>
+        t.action === task.action && t.referendumId === task.referendumId
+          ? task
+          : t
+      )
+    );
+  };
+
   return (
     <ManageContext.Provider
       value={{
         renderedSubscriptions: renderedSubscriptionsState,
+        intervalTasksState,
+        setIntervalTasks,
         setRenderedSubscriptions,
         updateRenderedSubscriptions,
+        updateIntervalTask,
       }}
     >
       {children}

--- a/src/renderer/screens/Home/NoAccounts.tsx
+++ b/src/renderer/screens/Home/NoAccounts.tsx
@@ -18,3 +18,17 @@ export const NoAccounts = () => (
     />
   </NoAccountsWrapper>
 );
+
+export const NoOpenGov = () => (
+  <NoAccountsWrapper>
+    <h4>No OpenGov subscriptions added.</h4>
+    <ButtonMonoInvert
+      lg
+      text="Explore OpenGov"
+      iconLeft={faLink}
+      onClick={() => {
+        window.myAPI.openWindow('openGov');
+      }}
+    />
+  </NoAccountsWrapper>
+);

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -57,6 +57,9 @@ export const ReferendumRow = ({ referendum }: ReferendumRowProps) => {
     const { referendaId: referendumId } = referendumInfo;
     task.referendumId = referendumId;
 
+    // Invert task status.
+    task.status = task.status === 'enable' ? 'disable' : 'enable';
+
     // Cache subscription in referenda subscriptions context.
     addReferendaSubscription({ ...task });
 

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -70,7 +70,6 @@ export const ReferendumRow = ({ referendum }: ReferendumRowProps) => {
 
     // - Receive feedback from main renderer to update:
     // - UI (toastify, subscription button)
-    // - Loading spinner if necessary.
     // - Update `Manage` UI to add subscription task.
   };
 

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -113,7 +113,11 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
               <AccordionPanel>
                 <ReferendaGroup>
                   {infos.map((referendum, j) => (
-                    <ReferendumRow key={j} referendum={referendum} />
+                    <ReferendumRow
+                      key={`${j}_${referendum.referendaId}`}
+                      referendum={referendum}
+                      index={j}
+                    />
                   ))}
                 </ReferendaGroup>
               </AccordionPanel>
@@ -128,7 +132,11 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
   const renderListed = () => (
     <ReferendaGroup style={{ display: groupingOn ? 'none' : 'block' }}>
       {getSortedActiveReferenda(newestFirst).map((referendum, i) => (
-        <ReferendumRow key={i} referendum={referendum} />
+        <ReferendumRow
+          key={`${i}_${referendum.referendaId}`}
+          referendum={referendum}
+          index={i}
+        />
       ))}
     </ReferendaGroup>
   );

--- a/src/renderer/screens/OpenGov/types.ts
+++ b/src/renderer/screens/OpenGov/types.ts
@@ -21,4 +21,5 @@ export interface ReferendaProps {
 
 export interface ReferendumRowProps {
   referendum: ActiveReferendaInfo;
+  index: number;
 }

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -62,7 +62,7 @@ export interface QueryMultiEntry {
   unsub: AnyFunction | null;
 }
 
-export type SubscriptionTaskType = 'chain' | 'account' | '';
+export type SubscriptionTaskType = 'account' | 'chain' | 'interval' | '';
 
 // Wraps an array of subscription tasks along with their
 // associated type (chain or account) and possible account


### PR DESCRIPTION
# Summary

This PR renders OpenGov referenda subscription tasks that have been added via the OpenGov window.

## Note

Controls on added OpenGov subscriptions are still static and are not yet hooked up to the system. The subscription toggle switch, one-shot button, and native OS notification checkbox, will be hooked up in the next PR. 

## Checklist

- [x] Context for storing and rendering interval subscriptions in main renderer.
- [x] Dynamically render OpenGov interval subscriptions when chain ID clicked. 
- [x] Go back to first manage section if all interval subscriptions have been removed. 
- [x] Categorise open gov subscriptions in accordion panels by referendum ID. 
- [x] Sort referendum categories in descending order.
- [x] Update accordion indices (all panels closed when new number of categories changes).