### PR TITLE
feat: persist interval subscriptions

### DIFF
--- a/src/controller/renderer/IntervalsController.ts
+++ b/src/controller/renderer/IntervalsController.ts
@@ -46,14 +46,13 @@ export class IntervalsController {
 
   /**
    * @name initIntervals
-   * @summary Initialize intervals and the interval clock.
+   * @summary Initialize the interval clock.
    */
-  static initIntervals() {
-    // TODO: Fetch persisted intervals and re-start the subscription.
-    // NOTE: This method is called when app switches to online mode.
+  static async initIntervals(isOnline: boolean) {
+    // NOTE: This method is called when app initializes and switches to online mode.
 
     // Start interval.
-    this.initClock();
+    isOnline && this.initClock();
   }
 
   /**

--- a/src/controller/renderer/IntervalsController.ts
+++ b/src/controller/renderer/IntervalsController.ts
@@ -124,9 +124,12 @@ export class IntervalsController {
    * @summary Start the interval for processing managed subscriptions.
    */
   private static startInterval() {
-    this.intervalId = setInterval(async () => {
-      await this.processTick();
-    }, this.tickDuration * 1000);
+    this.intervalId = setInterval(
+      async () => {
+        await this.processTick();
+      },
+      this.tickDuration * 1000 * 12 // 1 minute
+    );
   }
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -368,7 +368,6 @@ app.whenReady().then(async () => {
   ipcMain.handle('app:interval:tasks:get', async () => {
     const key = 'interval_subscriptions';
     const storePointer: Record<string, AnyJson> = store;
-
     const stored: string = storePointer.get(key) || '[]';
     return stored;
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,8 @@ import type {
 import type { FlattenedAccountData, FlattenedAccounts } from '@/types/accounts';
 import type { IpcMainInvokeEvent } from 'electron';
 import type { SubscriptionTask } from '@/types/subscriptions';
+import type { IntervalSubscription } from './controller/renderer/IntervalsController';
+import type { AnyJson } from '@w3ux/utils/types';
 
 const debug = MainDebug;
 
@@ -356,6 +358,63 @@ app.whenReady().then(async () => {
   // Show native notifications.
   ipcMain.on('app:notification:show', (_, { title, body }) => {
     NotificationsController.showNotification(title, body);
+  });
+
+  /**
+   * Interval subscriptions
+   */
+
+  // Get interval subscriptions from store.
+  ipcMain.handle('app:interval:tasks:get', async () => {
+    const key = 'interval_subscriptions';
+    const storePointer: Record<string, AnyJson> = store;
+
+    const stored: string = storePointer.get(key) || '[]';
+    return stored;
+  });
+
+  // Clear interval subscriptions from store.
+  ipcMain.handle('app:interval:tasks:clear', async () => {
+    const key = 'interval_subscriptions';
+    const storePointer: Record<string, AnyJson> = store;
+    storePointer.delete(key);
+    return 'done';
+  });
+
+  // Add interval subscription to store.
+  ipcMain.handle('app:interval:task:add', async (_, serialized: string) => {
+    const key = 'interval_subscriptions';
+    const storePointer: Record<string, AnyJson> = store;
+
+    const stored: IntervalSubscription[] = storePointer.get(key)
+      ? JSON.parse(storePointer.get(key) as string)
+      : [];
+
+    stored.push(JSON.parse(serialized));
+    storePointer.set(key, JSON.stringify(stored));
+  });
+
+  // Add interval subscription to store.
+  ipcMain.handle('app:interval:task:remove', async (_, serialized: string) => {
+    const key = 'interval_subscriptions';
+    const storePointer: Record<string, AnyJson> = store;
+
+    const stored: IntervalSubscription[] = storePointer.get(key)
+      ? JSON.parse(storePointer.get(key) as string)
+      : [];
+
+    const task: IntervalSubscription = JSON.parse(serialized);
+    const { action, chainId, referendumId } = task;
+    const filtered = stored.filter(
+      (t) =>
+        !(
+          t.action === action &&
+          t.chainId === chainId &&
+          t.referendumId === referendumId
+        )
+    );
+
+    storePointer.set(key, JSON.stringify(filtered));
   });
 
   /**

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -59,6 +59,22 @@ export const API: PreloadAPI = {
   },
 
   /**
+   * Interval subscriptions
+   */
+
+  getPersistedIntervalTasks: async () =>
+    await ipcRenderer.invoke('app:interval:tasks:get'),
+
+  clearPersistedIntervalTasks: async () =>
+    await ipcRenderer.invoke('app:interval:tasks:clear'),
+
+  persistIntervalTask: async (serialized: string) =>
+    await ipcRenderer.invoke('app:interval:task:add', serialized),
+
+  removeIntervalTask: async (serialized: string) =>
+    await ipcRenderer.invoke('app:interval:task:remove', serialized),
+
+  /**
    * File import and export
    */
 

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -471,7 +471,7 @@ export const useMainMessagePorts = () => {
    * @name handleAddInterval
    * @summary Add an interval subscription to the intervals controller.
    */
-  const handleAddInterval = (ev: MessageEvent) => {
+  const handleAddInterval = async (ev: MessageEvent) => {
     const { task: serialized } = ev.data.data;
     const task: IntervalSubscription = JSON.parse(serialized);
 
@@ -485,13 +485,16 @@ export const useMainMessagePorts = () => {
 
     // Add task to React state for rendering.
     addIntervalSubscription({ ...task });
+
+    // Persist task to store.
+    await window.myAPI.persistIntervalTask(JSON.stringify(task));
   };
 
   /**
    * @name handleRemoveInterval
    * @summary Remove an interval subscription from the intervals controller.
    */
-  const handleRemoveInterval = (ev: MessageEvent) => {
+  const handleRemoveInterval = async (ev: MessageEvent) => {
     const { task: serialized } = ev.data.data;
     const task: IntervalSubscription = JSON.parse(serialized);
 
@@ -505,6 +508,9 @@ export const useMainMessagePorts = () => {
 
     // Remove task from React state for rendering.
     removeIntervalSubscription({ ...task });
+
+    // Remove task from store.
+    window.myAPI.removeIntervalTask(JSON.stringify(task));
   };
 
   /**
@@ -631,11 +637,11 @@ export const useMainMessagePorts = () => {
               break;
             }
             case 'openGov:interval:add': {
-              handleAddInterval(ev);
+              await handleAddInterval(ev);
               break;
             }
             case 'openGov:interval:remove': {
-              handleRemoveInterval(ev);
+              await handleRemoveInterval(ev);
               break;
             }
             default: {

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -5,14 +5,17 @@ import { Config as ConfigOpenGov } from '@/config/processes/openGov';
 import { useEffect } from 'react';
 import { getTracks } from '@/model/Track';
 import { useTracks } from '@app/contexts/openGov/Tracks';
-import type { ActiveReferendaInfo } from '@/types/openGov';
 import { useReferenda } from '../contexts/openGov/Referenda';
 import { useTreasury } from '../contexts/openGov/Treasury';
+import { useReferendaSubscriptions } from '../contexts/openGov/ReferendaSubscriptions';
+import type { ActiveReferendaInfo } from '@/types/openGov';
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 
 export const useOpenGovMessagePorts = () => {
   const { setTracks, setFetchingTracks } = useTracks();
   const { setReferenda, setFetchingReferenda } = useReferenda();
   const { setTreasuryData } = useTreasury();
+  const { addReferendaSubscription } = useReferendaSubscriptions();
 
   /**
    * @name handleReceivedPort
@@ -43,6 +46,12 @@ export const useOpenGovMessagePorts = () => {
             }
             case 'openGov:treasury:set': {
               setTreasuryData(ev.data.data);
+              break;
+            }
+            case 'openGov:task:add': {
+              const { serialized } = ev.data.data;
+              const task: IntervalSubscription = JSON.parse(serialized);
+              addReferendaSubscription(task);
               break;
             }
             default: {

--- a/src/renderer/library/Header/index.tsx
+++ b/src/renderer/library/Header/index.tsx
@@ -11,6 +11,7 @@ import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { Config as RendererConfig } from '@/config/processes/renderer';
 import { faUnlock, faLock } from '@fortawesome/pro-solid-svg-icons';
 import type { HeaderProps } from './types';
+import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 
 export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
   const { pathname } = useLocation();
@@ -40,6 +41,17 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
     });
   };
 
+  const handleGet = async () => {
+    const serialized = await window.myAPI.getPersistedIntervalTasks();
+    const tasks: IntervalSubscription[] = JSON.parse(serialized);
+    tasks.forEach((t) => console.log(t));
+  };
+
+  const handleClear = async () => {
+    const result = await window.myAPI.clearPersistedIntervalTasks();
+    console.log(result);
+  };
+
   return (
     <HeaderWrapper>
       <div className="content-wrapper">
@@ -55,6 +67,9 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
                 iconTransform="shrink-5"
                 onClick={() => handleDocked()}
               />
+
+              <button onClick={async () => await handleGet()}>Get</button>
+              <button onClick={async () => await handleClear()}>Clear</button>
 
               {/* Cog menu*/}
               <Menu />

--- a/src/renderer/library/Header/index.tsx
+++ b/src/renderer/library/Header/index.tsx
@@ -11,7 +11,6 @@ import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { Config as RendererConfig } from '@/config/processes/renderer';
 import { faUnlock, faLock } from '@fortawesome/pro-solid-svg-icons';
 import type { HeaderProps } from './types';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 
 export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
   const { pathname } = useLocation();
@@ -41,17 +40,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
     });
   };
 
-  const handleGet = async () => {
-    const serialized = await window.myAPI.getPersistedIntervalTasks();
-    const tasks: IntervalSubscription[] = JSON.parse(serialized);
-    tasks.forEach((t) => console.log(t));
-  };
-
-  const handleClear = async () => {
-    const result = await window.myAPI.clearPersistedIntervalTasks();
-    console.log(result);
-  };
-
   return (
     <HeaderWrapper>
       <div className="content-wrapper">
@@ -67,9 +55,6 @@ export const Header = ({ showMenu, appLoading = false }: HeaderProps) => {
                 iconTransform="shrink-5"
                 onClick={() => handleDocked()}
               />
-
-              <button onClick={async () => await handleGet()}>Get</button>
-              <button onClick={async () => await handleClear()}>Clear</button>
 
               {/* Cog menu*/}
               <Menu />

--- a/src/renderer/screens/OpenGov/utils.ts
+++ b/src/renderer/screens/OpenGov/utils.ts
@@ -53,7 +53,7 @@ export const getSpacedOrigin = (origin: string) => {
       return 'Fellowship Admin';
     case 'GeneralAdmin':
       return 'General Admin';
-    case 'Auction Admin':
+    case 'AuctionAdmin':
       return 'Auction Admin';
     case 'ReferendumCanceller':
       return 'Referendum Canceller';
@@ -61,7 +61,7 @@ export const getSpacedOrigin = (origin: string) => {
       return 'Referendum Killer';
     case 'SmallTipper':
       return 'Small Tipper';
-    case 'Big Tipper':
+    case 'BigTipper':
       return 'Big Tipper';
     case 'SmallSpender':
       return 'Small Spender';

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -11,6 +11,12 @@ import type { SubscriptionTask } from './subscriptions';
 import type { PersistedSettings } from '@/renderer/screens/Settings/types';
 
 export interface PreloadAPI {
+  getPersistedIntervalTasks: () => Promise<string>;
+  clearPersistedIntervalTasks: () => Promise<string>;
+
+  persistIntervalTask: ApiPersistIntervalTask;
+  removeIntervalTask: ApiRemoveIntervalTask;
+
   getWindowId: () => string;
 
   exportAppData: ApiExportAppData;
@@ -181,3 +187,6 @@ type ApiReportStaleEvent = (
 ) => Electron.IpcRenderer;
 
 type ApiInitOnlineStatus = () => Promise<void>;
+
+type ApiPersistIntervalTask = (serialized: string) => Promise<void>;
+type ApiRemoveIntervalTask = (serialized: string) => Promise<void>;


### PR DESCRIPTION
# Summary

This PR persists and removes interval tasks from the Electron store when the `Add` and `Remove` buttons are clicked in the OpenGov window.

Persisted interval tasks are fetched when the app is launched to set React state and restore interval subscriptions from the previous time the app was used.
