### PR TITLE
chore: inserting and removing batched interval tasks

### DIFF
--- a/src/config/subscriptions/interval.ts
+++ b/src/config/subscriptions/interval.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const intervalTasks: IntervalSubscription[] = [
   // Polkadot

--- a/src/controller/renderer/EventsController.ts
+++ b/src/controller/renderer/EventsController.ts
@@ -20,13 +20,12 @@ import { getUnixTime } from 'date-fns';
 import { planckToUnit } from '@w3ux/utils';
 import type { ActionMeta } from '@/types/tx';
 import type { AnyData } from '@/types/misc';
-import type { ApiCallEntry } from '@/types/subscriptions';
+import type { IntervalSubscription, ApiCallEntry } from '@/types/subscriptions';
 import type {
   EventAccountData,
   EventCallback,
   EventChainData,
 } from '@/types/reporter';
-import type { IntervalSubscription } from './IntervalsController';
 import type { ValidatorData } from '@/types/accounts';
 
 export class EventsController {

--- a/src/controller/renderer/IntervalsController.ts
+++ b/src/controller/renderer/IntervalsController.ts
@@ -5,40 +5,10 @@ import { executeIntervaledOneShot } from '@/renderer/callbacks/intervaled';
 import { secondsUntilNextMinute } from '@/renderer/utils/timeUtils';
 import type { AnyData } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
-import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
-
-/// Where `default` reads the tasks `enableOsNotifications` field.
-export type NotificationPolicy = 'default' | 'none' | 'one-shot';
-
-export interface IntervalSubscription {
-  // Unique id for the task.
-  action: string;
-  // Number of ticks between each one-shot execution.
-  intervalSetting: IntervalSetting;
-  // Used as a countdown.
-  tickCounter: number;
-  // Task category.
-  category: string;
-  // Task's associated chain.
-  chainId: ChainID;
-  // Shown in renderer.
-  label: string;
-  // Enabled or disabled.
-  status: 'enable' | 'disable';
-  // Flag to enable or silence OS notifications.
-  enableOsNotifications: boolean;
-  // Key to retrieve help information about the task.
-  helpKey: HelpItemKey;
-  // Associated referendum id for task.
-  referendumId?: number;
-  // Flag to determine if the subscription was just build (may not be needed)
-  justBuilt?: boolean;
-}
-
-export interface IntervalSetting {
-  label: string;
-  ticksToWait: number;
-}
+import type {
+  IntervalSetting,
+  IntervalSubscription,
+} from '@/types/subscriptions';
 
 export class IntervalsController {
   /// Active interval subscriptions keyed by chain ID.

--- a/src/controller/renderer/NotificationsController.ts
+++ b/src/controller/renderer/NotificationsController.ts
@@ -12,10 +12,9 @@ import {
 } from '@/utils/EventUtils';
 import type { Account } from '@/model/Account';
 import type { AnyData } from '@/types/misc';
-import type { ApiCallEntry } from '@/types/subscriptions';
+import type { ApiCallEntry, IntervalSubscription } from '@/types/subscriptions';
 import type { NotificationData } from '@/types/reporter';
 import type { ValidatorData } from '@/types/accounts';
-import type { IntervalSubscription } from './IntervalsController';
 
 export class NotificationsController {
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,11 @@ import type {
 } from '@/types/reporter';
 import type { FlattenedAccountData, FlattenedAccounts } from '@/types/accounts';
 import type { IpcMainInvokeEvent } from 'electron';
-import type { SubscriptionTask } from '@/types/subscriptions';
-import type { IntervalSubscription } from './controller/renderer/IntervalsController';
 import type { AnyJson } from '@w3ux/utils/types';
+import type {
+  SubscriptionTask,
+  IntervalSubscription,
+} from '@/types/subscriptions';
 
 const debug = MainDebug;
 

--- a/src/renderer/callbacks/intervaled.ts
+++ b/src/renderer/callbacks/intervaled.ts
@@ -17,11 +17,11 @@ import {
 } from '../utils/openGovUtils';
 import type { AnyData } from '@/types/misc';
 import type { ActiveReferendaInfo, OneShotReturn } from '@/types/openGov';
+import type { NotificationData } from '@/types/reporter';
 import type {
   IntervalSubscription,
   NotificationPolicy,
-} from '@/controller/renderer/IntervalsController';
-import type { NotificationData } from '@/types/reporter';
+} from '@/types/subscriptions';
 
 /// Debugging function.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -345,16 +345,13 @@ export const BootstrappingProvider = ({
     const serialized = await window.myAPI.getPersistedIntervalTasks();
     const tasks: IntervalSubscription[] = JSON.parse(serialized);
 
+    // Insert subscriptions and start interval if online.
+    IntervalsController.insertSubscriptions(tasks, isOnline);
+
+    // Add tasks to React state in main and open gov window.
     for (const task of tasks) {
-      // Add task to interval subscription state.
       addIntervalSubscription({ ...task });
 
-      // Have intervals controller manage enabled subscriptions.
-      if (task.status === 'enable') {
-        IntervalsController.insertSubscription({ ...task });
-      }
-
-      // Post message to OpenGov window to cache tasks.
       RendererConfig.portToOpenGov.postMessage({
         task: 'openGov:task:add',
         data: {
@@ -362,8 +359,6 @@ export const BootstrappingProvider = ({
         },
       });
     }
-
-    await IntervalsController.initIntervals(isOnline);
   };
 
   const setSubscriptionsAndChainConnections = () => {

--- a/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -27,7 +27,7 @@ import { useIntervalSubscriptions } from '../IntervalSubscriptions';
 import { handleApiDisconnects } from '@/utils/ApiUtils';
 import type { BootstrappingInterface } from './types';
 import type { ChainID } from '@/types/chains';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const BootstrappingContext = createContext<BootstrappingInterface>(
   defaultBootstrappingContext

--- a/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
+++ b/src/renderer/contexts/main/IntervalSubscriptions/index.tsx
@@ -4,7 +4,7 @@
 import * as defaults from './defaults';
 import { createContext, useContext, useState } from 'react';
 import type { ChainID } from '@/types/chains';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 import type { IntervalSubscriptionsContextInterface } from './types';
 
 export const IntervalSubscriptionsContext =

--- a/src/renderer/contexts/main/IntervalSubscriptions/types.ts
+++ b/src/renderer/contexts/main/IntervalSubscriptions/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 import type { ChainID } from '@/types/chains';
 
 export interface IntervalSubscriptionsContextInterface {

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -5,11 +5,11 @@ import * as defaults from './defaults';
 import { useState, createContext, useContext, useRef } from 'react';
 import type { ReactNode } from 'react';
 import type {
+  IntervalSubscription,
   SubscriptionTask,
   WrappedSubscriptionTasks,
 } from '@/types/subscriptions';
 import type { ChainID } from '@/types/chains';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type { ManageContextInterface } from './types';
 
 // Hook to manage context.

--- a/src/renderer/contexts/main/Manage/types.ts
+++ b/src/renderer/contexts/main/Manage/types.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainID } from '@/types/chains';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type {
+  IntervalSubscription,
   SubscriptionTask,
   WrappedSubscriptionTasks,
 } from '@/types/subscriptions';

--- a/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
+++ b/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
@@ -4,7 +4,7 @@
 import * as defaults from './defaults';
 import { createContext, useContext, useState } from 'react';
 import type { ChainID } from '@/types/chains';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 import type { ReferendaSubscriptionsContextInterface } from './types';
 import type { ActiveReferendaInfo } from '@/types/openGov';
 

--- a/src/renderer/contexts/openGov/ReferendaSubscriptions/types.ts
+++ b/src/renderer/contexts/openGov/ReferendaSubscriptions/types.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainID } from '@/types/chains';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type { ActiveReferendaInfo } from '@/types/openGov';
+import type { IntervalSubscription } from '@/types/subscriptions';
 
 export interface ReferendaSubscriptionsContextInterface {
   subscriptions: Map<ChainID, IntervalSubscription[]>;

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -34,7 +34,7 @@ import { useIntervalSubscriptions } from '../contexts/main/IntervalSubscriptions
 import type { AccountSource, LocalAddress } from '@/types/accounts';
 import type { ActiveReferendaInfo } from '@/types/openGov';
 import type { AnyData } from '@/types/misc';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const useMainMessagePorts = () => {
   /// Main renderer contexts.

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -9,7 +9,7 @@ import { useReferenda } from '../contexts/openGov/Referenda';
 import { useTreasury } from '../contexts/openGov/Treasury';
 import { useReferendaSubscriptions } from '../contexts/openGov/ReferendaSubscriptions';
 import type { ActiveReferendaInfo } from '@/types/openGov';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const useOpenGovMessagePorts = () => {
   const { setTracks, setFetchingTracks } = useTracks();

--- a/src/renderer/screens/Home/Manage/IntervalRow.tsx
+++ b/src/renderer/screens/Home/Manage/IntervalRow.tsx
@@ -18,8 +18,8 @@ import {
 } from '@fortawesome/pro-light-svg-icons';
 import { Switch } from '@app/library/Switch';
 import { IntervalsController } from '@/controller/renderer/IntervalsController';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type { AnyData } from '@/types/misc';
+import type { IntervalSubscription } from '@/types/subscriptions';
 
 interface IntervalRowProps {
   task: IntervalSubscription;

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -271,25 +271,23 @@ export const Permissions = ({
       return;
     }
 
-    // Update task state.
-    for (const task of tasks) {
-      // Handle task in intervals controller.
-      switch (task.status) {
-        case 'enable': {
-          IntervalsController.insertSubscription({ ...task });
-          break;
-        }
-        case 'disable': {
-          IntervalsController.removeSubscription({ ...task });
-          break;
-        }
+    // Update managed tasks in intervals controller.
+    switch (tasks[0].status) {
+      case 'enable': {
+        IntervalsController.insertSubscriptions(tasks);
+        break;
       }
+      case 'disable': {
+        IntervalsController.removeSubscriptions(tasks);
+        break;
+      }
+    }
 
-      // Update main renderer state.
+    // Update React and store state.
+    for (const task of tasks) {
       updateIntervalSubscription({ ...task });
       tryUpdateDynamicIntervalTask({ ...task });
 
-      // Update OpenGov renderer state.
       ConfigRenderer.portToOpenGov.postMessage({
         task: 'openGov:task:update',
         data: {
@@ -297,7 +295,6 @@ export const Permissions = ({
         },
       });
 
-      // Update persisted task in store.
       await window.myAPI.updateIntervalTask(JSON.stringify(task));
     }
   };

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -26,8 +26,8 @@ import { useManage } from '@/renderer/contexts/main/Manage';
 import { useIntervalSubscriptions } from '@/renderer/contexts/main/IntervalSubscriptions';
 import type { AnyFunction } from '@w3ux/utils/types';
 import type { PermissionsProps } from './types';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
 import type {
+  IntervalSubscription,
   SubscriptionTask,
   WrappedSubscriptionTasks,
 } from '@/types/subscriptions';

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -20,7 +20,7 @@ import {
 } from '@fortawesome/pro-solid-svg-icons';
 import type { ActiveReferendaInfo } from '@/types/openGov';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
-import type { IntervalSubscription } from '@/controller/renderer/IntervalsController';
+import type { IntervalSubscription } from '@/types/subscriptions';
 import type { ReferendumRowProps } from '../types';
 
 export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -6,6 +6,39 @@ import type { AnyFunction, AnyData } from './misc';
 import type { FlattenedAccountData } from './accounts';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
 
+/// Where `default` reads the tasks `enableOsNotifications` field.
+export type NotificationPolicy = 'default' | 'none' | 'one-shot';
+
+export interface IntervalSetting {
+  label: string;
+  ticksToWait: number;
+}
+
+export interface IntervalSubscription {
+  // Unique id for the task.
+  action: string;
+  // Number of ticks between each one-shot execution.
+  intervalSetting: IntervalSetting;
+  // Used as a countdown.
+  tickCounter: number;
+  // Task category.
+  category: string;
+  // Task's associated chain.
+  chainId: ChainID;
+  // Shown in renderer.
+  label: string;
+  // Enabled or disabled.
+  status: 'enable' | 'disable';
+  // Flag to enable or silence OS notifications.
+  enableOsNotifications: boolean;
+  // Key to retrieve help information about the task.
+  helpKey: HelpItemKey;
+  // Associated referendum id for task.
+  referendumId?: number;
+  // Flag to determine if the subscription was just build (may not be needed)
+  justBuilt?: boolean;
+}
+
 export type SubscriptionNextStatus = 'enable' | 'disable';
 
 export interface SubscriptionTask {


### PR DESCRIPTION
# Summary

Adds methods in the intervals controller for processing (inserting or removing) an array of `IntervalSubscription` objects. Called when fetching persisted tasks from the store on app initialisation, or when clicking the "global" toggle to turn on or off all subscriptions for a referendum.

An intervals controller optimisation. 