### PR TITLE
chore: limit fetching open gov data + refresh data buttons

### DIFF
--- a/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -8,7 +8,7 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   referenda: [],
   fetchingReferenda: false,
   activeReferendaChainId: 'Polkadot',
-  setDataCached: (c) => {},
+  receiveReferendaData: (i) => {},
   fetchReferendaData: (c) => {},
   setReferenda: (r) => {},
   setFetchingReferenda: (f) => {},

--- a/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -8,6 +8,7 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   referenda: [],
   fetchingReferenda: false,
   activeReferendaChainId: 'Polkadot',
+  setDataCached: (c) => {},
   fetchReferendaData: (c) => {},
   setReferenda: (r) => {},
   setFetchingReferenda: (f) => {},

--- a/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -8,6 +8,7 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   referenda: [],
   fetchingReferenda: false,
   activeReferendaChainId: 'Polkadot',
+  fetchReferendaData: (c) => {},
   setReferenda: (r) => {},
   setFetchingReferenda: (f) => {},
   setActiveReferendaChainId: (c) => {},

--- a/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -10,9 +10,9 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   activeReferendaChainId: 'Polkadot',
   receiveReferendaData: (i) => {},
   fetchReferendaData: (c) => {},
+  refetchReferenda: () => {},
   setReferenda: (r) => {},
   setFetchingReferenda: (f) => {},
-  setActiveReferendaChainId: (c) => {},
   getSortedActiveReferenda: (d) => [],
   getCategorisedReferenda: (d) => new Map(),
 };

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
+import { Config as ConfigOpenGov } from '@/config/processes/openGov';
 import { createContext, useContext, useState } from 'react';
 import { getOrderedOrigins } from '@/renderer/utils/openGovUtils';
+import { useConnections } from '@app/contexts/common/Connections';
 import type { ChainID } from '@/types/chains';
 import type { ReferendaContextInterface } from './types';
 import type { ActiveReferendaInfo } from '@/types/openGov';
@@ -19,6 +21,8 @@ export const ReferendaProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { isConnected } = useConnections();
+
   /// Referenda data received from API.
   const [referenda, setReferenda] = useState<ActiveReferendaInfo[]>([]);
 
@@ -28,6 +32,21 @@ export const ReferendaProvider = ({
   /// Chain ID for currently rendered referenda.
   const [activeReferendaChainId, setActiveReferendaChainId] =
     useState<ChainID>('Polkadot');
+
+  /// Initiate feching referenda data.
+  const fetchReferendaData = (chainId: ChainID) => {
+    if (!isConnected) {
+      return;
+    }
+
+    setActiveReferendaChainId(chainId);
+    setFetchingReferenda(true);
+
+    ConfigOpenGov.portOpenGov.postMessage({
+      task: 'openGov:referenda:get',
+      data: { chainId },
+    });
+  };
 
   /// Get all referenda sorted by desc or asc.
   const getSortedActiveReferenda = (desc: boolean) =>
@@ -83,6 +102,7 @@ export const ReferendaProvider = ({
         referenda,
         fetchingReferenda,
         activeReferendaChainId,
+        fetchReferendaData,
         setReferenda,
         setFetchingReferenda,
         setActiveReferendaChainId,

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -41,7 +41,7 @@ export const ReferendaProvider = ({
     // Return early if offline or data is already fetched for the chain.
     if (
       !isConnected ||
-      (dataCachedRef.current && chainId === activeReferendaChainId)
+      (dataCachedRef.current === true && chainId === activeReferendaChainId)
     ) {
       return;
     }
@@ -52,6 +52,15 @@ export const ReferendaProvider = ({
     ConfigOpenGov.portOpenGov.postMessage({
       task: 'openGov:referenda:get',
       data: { chainId },
+    });
+  };
+
+  /// Re-fetch referenda, called when user clicks refresh button.
+  const refetchReferenda = () => {
+    setFetchingReferenda(true);
+    ConfigOpenGov.portOpenGov.postMessage({
+      task: 'openGov:referenda:get',
+      data: { chainId: activeReferendaChainId },
     });
   };
 
@@ -117,10 +126,10 @@ export const ReferendaProvider = ({
         fetchingReferenda,
         activeReferendaChainId,
         fetchReferendaData,
+        refetchReferenda,
         receiveReferendaData,
         setReferenda,
         setFetchingReferenda,
-        setActiveReferendaChainId,
         getSortedActiveReferenda,
         getCategorisedReferenda,
       }}

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -55,6 +55,13 @@ export const ReferendaProvider = ({
     });
   };
 
+  /// Set state after receiving referenda data from main renderer.
+  const receiveReferendaData = (info: ActiveReferendaInfo[]) => {
+    setReferenda(info);
+    setFetchingReferenda(false);
+    dataCachedRef.current = true;
+  };
+
   /// Get all referenda sorted by desc or asc.
   const getSortedActiveReferenda = (desc: boolean) =>
     referenda.sort((a, b) =>
@@ -103,17 +110,14 @@ export const ReferendaProvider = ({
     return map;
   };
 
-  /// Setter for data cached ref.
-  const setDataCached = (cached: boolean) => (dataCachedRef.current = cached);
-
   return (
     <ReferendaContext.Provider
       value={{
         referenda,
         fetchingReferenda,
         activeReferendaChainId,
-        setDataCached,
         fetchReferendaData,
+        receiveReferendaData,
         setReferenda,
         setFetchingReferenda,
         setActiveReferendaChainId,

--- a/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/src/renderer/contexts/openGov/Referenda/types.ts
@@ -8,6 +8,7 @@ export interface ReferendaContextInterface {
   referenda: ActiveReferendaInfo[];
   fetchingReferenda: boolean;
   activeReferendaChainId: ChainID;
+  fetchReferendaData: (chainId: ChainID) => void;
   setReferenda: (referenda: ActiveReferendaInfo[]) => void;
   setActiveReferendaChainId: (chainId: ChainID) => void;
   setFetchingReferenda: (flag: boolean) => void;

--- a/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/src/renderer/contexts/openGov/Referenda/types.ts
@@ -9,9 +9,9 @@ export interface ReferendaContextInterface {
   fetchingReferenda: boolean;
   activeReferendaChainId: ChainID;
   fetchReferendaData: (chainId: ChainID) => void;
+  refetchReferenda: () => void;
   receiveReferendaData: (info: ActiveReferendaInfo[]) => void;
   setReferenda: (referenda: ActiveReferendaInfo[]) => void;
-  setActiveReferendaChainId: (chainId: ChainID) => void;
   setFetchingReferenda: (flag: boolean) => void;
   getSortedActiveReferenda: (desc: boolean) => ActiveReferendaInfo[];
   getCategorisedReferenda: (

--- a/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/src/renderer/contexts/openGov/Referenda/types.ts
@@ -8,6 +8,7 @@ export interface ReferendaContextInterface {
   referenda: ActiveReferendaInfo[];
   fetchingReferenda: boolean;
   activeReferendaChainId: ChainID;
+  setDataCached: (cached: boolean) => void;
   fetchReferendaData: (chainId: ChainID) => void;
   setReferenda: (referenda: ActiveReferendaInfo[]) => void;
   setActiveReferendaChainId: (chainId: ChainID) => void;

--- a/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/src/renderer/contexts/openGov/Referenda/types.ts
@@ -8,8 +8,8 @@ export interface ReferendaContextInterface {
   referenda: ActiveReferendaInfo[];
   fetchingReferenda: boolean;
   activeReferendaChainId: ChainID;
-  setDataCached: (cached: boolean) => void;
   fetchReferendaData: (chainId: ChainID) => void;
+  receiveReferendaData: (info: ActiveReferendaInfo[]) => void;
   setReferenda: (referenda: ActiveReferendaInfo[]) => void;
   setActiveReferendaChainId: (chainId: ChainID) => void;
   setFetchingReferenda: (flag: boolean) => void;

--- a/src/renderer/contexts/openGov/Tracks/defaults.ts
+++ b/src/renderer/contexts/openGov/Tracks/defaults.ts
@@ -8,9 +8,9 @@ export const defaultTracksContext: TracksContextInterface = {
   tracks: [],
   fetchingTracks: false,
   activeChainId: 'Polkadot',
+  fetchTracksData: (c) => {},
+  receiveTracksData: (d) => {},
   setTracks: (t) => {},
   setFetchingTracks: (f) => {},
   setActiveChainId: (c) => {},
-  setDataCached: (c) => {},
-  getDataCached: () => false,
 };

--- a/src/renderer/contexts/openGov/Tracks/defaults.ts
+++ b/src/renderer/contexts/openGov/Tracks/defaults.ts
@@ -11,4 +11,6 @@ export const defaultTracksContext: TracksContextInterface = {
   setTracks: (t) => {},
   setFetchingTracks: (f) => {},
   setActiveChainId: (c) => {},
+  setDataCached: (c) => {},
+  getDataCached: () => false,
 };

--- a/src/renderer/contexts/openGov/Tracks/index.tsx
+++ b/src/renderer/contexts/openGov/Tracks/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useRef, useState } from 'react';
 import type { ChainID } from '@/types/chains';
 import type { Track } from '@/model/Track';
 import type { TracksContextInterface } from './types';
@@ -21,6 +21,16 @@ export const TracksProvider = ({ children }: { children: React.ReactNode }) => {
   /// Chain ID for currently rendered tracks.
   const [activeChainId, setActiveChainId] = useState<ChainID>('Polkadot');
 
+  /// Ref to indicate if data has been fetched and cached.
+  const dataCachedRef = useRef(false);
+
+  /// Accessors for for cached ref.
+  const getDataCached = (): boolean => dataCachedRef.current;
+
+  const setDataCached = (cached: boolean) => {
+    dataCachedRef.current = cached;
+  };
+
   return (
     <TracksContext.Provider
       value={{
@@ -30,6 +40,8 @@ export const TracksProvider = ({ children }: { children: React.ReactNode }) => {
         setTracks,
         setFetchingTracks,
         setActiveChainId,
+        getDataCached,
+        setDataCached,
       }}
     >
       {children}

--- a/src/renderer/contexts/openGov/Tracks/types.ts
+++ b/src/renderer/contexts/openGov/Tracks/types.ts
@@ -11,4 +11,6 @@ export interface TracksContextInterface {
   setTracks: (tracks: Track[]) => void;
   setFetchingTracks: (fetching: boolean) => void;
   setActiveChainId: (chainId: ChainID) => void;
+  setDataCached: (cached: boolean) => void;
+  getDataCached: () => boolean;
 }

--- a/src/renderer/contexts/openGov/Tracks/types.ts
+++ b/src/renderer/contexts/openGov/Tracks/types.ts
@@ -8,9 +8,9 @@ export interface TracksContextInterface {
   tracks: Track[];
   fetchingTracks: boolean;
   activeChainId: ChainID;
+  fetchTracksData: (chainId: ChainID) => void;
+  receiveTracksData: (data: Track[]) => void;
   setTracks: (tracks: Track[]) => void;
   setFetchingTracks: (fetching: boolean) => void;
   setActiveChainId: (chainId: ChainID) => void;
-  setDataCached: (cached: boolean) => void;
-  getDataCached: () => boolean;
 }

--- a/src/renderer/contexts/openGov/Treasury/default.ts
+++ b/src/renderer/contexts/openGov/Treasury/default.ts
@@ -19,4 +19,5 @@ export const defaultTreasuryContext: TreasuryContextInterface = {
   getFormattedSpendPeriod: () => '',
   getSpendPeriodProgress: () => '',
   getFormattedRemainingSpendPeriod: () => '',
+  refetchStats: () => {},
 };

--- a/src/renderer/contexts/openGov/Treasury/index.tsx
+++ b/src/renderer/contexts/openGov/Treasury/index.tsx
@@ -3,7 +3,7 @@
 
 import * as defaults from './default';
 import { Config as ConfigOpenGov } from '@/config/processes/openGov';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useRef, useState } from 'react';
 import { encodeAddress } from '@polkadot/util-crypto';
 import BigNumber from 'bignumber.js';
 import { rmCommas } from '@w3ux/utils';
@@ -50,8 +50,15 @@ export const TreasuryProvider = ({
     new BigNumber(0)
   );
 
+  /// Ref to indicate if data is has been fetched and cached.
+  const dataCachedRef = useRef(false);
+
   /// Initialize context when OpenGov window loads.
   const initTreasury = (chainId: ChainID) => {
+    if (dataCachedRef.current && chainId === treasuryChainId) {
+      return;
+    }
+
     setFetchingTreasuryData(true);
     setTreasuryChainId(chainId);
 
@@ -83,6 +90,9 @@ export const TreasuryProvider = ({
     );
 
     setFetchingTreasuryData(false);
+
+    // Update cached flag.
+    dataCachedRef.current = true;
   };
 
   /// Getter for the encoded treasury address.

--- a/src/renderer/contexts/openGov/Treasury/index.tsx
+++ b/src/renderer/contexts/openGov/Treasury/index.tsx
@@ -69,6 +69,16 @@ export const TreasuryProvider = ({
     });
   };
 
+  /// Re-fetch treasury stats.
+  const refetchStats = () => {
+    setFetchingTreasuryData(true);
+
+    ConfigOpenGov.portOpenGov.postMessage({
+      task: 'openGov:treasury:init',
+      data: { chainId: treasuryChainId },
+    });
+  };
+
   /// Setter for treasury public key.
   const setTreasuryData = (data: AnyData) => {
     const {
@@ -176,6 +186,7 @@ export const TreasuryProvider = ({
         getFormattedSpendPeriod,
         getSpendPeriodProgress,
         getFormattedRemainingSpendPeriod,
+        refetchStats,
       }}
     >
       {children}

--- a/src/renderer/contexts/openGov/Treasury/types.ts
+++ b/src/renderer/contexts/openGov/Treasury/types.ts
@@ -19,4 +19,5 @@ export interface TreasuryContextInterface {
   getFormattedSpendPeriod: () => string;
   getSpendPeriodProgress: () => string;
   getFormattedRemainingSpendPeriod: () => string;
+  refetchStats: () => void;
 }

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -14,8 +14,16 @@ import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const useOpenGovMessagePorts = () => {
   const { setIsConnected } = useConnections();
-  const { setTracks, setFetchingTracks, setDataCached } = useTracks();
-  const { setReferenda, setFetchingReferenda } = useReferenda();
+  const {
+    setTracks,
+    setFetchingTracks,
+    setDataCached: setTracksDataCached,
+  } = useTracks();
+  const {
+    setReferenda,
+    setFetchingReferenda,
+    setDataCached: setReferendaDataCached,
+  } = useReferenda();
   const { setTreasuryData } = useTreasury();
   const {
     addReferendaSubscription,
@@ -45,7 +53,7 @@ export const useOpenGovMessagePorts = () => {
             case 'openGov:tracks:receive': {
               setTracks(getTracks(ev.data.data.result));
               setFetchingTracks(false);
-              setDataCached(true);
+              setTracksDataCached(true);
               break;
             }
             case 'openGov:referenda:receive': {
@@ -54,6 +62,7 @@ export const useOpenGovMessagePorts = () => {
 
               setReferenda(parsed);
               setFetchingReferenda(false);
+              setReferendaDataCached(true);
               break;
             }
             case 'openGov:treasury:set': {

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -14,7 +14,7 @@ import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const useOpenGovMessagePorts = () => {
   const { setIsConnected } = useConnections();
-  const { setTracks, setFetchingTracks } = useTracks();
+  const { setTracks, setFetchingTracks, setDataCached } = useTracks();
   const { setReferenda, setFetchingReferenda } = useReferenda();
   const { setTreasuryData } = useTreasury();
   const {
@@ -45,6 +45,7 @@ export const useOpenGovMessagePorts = () => {
             case 'openGov:tracks:receive': {
               setTracks(getTracks(ev.data.data.result));
               setFetchingTracks(false);
+              setDataCached(true);
               break;
             }
             case 'openGov:referenda:receive': {

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -14,13 +14,11 @@ import type { IntervalSubscription } from '@/types/subscriptions';
 
 export const useOpenGovMessagePorts = () => {
   const { setIsConnected } = useConnections();
-  const {
-    setTracks,
-    setFetchingTracks,
-    setDataCached: setTracksDataCached,
-  } = useTracks();
+
+  const { receiveTracksData } = useTracks();
   const { receiveReferendaData } = useReferenda();
   const { setTreasuryData } = useTreasury();
+
   const {
     addReferendaSubscription,
     updateReferendaSubscription,
@@ -47,9 +45,7 @@ export const useOpenGovMessagePorts = () => {
               break;
             }
             case 'openGov:tracks:receive': {
-              setTracks(getTracks(ev.data.data.result));
-              setFetchingTracks(false);
-              setTracksDataCached(true);
+              receiveTracksData(getTracks(ev.data.data.result));
               break;
             }
             case 'openGov:referenda:receive': {

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -19,11 +19,7 @@ export const useOpenGovMessagePorts = () => {
     setFetchingTracks,
     setDataCached: setTracksDataCached,
   } = useTracks();
-  const {
-    setReferenda,
-    setFetchingReferenda,
-    setDataCached: setReferendaDataCached,
-  } = useReferenda();
+  const { receiveReferendaData } = useReferenda();
   const { setTreasuryData } = useTreasury();
   const {
     addReferendaSubscription,
@@ -59,10 +55,7 @@ export const useOpenGovMessagePorts = () => {
             case 'openGov:referenda:receive': {
               const { json } = ev.data.data;
               const parsed: ActiveReferendaInfo[] = JSON.parse(json);
-
-              setReferenda(parsed);
-              setFetchingReferenda(false);
-              setReferendaDataCached(true);
+              receiveReferendaData(parsed);
               break;
             }
             case 'openGov:treasury:set': {

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -13,16 +13,18 @@ import { Config as ConfigOpenGov } from '@/config/processes/openGov';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import {
   faCaretLeft,
+  faDownFromDottedLine,
   faLayerGroup,
   faLineHeight,
   faTimer,
 } from '@fortawesome/pro-solid-svg-icons';
 import { useConnections } from '@/renderer/contexts/common/Connections';
+import { useEffect, useState } from 'react';
 import { useReferenda } from '@/renderer/contexts/openGov/Referenda';
+import { useTooltip } from '@/renderer/contexts/common/Tooltip';
+import { getSpacedOrigin } from '@/renderer/utils/openGovUtils';
 import { ReferendumRow } from './ReferendumRow';
 import { ReferendaGroup, StickyHeadings } from './Wrappers';
-import { useEffect, useState } from 'react';
-import { getSpacedOrigin } from '@/renderer/utils/openGovUtils';
 import {
   renderPlaceholders,
   ControlsWrapper,
@@ -32,16 +34,19 @@ import {
 } from '@/renderer/utils/common';
 import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCaretHeaders';
 
-export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
+export const Referenda = ({ setSection }: ReferendaProps) => {
   const {
     referenda,
     fetchingReferenda,
+    refetchReferenda,
     setFetchingReferenda,
     getSortedActiveReferenda,
     getCategorisedReferenda,
+    activeReferendaChainId: chainId,
   } = useReferenda();
 
   const { isConnected } = useConnections();
+  const { setTooltipTextAndOpen } = useTooltip();
 
   /// Sorting controls state.
   const [newestFirst, setNewestFirst] = useState(true);
@@ -85,6 +90,11 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
       });
     }
   }, [isConnected]);
+
+  /// Re-fetch referenda when user clicks refresh button.
+  const handleRefetchReferenda = () => {
+    refetchReferenda();
+  };
 
   /// Utility for making expand button dynamic.
   const isExpandActive = () =>
@@ -213,6 +223,26 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
               onLabel="All Expanded"
               offLabel="Collapsed"
             />
+
+            <div
+              className="tooltip-trigger-element"
+              data-tooltip-text={
+                isConnected ? 'Refresh Referenda' : 'Currently Offline'
+              }
+              onMouseMove={() =>
+                setTooltipTextAndOpen(
+                  isConnected ? 'Refresh Referenda' : 'Currently Offline'
+                )
+              }
+            >
+              <SortControlButton
+                isActive={true}
+                isDisabled={fetchingReferenda || !isConnected}
+                onClick={() => handleRefetchReferenda()}
+                faIcon={faDownFromDottedLine}
+                fixedWidth={false}
+              />
+            </div>
           </ControlsWrapper>
 
           {/* Sticky Headings */}
@@ -224,7 +254,7 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
                   <div className="heading">Origin</div>
                 </div>
                 <div className="right">
-                  <div className="heading">OpenGov Portal Links</div>
+                  <div className="heading">Portal Links</div>
                   <div className="heading">Subscriptions</div>
                 </div>
               </div>
@@ -262,7 +292,9 @@ export const Referenda = ({ setSection, chainId }: ReferendaProps) => {
             </div>
             <div className="footer-stat">
               <h2>Active Referenda:</h2>
-              <span>{fetchingReferenda ? '-' : referenda.length}</span>
+              <span style={{ minWidth: '14px' }}>
+                {fetchingReferenda ? '-' : referenda.length}
+              </span>
             </div>
           </section>
         </div>

--- a/src/renderer/screens/OpenGov/Tracks/index.tsx
+++ b/src/renderer/screens/OpenGov/Tracks/index.tsx
@@ -27,11 +27,16 @@ import {
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
 import type { TracksProps } from '../types';
 
-export const Tracks = ({ setSection, chainId }: TracksProps) => {
-  /// Context data.
-  const { tracks, fetchingTracks, setFetchingTracks } = useTracks();
+export const Tracks = ({ setSection }: TracksProps) => {
   const { openHelp } = useHelp();
   const { isConnected } = useConnections();
+
+  const {
+    activeChainId: chainId,
+    fetchingTracks,
+    tracks,
+    setFetchingTracks,
+  } = useTracks();
 
   /// Controls state.
   const [sortIdAscending, setSortIdAscending] = useState(true);

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -320,15 +320,25 @@ export const OpenGov: React.FC = () => {
                           offLabel="Kusama"
                         />
                       )}
-                      <SortControlButton
-                        isActive={true}
-                        isDisabled={fetchingTreasuryData || !isConnected}
-                        onClick={() => refetchTreasuryStats()}
-                        onLabel=""
-                        offLabel=""
-                        faIcon={faDownFromDottedLine}
-                        fixedWidth={false}
-                      />
+                      <div
+                        className="tooltip-trigger-element"
+                        data-tooltip-text={
+                          isConnected ? 'Refresh Stats' : 'Currently Offline'
+                        }
+                        onMouseMove={() =>
+                          setTooltipTextAndOpen(
+                            isConnected ? 'Refresh Stats' : 'Currently Offline'
+                          )
+                        }
+                      >
+                        <SortControlButton
+                          isActive={true}
+                          isDisabled={fetchingTreasuryData || !isConnected}
+                          onClick={() => refetchTreasuryStats()}
+                          faIcon={faDownFromDottedLine}
+                          fixedWidth={false}
+                        />
+                      </div>
                     </ControlsWrapper>
                   </span>
                 </div>

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -55,7 +55,9 @@ export const OpenGov: React.FC = () => {
   const { setTooltipTextAndOpen } = useTooltip();
 
   /// Tracks context.
-  const { setFetchingTracks, setActiveChainId, activeChainId } = useTracks();
+  const { setFetchingTracks, setActiveChainId, activeChainId, getDataCached } =
+    useTracks();
+
   const {
     setFetchingReferenda,
     setActiveReferendaChainId,
@@ -94,7 +96,7 @@ export const OpenGov: React.FC = () => {
     setSectionContent('tracks');
     setActiveChainId(chainId);
 
-    if (isConnected) {
+    if (isConnected && (!getDataCached() || activeChainId !== chainId)) {
       setFetchingTracks(true);
 
       // Request tracks data from main renderer.

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -54,10 +54,8 @@ export const OpenGov: React.FC = () => {
   const { openHelp } = useHelp();
   const { setTooltipTextAndOpen } = useTooltip();
 
-  /// Tracks context.
-  const { setFetchingTracks, setActiveChainId, activeChainId, getDataCached } =
-    useTracks();
-
+  /// Tracks and referenda contexts.
+  const { fetchTracksData } = useTracks();
   const { fetchReferendaData } = useReferenda();
 
   /// Section state.
@@ -90,20 +88,7 @@ export const OpenGov: React.FC = () => {
   /// Open origins and tracks information.
   const handleOpenTracks = (chainId: ChainID) => {
     setSectionContent('tracks');
-    setActiveChainId(chainId);
-
-    if (isConnected && (!getDataCached() || activeChainId !== chainId)) {
-      setFetchingTracks(true);
-
-      // Request tracks data from main renderer.
-      ConfigOpenGov.portOpenGov.postMessage({
-        task: 'openGov:tracks:get',
-        data: {
-          chainId,
-        },
-      });
-    }
-
+    fetchTracksData(chainId);
     setSection(1);
   };
 
@@ -331,9 +316,7 @@ export const OpenGov: React.FC = () => {
 
         {/* Section 2 */}
         <section className="carousel-section-wrapper">
-          {sectionContent === 'tracks' && (
-            <Tracks setSection={setSection} chainId={activeChainId} />
-          )}
+          {sectionContent === 'tracks' && <Tracks setSection={setSection} />}
           {sectionContent === 'referenda' && (
             <Referenda setSection={setSection} />
           )}

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -58,11 +58,7 @@ export const OpenGov: React.FC = () => {
   const { setFetchingTracks, setActiveChainId, activeChainId, getDataCached } =
     useTracks();
 
-  const {
-    setFetchingReferenda,
-    setActiveReferendaChainId,
-    activeReferendaChainId,
-  } = useReferenda();
+  const { fetchReferendaData, activeReferendaChainId } = useReferenda();
 
   /// Section state.
   const [section, setSection] = useState<number>(0);
@@ -116,22 +112,10 @@ export const OpenGov: React.FC = () => {
     refetchStats();
   };
 
-  /// Open proposals.
+  /// Open referenda.
   const handleOpenReferenda = (chainId: ChainID) => {
     setSectionContent('referenda');
-    setActiveReferendaChainId(chainId);
-
-    if (isConnected) {
-      setFetchingReferenda(true);
-
-      ConfigOpenGov.portOpenGov.postMessage({
-        task: 'openGov:referenda:get',
-        data: {
-          chainId,
-        },
-      });
-    }
-
+    fetchReferendaData(chainId);
     setSection(1);
   };
 

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -58,7 +58,7 @@ export const OpenGov: React.FC = () => {
   const { setFetchingTracks, setActiveChainId, activeChainId, getDataCached } =
     useTracks();
 
-  const { fetchReferendaData, activeReferendaChainId } = useReferenda();
+  const { fetchReferendaData } = useReferenda();
 
   /// Section state.
   const [section, setSection] = useState<number>(0);
@@ -335,10 +335,7 @@ export const OpenGov: React.FC = () => {
             <Tracks setSection={setSection} chainId={activeChainId} />
           )}
           {sectionContent === 'referenda' && (
-            <Referenda
-              setSection={setSection}
-              chainId={activeReferendaChainId}
-            />
+            <Referenda setSection={setSection} />
           )}
         </section>
       </ModalMotionTwoSection>

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -18,7 +18,7 @@ import { useReferenda } from '@/renderer/contexts/openGov/Referenda';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
 import { useTreasury } from '@/renderer/contexts/openGov/Treasury';
 import { OpenGovCard, TreasuryStats } from './Wrappers';
-import { faInfo } from '@fortawesome/pro-solid-svg-icons';
+import { faInfo, faDownFromDottedLine } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import type { ChainID } from '@/types/chains';
@@ -47,6 +47,7 @@ export const OpenGov: React.FC = () => {
     getFormattedNextBurn,
     getFormattedToBeAwarded,
     getSpendPeriodProgress,
+    refetchStats,
   } = useTreasury();
 
   /// Help overlay and tooltip.
@@ -106,6 +107,11 @@ export const OpenGov: React.FC = () => {
     }
 
     setSection(1);
+  };
+
+  /// Re-fetch treasury stats when user clicks refresh button.
+  const refetchTreasuryStats = () => {
+    refetchStats();
   };
 
   /// Open proposals.
@@ -314,6 +320,15 @@ export const OpenGov: React.FC = () => {
                           offLabel="Kusama"
                         />
                       )}
+                      <SortControlButton
+                        isActive={true}
+                        isDisabled={fetchingTreasuryData || !isConnected}
+                        onClick={() => refetchTreasuryStats()}
+                        onLabel=""
+                        offLabel=""
+                        faIcon={faDownFromDottedLine}
+                        fixedWidth={false}
+                      />
                     </ControlsWrapper>
                   </span>
                 </div>

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -144,9 +144,11 @@ export const OpenGov: React.FC = () => {
   );
 
   /// Handle changing treasury stats.
-  const handleChangeStats = () => {
-    const target = treasuryChainId === 'Polkadot' ? 'Kusama' : 'Polkadot';
-    initTreasury(target);
+  const handleChangeStats = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const target = event.target.value as ChainID;
+    if (target !== treasuryChainId) {
+      initTreasury(target);
+    }
   };
 
   /// Wrap some market around a tooltip if offline mode.
@@ -294,32 +296,26 @@ export const OpenGov: React.FC = () => {
           <StatsFooter $chainId={'Polkadot'}>
             <div>
               <section className="left">
-                <div className="footer-stat">
+                <div className="footer-stat" style={{ columnGap: '0' }}>
                   <h2>Treasury Stats:</h2>
                   <span style={{ marginLeft: '1rem' }}>
                     <ControlsWrapper style={{ marginBottom: '0' }}>
+                      {/* Select Box */}
                       {wrapWithOfflineTooltip(
-                        <SortControlButton
-                          isActive={treasuryChainId === 'Polkadot'}
-                          isDisabled={
-                            treasuryChainId === 'Polkadot' || !isConnected
-                          }
-                          onClick={() => handleChangeStats()}
-                          onLabel="Polkadot"
-                          offLabel="Polkadot"
-                        />
+                        <div className="select-wrapper">
+                          <select
+                            disabled={!isConnected}
+                            id="select-treasury-chain"
+                            value={treasuryChainId}
+                            onChange={(e) => handleChangeStats(e)}
+                          >
+                            <option value="Polkadot">Polkadot</option>
+                            <option value="Kusama">Kusama</option>
+                          </select>
+                        </div>
                       )}
-                      {wrapWithOfflineTooltip(
-                        <SortControlButton
-                          isActive={treasuryChainId === 'Kusama'}
-                          isDisabled={
-                            treasuryChainId === 'Kusama' || !isConnected
-                          }
-                          onClick={() => handleChangeStats()}
-                          onLabel="Kusama"
-                          offLabel="Kusama"
-                        />
-                      )}
+
+                      {/* Re-fetch Stats */}
                       <div
                         className="tooltip-trigger-element"
                         data-tooltip-text={

--- a/src/renderer/screens/OpenGov/types.ts
+++ b/src/renderer/screens/OpenGov/types.ts
@@ -16,7 +16,6 @@ export interface TrackRowProps {
 
 export interface ReferendaProps {
   setSection: (section: number) => void;
-  chainId: ChainID;
 }
 
 export interface ReferendumRowProps {

--- a/src/renderer/screens/OpenGov/types.ts
+++ b/src/renderer/screens/OpenGov/types.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { Track } from '@/model/Track';
-import type { ChainID } from '@/types/chains';
 import type { ActiveReferendaInfo } from '@/types/openGov';
 
 export interface TracksProps {
   setSection: (section: number) => void;
-  chainId: ChainID;
 }
 
 export interface TrackRowProps {

--- a/src/renderer/utils/common.tsx
+++ b/src/renderer/utils/common.tsx
@@ -92,8 +92,8 @@ const LoadingPlaceholderWrapper = styled.div<{
 interface SortControlsButtonProps {
   isActive: boolean;
   isDisabled: boolean;
-  onLabel: string;
-  offLabel: string;
+  onLabel?: string;
+  offLabel?: string;
   fixedWidth?: boolean;
   onClick?: AnyFunction;
   faIcon?: IconDefinition;
@@ -104,8 +104,8 @@ export const SortControlButton: React.FC<SortControlsButtonProps> = ({
   isDisabled,
   onClick,
   faIcon,
-  onLabel,
-  offLabel,
+  onLabel = '',
+  offLabel = '',
   fixedWidth = true,
 }: SortControlsButtonProps) => {
   /// Utility to calculate button classes.

--- a/src/renderer/utils/common.tsx
+++ b/src/renderer/utils/common.tsx
@@ -94,6 +94,7 @@ interface SortControlsButtonProps {
   isDisabled: boolean;
   onLabel: string;
   offLabel: string;
+  fixedWidth?: boolean;
   onClick?: AnyFunction;
   faIcon?: IconDefinition;
 }
@@ -105,12 +106,15 @@ export const SortControlButton: React.FC<SortControlsButtonProps> = ({
   faIcon,
   onLabel,
   offLabel,
+  fixedWidth = true,
 }: SortControlsButtonProps) => {
   /// Utility to calculate button classes.
   const getButtonClass = () => {
     const classes = ['icon-wrapper'];
+    fixedWidth && classes.push('fixed');
     isActive && classes.push('active');
     isDisabled && classes.push('disable');
+    onLabel === '' && offLabel === '' && classes.push('icon-only');
     return classes.join(' ');
   };
 
@@ -205,7 +209,7 @@ export const ControlsWrapper = styled.div<{
     display: flex;
     column-gap: 0.75rem;
     align-items: center;
-    min-width: 120px;
+    min-width: auto;
 
     position: relative;
     border: 1px solid #535353;
@@ -218,6 +222,14 @@ export const ControlsWrapper = styled.div<{
     transition: opacity 0.1s ease-out;
     cursor: pointer;
 
+    &.fixed {
+      min-width: 120px !important;
+    }
+    &.icon-only {
+      .icon {
+        margin-left: 1.5rem !important;
+      }
+    }
     span {
       display: inline-block;
       padding-right: 0.7rem;

--- a/src/renderer/utils/common.tsx
+++ b/src/renderer/utils/common.tsx
@@ -257,7 +257,28 @@ export const ControlsWrapper = styled.div<{
       }
     }
     &.disable {
-      opacity: 0.25;
+      opacity: 0.4;
+    }
+  }
+
+  /* Select */
+  .select-wrapper {
+    display: flex;
+    align-items: center;
+    column-gap: 0.25rem;
+
+    border: 1px solid var(--border-secondary-color);
+    border-radius: 1.25rem;
+    padding: 0.35rem 1.5rem;
+    cursor: pointer;
+
+    select {
+      font-size: 1rem;
+      background-color: inherit;
+      color: #929292;
+      opacity: 0.8;
+      border: none;
+      cursor: pointer;
     }
   }
 `;


### PR DESCRIPTION
# Summary

## Checklist

### Treasury Stats

- [x] Treasury stats fetched once and cached.
- [x] Re-fetch treasury stats UI button added to footer.
- [x] Select box UI added to choose treasury stats chain (Polkadot or Kusama)

### Tracks

- [x] Tracks data fetched once and cached.
- [x] Re-fetch track data if different chain requested (Polkadot or Kusama).

###  Referenda

- [x] Referenda data fetched once until new chain is requested (Polkadot or Kusama).
- [x] Re-fetch referenda UI button added to controls.