### PR TITLE
chore: account import iteration

### DIFF
--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -22,6 +22,7 @@ import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/c
 import { AddressesProvider as ImportAddressesProvider } from '@app/contexts/import/Addresses';
 import { ImportHandlerProvider } from './contexts/import/ImportHandler';
 import { RemoveHandlerProvider } from './contexts/import/RemoveHandler';
+import { DeleteHandlerProvider } from './contexts/import/DeleteHandler';
 
 // Settings window contexts.
 import { SettingFlagsProvider } from './contexts/settings/SettingFlags';
@@ -69,7 +70,8 @@ const getProvidersForWindow = () => {
         ImportAddressesProvider,
         ImportAccountStatusesProvider,
         ImportHandlerProvider, // Requires useAccountStatuses + useAddresses
-        RemoveHandlerProvider // Requires useAddresses
+        RemoveHandlerProvider, // Requires useAddresses
+        DeleteHandlerProvider // Requires useAccountStatuses + useAddresses
       )(Theme);
     }
     case 'settings': {

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -21,6 +21,7 @@ import { IntervalSubscriptionsProvider } from './contexts/main/IntervalSubscript
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
 import { AddressesProvider as ImportAddressesProvider } from '@app/contexts/import/Addresses';
 import { ImportHandlerProvider } from './contexts/import/ImportHandler';
+import { RemoveHandlerProvider } from './contexts/import/RemoveHandler';
 
 // Settings window contexts.
 import { SettingFlagsProvider } from './contexts/settings/SettingFlags';
@@ -67,7 +68,8 @@ const getProvidersForWindow = () => {
         ConnectionsProvider,
         ImportAddressesProvider,
         ImportAccountStatusesProvider,
-        ImportHandlerProvider // Requires useAccountStatuses + useAddresses
+        ImportHandlerProvider, // Requires useAccountStatuses + useAddresses
+        RemoveHandlerProvider // Requires useAddresses
       )(Theme);
     }
     case 'settings': {

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -20,6 +20,7 @@ import { IntervalSubscriptionsProvider } from './contexts/main/IntervalSubscript
 // Import window contexts.
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
 import { AddressesProvider as ImportAddressesProvider } from '@app/contexts/import/Addresses';
+import { ImportHandlerProvider } from './contexts/import/ImportHandler';
 
 // Settings window contexts.
 import { SettingFlagsProvider } from './contexts/settings/SettingFlags';
@@ -65,7 +66,8 @@ const getProvidersForWindow = () => {
         TooltipProvider,
         ConnectionsProvider,
         ImportAddressesProvider,
-        ImportAccountStatusesProvider
+        ImportAccountStatusesProvider,
+        ImportHandlerProvider // Requires useAccountStatuses + useAddresses
       )(Theme);
     }
     case 'settings': {

--- a/src/renderer/contexts/import/Addresses/types.ts
+++ b/src/renderer/contexts/import/Addresses/types.ts
@@ -7,8 +7,10 @@ export interface AddressesContextInterface {
   ledgerAddresses: LedgerLocalAddress[];
   readOnlyAddresses: LocalAddress[];
   vaultAddresses: LocalAddress[];
-  setLedgerAddresses: (a: LedgerLocalAddress[]) => void;
-  setReadOnlyAddresses: (a: LocalAddress[]) => void;
-  setVaultAddresses: (a: LocalAddress[]) => void;
+  setLedgerAddresses: React.Dispatch<
+    React.SetStateAction<LedgerLocalAddress[]>
+  >;
+  setReadOnlyAddresses: React.Dispatch<React.SetStateAction<LocalAddress[]>>;
+  setVaultAddresses: React.Dispatch<React.SetStateAction<LocalAddress[]>>;
   importAccountJson: (a: LocalAddress) => void;
 }

--- a/src/renderer/contexts/import/DeleteHandler/defaults.ts
+++ b/src/renderer/contexts/import/DeleteHandler/defaults.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { DeleteHandlerContextInterface } from './types';
+
+export const defaultDeleteHandlerContext: DeleteHandlerContextInterface = {
+  handleDeleteAddress: () => false,
+};

--- a/src/renderer/contexts/import/DeleteHandler/index.tsx
+++ b/src/renderer/contexts/import/DeleteHandler/index.tsx
@@ -1,0 +1,147 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { Config as ConfigImport } from '@/config/processes/import';
+import { createContext, useContext } from 'react';
+import { useAccountStatuses } from '../AccountStatuses';
+import { useAddresses } from '@app/contexts/import/Addresses';
+import { getAddressChainId } from '@/renderer/Utils';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
+import type { DeleteHandlerContextInterface } from './types';
+
+export const DeleteHandlerContext =
+  createContext<DeleteHandlerContextInterface>(
+    defaults.defaultDeleteHandlerContext
+  );
+
+export const useDeleteHandler = () => useContext(DeleteHandlerContext);
+
+export const DeleteHandlerProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { deleteAccountStatus } = useAccountStatuses();
+  const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
+    useAddresses();
+
+  /// Exposed function to delete an address.
+  const handleDeleteAddress = (
+    address: string,
+    source: AccountSource
+  ): boolean => {
+    // Remove status entry from account statuses context.
+    deleteAccountStatus(address, source);
+
+    let goBack = false;
+
+    if (source === 'vault') {
+      goBack = handleDeleteVaultAddress(address, source);
+    } else if (source === 'ledger') {
+      goBack = handleDeleteLedgerAddress(address, source);
+    } else if (source === 'read-only') {
+      goBack = handleDeleteReadOnlyAddress(address, source);
+    }
+
+    return goBack;
+  };
+
+  /// Handle deletion of a read-only address.
+  const handleDeleteReadOnlyAddress = (
+    address: string,
+    source: AccountSource
+  ): boolean => {
+    // Update import window's managed address state and local storage.
+    setReadOnlyAddresses((prevState: LocalAddress[]) => {
+      const newAddresses = prevState.filter(
+        (a: LocalAddress) => a.address !== address
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressDeleteMessage(address);
+    return false;
+  };
+
+  /// Handle deletion of a vault address.
+  const handleDeleteVaultAddress = (
+    address: string,
+    source: AccountSource
+  ): boolean => {
+    let goBack = false;
+
+    // Update import window's managed address state and local storage.
+    setVaultAddresses((prevState: LocalAddress[]) => {
+      const newAddresses = prevState.filter(
+        (a: LocalAddress) => a.address !== address
+      );
+
+      newAddresses.length === 0 && (goBack = true);
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressDeleteMessage(address);
+    return goBack;
+  };
+
+  /// Handle deletion of a ledger address.
+  const handleDeleteLedgerAddress = (
+    address: string,
+    source: AccountSource
+  ): boolean => {
+    // Update import window's managed address state and local storage.
+    setLedgerAddresses((prevState: LedgerLocalAddress[]) => {
+      const newAddresses = prevState.filter(
+        (a: LedgerLocalAddress) => a.address !== address
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressDeleteMessage(address);
+    return false;
+  };
+
+  /// Send address data to main window to process removal.
+  const postAddressDeleteMessage = (address: string) => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:address:delete',
+      data: {
+        address,
+        chainId: getAddressChainId(address),
+      },
+    });
+  };
+
+  return (
+    <DeleteHandlerContext.Provider
+      value={{
+        handleDeleteAddress,
+      }}
+    >
+      {children}
+    </DeleteHandlerContext.Provider>
+  );
+};

--- a/src/renderer/contexts/import/DeleteHandler/types.ts
+++ b/src/renderer/contexts/import/DeleteHandler/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AccountSource } from '@/types/accounts';
+
+export interface DeleteHandlerContextInterface {
+  handleDeleteAddress: (address: string, source: AccountSource) => boolean;
+}

--- a/src/renderer/contexts/import/ImportHandler/defaults.ts
+++ b/src/renderer/contexts/import/ImportHandler/defaults.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { ImportHandlerContextInterface } from './types';
+
+export const defaultImportHandlerContext: ImportHandlerContextInterface = {
+  handleImportAddress: () => {},
+};

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -1,0 +1,146 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { Config as ConfigImport } from '@/config/processes/import';
+import { getAddressChainId } from '@/renderer/Utils';
+import { createContext, useContext } from 'react';
+import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
+import { useAddresses } from '@app/contexts/import/Addresses';
+import type { ImportHandlerContextInterface } from './types';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
+
+export const ImportHandlerContext =
+  createContext<ImportHandlerContextInterface>(
+    defaults.defaultImportHandlerContext
+  );
+
+export const useImportHandler = () => useContext(ImportHandlerContext);
+
+export const ImportHandlerProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { setStatusForAccount } = useAccountStatuses();
+  const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
+    useAddresses();
+
+  /// Exposed function to import an address.
+  const handleImportAddress = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    // Set processing flag for account.
+    setStatusForAccount(address, source, true);
+
+    // Process account import in main renderer.
+    if (source === 'vault') {
+      handleVaultImport(address, source, accountName);
+    } else if (source === 'ledger') {
+      handleLedgerImport(address, source, accountName);
+    } else if (source === 'read-only') {
+      handleReadOnlyImport(address, source, accountName);
+    }
+  };
+
+  /// Handle a read-only address import.
+  const handleReadOnlyImport = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    setReadOnlyAddresses((prev: LocalAddress[]) => {
+      const newAddresses: LocalAddress[] = prev.map((a: LocalAddress) =>
+        a.address === address ? { ...a, isImported: true } : a
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressToMainWindow(address, source, accountName);
+  };
+
+  /// Handle a vault address import.
+  const handleVaultImport = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    // Update import window's managed address state and local storage.
+    setVaultAddresses((prev: LocalAddress[]) => {
+      const newAddresses = prev.map((a: LocalAddress) =>
+        a.address === address ? { ...a, isImported: true } : a
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressToMainWindow(address, source, accountName);
+  };
+
+  /// Handle a ledger address import.
+  const handleLedgerImport = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    // Update import window's managed address state and local storage.
+    setLedgerAddresses((prev: LedgerLocalAddress[]) => {
+      const newAddresses = prev.map((a: LedgerLocalAddress) =>
+        a.address === address ? { ...a, isImported: true } : a
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressToMainWindow(address, source, accountName);
+  };
+
+  /// Send address data to main window to process.
+  const postAddressToMainWindow = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:address:import',
+      data: {
+        chainId: getAddressChainId(address),
+        source,
+        address,
+        name: accountName,
+      },
+    });
+  };
+
+  return (
+    <ImportHandlerContext.Provider
+      value={{
+        handleImportAddress,
+      }}
+    >
+      {children}
+    </ImportHandlerContext.Provider>
+  );
+};

--- a/src/renderer/contexts/import/ImportHandler/types.ts
+++ b/src/renderer/contexts/import/ImportHandler/types.ts
@@ -1,0 +1,12 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AccountSource } from '@/types/accounts';
+
+export interface ImportHandlerContextInterface {
+  handleImportAddress: (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => void;
+}

--- a/src/renderer/contexts/import/RemoveHandler/defaults.ts
+++ b/src/renderer/contexts/import/RemoveHandler/defaults.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { RemoveHandlerContextInterface } from './types';
+
+export const defaultRemoveHandlerContext: RemoveHandlerContextInterface = {
+  handleRemoveAddress: () => {},
+};

--- a/src/renderer/contexts/import/RemoveHandler/index.tsx
+++ b/src/renderer/contexts/import/RemoveHandler/index.tsx
@@ -1,0 +1,125 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { Config as ConfigImport } from '@/config/processes/import';
+import { getAddressChainId } from '@/renderer/Utils';
+import { createContext, useContext } from 'react';
+import { useAddresses } from '@app/contexts/import/Addresses';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
+import type { RemoveHandlerContextInterface } from './types';
+
+export const RemoveHandlerContext =
+  createContext<RemoveHandlerContextInterface>(
+    defaults.defaultRemoveHandlerContext
+  );
+
+export const useRemoveHandler = () => useContext(RemoveHandlerContext);
+
+export const RemoveHandlerProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
+    useAddresses();
+
+  /// Exposed function to remove an address.
+  const handleRemoveAddress = (address: string, source: AccountSource) => {
+    if (source === 'vault') {
+      handleRemoveVaultAddress(address, source);
+    } else if (source === 'ledger') {
+      handleRemoveLedgerAddress(address, source);
+    } else if (source === 'read-only') {
+      handleRemoveReadOnlyAddress(address, source);
+    }
+  };
+
+  // Handle removal of a read-only address.
+  const handleRemoveReadOnlyAddress = (
+    address: string,
+    source: AccountSource
+  ) => {
+    // Update import window's managed address state and local storage.
+    setReadOnlyAddresses((prevState: LocalAddress[]) => {
+      const newAddresses = prevState.map((a: LocalAddress) =>
+        a.address === address ? { ...a, isImported: false } : a
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressToMainWindow(address);
+  };
+
+  /// Handle removal of a vault address.
+  const handleRemoveVaultAddress = (address: string, source: AccountSource) => {
+    // Update import window's managed address state and local storage.
+    setVaultAddresses((prevState: LocalAddress[]) => {
+      const newAddresses = prevState.map((a: LocalAddress) =>
+        a.address === address ? { ...a, isImported: false } : a
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressToMainWindow(address);
+  };
+
+  /// Handle removal of a ledger address.
+  const handleRemoveLedgerAddress = (
+    address: string,
+    source: AccountSource
+  ) => {
+    // Update import window's managed address state and local storage.
+    setLedgerAddresses((prevState: LedgerLocalAddress[]) => {
+      const newAddresses = prevState.map((a: LedgerLocalAddress) =>
+        a.address === address ? { ...a, isImported: false } : a
+      );
+
+      localStorage.setItem(
+        ConfigImport.getStorageKey(source),
+        JSON.stringify(newAddresses)
+      );
+
+      return newAddresses;
+    });
+
+    postAddressToMainWindow(address);
+  };
+
+  /// Send address data to main window to process removal.
+  const postAddressToMainWindow = (address: string) => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:address:remove',
+      data: {
+        address,
+        chainId: getAddressChainId(address),
+      },
+    });
+  };
+
+  return (
+    <RemoveHandlerContext.Provider
+      value={{
+        handleRemoveAddress,
+      }}
+    >
+      {children}
+    </RemoveHandlerContext.Provider>
+  );
+};

--- a/src/renderer/contexts/import/RemoveHandler/types.ts
+++ b/src/renderer/contexts/import/RemoveHandler/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AccountSource } from '@/types/accounts';
+
+export interface RemoveHandlerContextInterface {
+  handleRemoveAddress: (address: string, source: AccountSource) => void;
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -10,6 +10,7 @@ import '@app/theme/accents/polkadot-relay.css';
 // App styles.
 import './theme/theme.scss';
 import './theme/index.scss';
+import './theme/utils.scss';
 
 // Library styles.
 import './kits/Buttons/index.scss';

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -14,36 +14,35 @@ import { Identicon } from '@app/library/Identicon';
 import { useState } from 'react';
 import { renderToast, validateAccountName } from '@/renderer/utils/ImportUtils';
 import { Wrapper } from './Wrapper';
-import type { FormEvent } from 'react';
-import type { HardwareAddressProps } from './types';
 import { getAddressChainId } from '@/renderer/Utils';
+import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useConnections } from '@/renderer/contexts/common/Connections';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
+import type { FormEvent } from 'react';
+import type { HardwareAddressProps } from './types';
 
 export const HardwareAddress = ({
   address,
+  source,
   index,
   isImported,
   orderData,
-  isProcessing,
   accountName,
   renameHandler,
   openConfirmHandler,
   openRemoveHandler,
   openDeleteHandler,
 }: HardwareAddressProps) => {
+  const { setTooltipTextAndOpen } = useTooltip();
+  const { isConnected } = useConnections();
+  const { getStatusForAccount } = useAccountStatuses();
+
   // Store whether this address is being edited.
   const [editing, setEditing] = useState<boolean>(false);
 
   // Store the currently edited name and validation errors flag.
   const [editName, setEditName] = useState<string>(accountName);
-
-  // Get app connection status.
-  const { isConnected } = useConnections();
-
-  // Use tool tip.
-  const { setTooltipTextAndOpen } = useTooltip();
 
   // Cancel button clicked for edit input.
   const cancelEditing = () => {
@@ -91,6 +90,9 @@ export const HardwareAddress = ({
     const ChainIcon = chainIcon(chainId);
     return <ChainIcon className={editing ? 'chain-icon' : 'chain-icon fade'} />;
   };
+
+  // Utility to get processing status.
+  const isProcessing = () => getStatusForAccount(address, source) || false;
 
   // Function to render wrapper JSX.
   const renderContent = () => (
@@ -155,7 +157,7 @@ export const HardwareAddress = ({
 
       {/* Account buttons */}
       <div className="action">
-        {isImported && !isProcessing ? (
+        {isImported && !isProcessing() ? (
           <div
             style={{ position: 'relative' }}
             className="tooltip-trigger-element"
@@ -185,14 +187,14 @@ export const HardwareAddress = ({
               iconLeft={faDownFromDottedLine}
               iconTransform="grow-2"
               text={''}
-              onClick={() => !isProcessing && openConfirmHandler()}
+              onClick={() => !isProcessing() && openConfirmHandler()}
               className={
-                isProcessing
+                isProcessing()
                   ? 'account-action-btn processing'
                   : 'account-action-btn green-hover'
               }
             />
-            {isProcessing && (
+            {isProcessing() && (
               <div
                 style={{ position: 'absolute', left: '3px', top: '8px' }}
                 className="lds-ellipsis"

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -113,6 +113,7 @@ export const HardwareAddress = ({
                 </h5>
                 <input
                   type="text"
+                  disabled={isProcessing()}
                   value={editing ? editName : accountName}
                   onChange={(e) => handleChange(e)}
                   onFocus={() => setEditing(true)}
@@ -124,7 +125,7 @@ export const HardwareAddress = ({
                   }}
                 />
 
-                {editing && (
+                {editing && !isProcessing() && (
                   <div style={{ display: 'flex' }}>
                     &nbsp;
                     <button
@@ -213,6 +214,7 @@ export const HardwareAddress = ({
           onMouseMove={() => setTooltipTextAndOpen('Delete')}
         >
           <ButtonMono
+            disabled={isProcessing()}
             className="account-action-btn red-hover"
             iconLeft={faTrash}
             iconTransform="shrink-2"

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -1,11 +1,7 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import {
-  faDownFromDottedLine,
-  faEraser,
-  faTrash,
-} from '@fortawesome/pro-solid-svg-icons';
+import { faMinusLarge, faTrash } from '@fortawesome/pro-solid-svg-icons';
 import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { chainIcon } from '@/config/chains';
 import { unescape } from '@w3ux/utils';
@@ -21,6 +17,7 @@ import { useTooltip } from '@/renderer/contexts/common/Tooltip';
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
 import type { FormEvent } from 'react';
 import type { HardwareAddressProps } from './types';
+import { faPlusLarge } from '@fortawesome/pro-light-svg-icons';
 
 export const HardwareAddress = ({
   address,
@@ -162,12 +159,13 @@ export const HardwareAddress = ({
           <div
             style={{ position: 'relative' }}
             className="tooltip-trigger-element"
-            data-tooltip-text={'Remove'}
-            onMouseMove={() => setTooltipTextAndOpen('Remove')}
+            data-tooltip-text={'Remove From Main Window'}
+            onMouseMove={() => setTooltipTextAndOpen('Remove From Main Window')}
           >
             <ButtonMono
               className="account-action-btn orange-hover"
-              iconLeft={faEraser}
+              iconLeft={faMinusLarge}
+              iconTransform={'shrink-4'}
               text={''}
               onClick={() => openRemoveHandler()}
             />
@@ -179,14 +177,14 @@ export const HardwareAddress = ({
             data-tooltip-text={isConnected ? 'Import' : 'Currently Offline'}
             onMouseMove={() =>
               isConnected
-                ? setTooltipTextAndOpen('Import')
+                ? setTooltipTextAndOpen('Add To Main Window')
                 : setTooltipTextAndOpen('Currently Offline')
             }
           >
             <ButtonMono
               disabled={!isConnected}
-              iconLeft={faDownFromDottedLine}
-              iconTransform="grow-2"
+              iconLeft={faPlusLarge}
+              iconTransform="grow-0"
               text={''}
               onClick={() => !isProcessing() && openConfirmHandler()}
               className={

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -9,11 +9,10 @@ import {
 import { faCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { chainIcon } from '@/config/chains';
 import { unescape } from '@w3ux/utils';
-import { Flip, toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Identicon } from '@app/library/Identicon';
 import { useState } from 'react';
-import { validateAccountName } from '@/renderer/utils/ImportUtils';
+import { renderToast, validateAccountName } from '@/renderer/utils/ImportUtils';
 import { Wrapper } from './Wrapper';
 import type { FormEvent } from 'react';
 import type { HardwareAddressProps } from './types';
@@ -64,40 +63,14 @@ export const HardwareAddress = ({
 
     // Handle validation failure.
     if (!validateAccountName(trimmed)) {
-      // Render error alert.
-      toast.error('Bad account name.', {
-        position: 'top-center',
-        autoClose: 3000,
-        hideProgressBar: true,
-        closeOnClick: false,
-        closeButton: false,
-        pauseOnHover: false,
-        draggable: false,
-        progress: undefined,
-        theme: 'dark',
-        transition: Flip,
-        toastId: `toast-${trimmed}`, // prevent duplicate alerts
-      });
-
+      renderToast('Bad account name.', 'error', `toast-${trimmed}`);
       setEditName(accountName);
       setEditing(false);
       return;
     }
 
     // Render success alert.
-    toast.success('Account name updated.', {
-      position: 'top-center',
-      autoClose: 3000,
-      hideProgressBar: true,
-      closeOnClick: false,
-      closeButton: false,
-      pauseOnHover: false,
-      draggable: false,
-      progress: undefined,
-      theme: 'dark',
-      transition: Flip,
-      toastId: `toast-${trimmed}`, // prevent duplicate alerts
-    });
+    renderToast('Account name updated.', 'success', `toast-${trimmed}`);
 
     // Otherwise rename account.
     renameHandler(address, trimmed);

--- a/src/renderer/library/Hardware/HardwareAddress/types.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/types.ts
@@ -1,19 +1,20 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { AccountSource } from '@/types/accounts';
 import type { ComponentBase } from '@/renderer/types';
 
 export type HardwareAddressProps = ComponentBase & {
   // the address to import.
   address: string;
+  // The account's import source.
+  source: AccountSource;
   // the index of the address.
   index: number;
   // Whether this address is imported in main window.
   isImported: boolean;
   // Index data for the current address.
   orderData: { curIndex: number; lastIndex: number };
-  // The account's processing flag.
-  isProcessing: boolean;
   // current name of the account.
   accountName: string;
   // handle rename

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -1,111 +1,21 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
 import { Identicon } from '@app/library/Identicon';
 import { ConfirmWrapper } from './Wrappers';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
-import { getAddressChainId } from '@/renderer/Utils';
-import { Config as ConfigImport } from '@/config/processes/import';
+import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
 import type { ConfirmProps } from './types';
-import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
 
-export const Confirm = ({
-  setAddresses,
-  address,
-  name,
-  source,
-}: ConfirmProps) => {
+export const Confirm = ({ address, name, source }: ConfirmProps) => {
   const { setStatus } = useOverlay();
-  const { setStatusForAccount } = useAccountStatuses();
+  const { handleImportAddress } = useImportHandler();
 
-  // Click handler function.
-  const handleImportAddress = () => {
-    // Set processing flag for account.
-    setStatusForAccount(address, source, true);
-
-    // Process account import in main renderer.
-    if (source === 'vault') {
-      handleVaultImport();
-    } else if (source === 'ledger') {
-      handleLedgerImport();
-    } else if (source === 'read-only') {
-      handleReadOnlyImport();
-    }
-
+  const handleClickConfirm = () => {
+    handleImportAddress(address, source, name);
     setStatus(0);
-  };
-
-  // Handle a ledger address import.
-  const handleLedgerImport = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LedgerLocalAddress[]) => {
-      const newAddresses = prevState.map((a: LedgerLocalAddress) =>
-        a.address === address ? { ...a, isImported: true } : a
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressToMainWindow();
-  };
-
-  // Handle a vault address import.
-  const handleVaultImport = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LocalAddress[]) => {
-      const newAddresses = prevState.map((a: LocalAddress) =>
-        a.address === address ? { ...a, isImported: true } : a
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressToMainWindow();
-  };
-
-  // Handle a read-only address import.
-  const handleReadOnlyImport = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LocalAddress[]) => {
-      const newAddresses = prevState.map((a: LocalAddress) =>
-        a.address === address ? { ...a, isImported: true } : a
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressToMainWindow();
-  };
-
-  // Send address data to main window to process.
-  const postAddressToMainWindow = () => {
-    ConfigImport.portImport.postMessage({
-      task: 'renderer:address:import',
-      data: {
-        chainId: getAddressChainId(address),
-        source,
-        address,
-        name,
-      },
-    });
   };
 
   return (
@@ -125,7 +35,7 @@ export const Confirm = ({
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />
         <ButtonMono
           text="Import Account"
-          onClick={() => handleImportAddress()}
+          onClick={() => handleClickConfirm()}
         />
       </div>
     </ConfirmWrapper>

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -21,22 +21,15 @@ export const Confirm = ({ address, name, source }: ConfirmProps) => {
   return (
     <ConfirmWrapper>
       <Identicon value={address} size={60} />
-      <h3>Import Account</h3>
+      <h3>Add Account</h3>
       <h5>{address}</h5>
       <p>
-        Importing this account will automatically subscribe it to events
-        relevant to its on-chain activity.
-      </p>
-      <p>
-        After importing, events can be manually managed from the main
-        menu&apos;s Manage tab.
+        This account will be added to the <b>Subscriptions</b> tab in the main
+        window. Click on the account to manage its subscriptions.
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />
-        <ButtonMono
-          text="Import Account"
-          onClick={() => handleClickConfirm()}
-        />
+        <ButtonMono text="Add Account" onClick={() => handleClickConfirm()} />
       </div>
     </ConfirmWrapper>
   );

--- a/src/renderer/screens/Import/Addresses/Delete.tsx
+++ b/src/renderer/screens/Import/Addresses/Delete.tsx
@@ -121,8 +121,8 @@ export const Delete = ({
       <h3>Delete Account</h3>
       <h5>{address}</h5>
       <p>
-        Deleting this account will unsubscribe it from all of its events. After
-        deleted, it will need to be re-imported into the application.
+        Deleting this account will turn off all of its active subscriptions.
+        After deleted, it will need to be re-imported into the application.
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />

--- a/src/renderer/screens/Import/Addresses/Delete.tsx
+++ b/src/renderer/screens/Import/Addresses/Delete.tsx
@@ -3,116 +3,21 @@
 
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
-import { Config as ConfigImport } from '@/config/processes/import';
 import { ConfirmWrapper } from './Wrappers';
-import { getAddressChainId } from '@/renderer/Utils';
 import { Identicon } from '@/renderer/library/Identicon';
-import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
+import { useDeleteHandler } from '@/renderer/contexts/import/DeleteHandler';
 import type { DeleteProps } from './types';
-import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
 
-export const Delete = ({
-  address,
-  setAddresses,
-  source,
-  setSection,
-}: DeleteProps) => {
+export const Delete = ({ address, source, setSection }: DeleteProps) => {
   const { setStatus } = useOverlay();
-  const { deleteAccountStatus } = useAccountStatuses();
+  const { handleDeleteAddress } = useDeleteHandler();
 
   // Click handler function.
-  const handleDeleteAddress = () => {
-    // Remove status entry from account statuses context.
-    deleteAccountStatus(address, source);
-
-    if (source === 'vault') {
-      handleDeleteVaultAddress();
-    } else if (source === 'ledger') {
-      handleDeleteLedgerAddress();
-    } else if (source === 'read-only') {
-      handleDeleteReadOnlyAddress();
-    }
-
+  const handleDeleteClick = () => {
+    const goBack = handleDeleteAddress(address, source);
     setStatus(0);
-  };
-
-  // Handle deletion of a ledger address.
-  const handleDeleteLedgerAddress = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LedgerLocalAddress[]) => {
-      const newAddresses = prevState.filter(
-        (a: LedgerLocalAddress) => a.address !== address
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    // Go back to import home page.
-    setSection(0);
-
-    postAddressDeleteMessage();
-  };
-
-  // Handle deletion of a vault address.
-  const handleDeleteVaultAddress = () => {
-    let goBack = false;
-
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LocalAddress[]) => {
-      const newAddresses = prevState.filter(
-        (a: LocalAddress) => a.address !== address
-      );
-
-      newAddresses.length === 0 && (goBack = true);
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressDeleteMessage();
-
-    // Go back to import home screen if no more vault addresses are imported.
     goBack && setSection(0);
-  };
-
-  // Handle deletion of a read-only address.
-  const handleDeleteReadOnlyAddress = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LocalAddress[]) => {
-      const newAddresses = prevState.filter(
-        (a: LocalAddress) => a.address !== address
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressDeleteMessage();
-  };
-
-  // Send address data to main window to process removal.
-  const postAddressDeleteMessage = () => {
-    ConfigImport.portImport.postMessage({
-      task: 'renderer:address:delete',
-      data: {
-        address,
-        chainId: getAddressChainId(address),
-      },
-    });
   };
 
   return (
@@ -121,15 +26,12 @@ export const Delete = ({
       <h3>Delete Account</h3>
       <h5>{address}</h5>
       <p>
-        Deleting this account will turn off all of its active subscriptions.
-        After deleted, it will need to be re-imported into the application.
+        Deleting this account will turn off all of its active subscriptions. It
+        will need to be re-imported into the application after deletion.
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />
-        <ButtonMono
-          text="Delete Account"
-          onClick={() => handleDeleteAddress()}
-        />
+        <ButtonMono text="Delete Account" onClick={() => handleDeleteClick()} />
       </div>
     </ConfirmWrapper>
   );

--- a/src/renderer/screens/Import/Addresses/Remove.tsx
+++ b/src/renderer/screens/Import/Addresses/Remove.tsx
@@ -24,9 +24,8 @@ export const Remove = ({ address, source }: RemoveProps) => {
       <h3>Remove Account</h3>
       <h5>{address}</h5>
       <p>
-        Removing this account will unsubscribe it from all of its events. After
-        removal, this account will need to be re-imported to resume receiving
-        events.
+        This account will be removed from the main window. All active
+        subscriptions associated with this account will be turned off.
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />

--- a/src/renderer/screens/Import/Addresses/Remove.tsx
+++ b/src/renderer/screens/Import/Addresses/Remove.tsx
@@ -6,93 +6,16 @@ import { Identicon } from '@app/library/Identicon';
 import { ConfirmWrapper } from './Wrappers';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
-import { Config as ConfigImport } from '@/config/processes/import';
-import { getAddressChainId } from '@/renderer/Utils';
+import { useRemoveHandler } from '@/renderer/contexts/import/RemoveHandler';
 import type { RemoveProps } from './types';
-import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
 
-export const Remove = ({ address, setAddresses, source }: RemoveProps) => {
+export const Remove = ({ address, source }: RemoveProps) => {
   const { setStatus } = useOverlay();
+  const { handleRemoveAddress } = useRemoveHandler();
 
-  // Click handler function.
-  const handleRemoveAddress = () => {
-    if (source === 'vault') {
-      handleRemoveVaultAddress();
-    } else if (source === 'ledger') {
-      handleRemoveLedgerAddress();
-    } else if (source === 'read-only') {
-      handleRemoveReadOnlyAddress();
-    }
-
+  const handleClickRemove = () => {
+    handleRemoveAddress(address, source);
     setStatus(0);
-  };
-
-  // Handle removal of a ledger address.
-  const handleRemoveLedgerAddress = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LedgerLocalAddress[]) => {
-      const newAddresses = prevState.map((a: LedgerLocalAddress) =>
-        a.address === address ? { ...a, isImported: false } : a
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressToMainWindow();
-  };
-
-  // Handle removal of a vault address.
-  const handleRemoveVaultAddress = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LocalAddress[]) => {
-      const newAddresses = prevState.map((a: LocalAddress) =>
-        a.address === address ? { ...a, isImported: false } : a
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressToMainWindow();
-  };
-
-  // Handle removal of a read-only address.
-  const handleRemoveReadOnlyAddress = () => {
-    // Update import window's managed address state and local storage.
-    setAddresses((prevState: LocalAddress[]) => {
-      const newAddresses = prevState.map((a: LocalAddress) =>
-        a.address === address ? { ...a, isImported: false } : a
-      );
-
-      localStorage.setItem(
-        ConfigImport.getStorageKey(source),
-        JSON.stringify(newAddresses)
-      );
-
-      return newAddresses;
-    });
-
-    postAddressToMainWindow();
-  };
-
-  // Send address data to main window to process removal.
-  const postAddressToMainWindow = () => {
-    ConfigImport.portImport.postMessage({
-      task: 'renderer:address:remove',
-      data: {
-        address,
-        chainId: getAddressChainId(address),
-      },
-    });
   };
 
   return (
@@ -107,10 +30,7 @@ export const Remove = ({ address, setAddresses, source }: RemoveProps) => {
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />
-        <ButtonMono
-          text="Remove Account"
-          onClick={() => handleRemoveAddress()}
-        />
+        <ButtonMono text="Remove Account" onClick={() => handleClickRemove()} />
       </div>
     </ConfirmWrapper>
   );

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -20,7 +20,6 @@ export interface AddressProps {
 
 export interface ConfirmProps {
   address: string;
-  setAddresses: AnyFunction;
   name: string;
   source: AccountSource;
 }

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -26,7 +26,6 @@ export interface ConfirmProps {
 
 export interface RemoveProps {
   address: string;
-  setAddresses: AnyFunction;
   source: AccountSource;
 }
 

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -10,7 +10,6 @@ export interface AddressProps {
   address: string;
   index: number;
   isImported: boolean;
-  setAddresses: AnyFunction;
   setSection: AnyFunction;
   orderData: {
     curIndex: number;
@@ -31,7 +30,6 @@ export interface RemoveProps {
 
 export interface DeleteProps {
   address: string;
-  setAddresses: AnyFunction;
   source: AccountSource;
   setSection: AnyFunction | null;
 }

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -48,14 +48,7 @@ export const Address = ({
       isImported={isImported}
       orderData={orderData}
       openRemoveHandler={() =>
-        openOverlayWith(
-          <Remove
-            address={address}
-            setAddresses={setAddresses}
-            source="ledger"
-          />,
-          'small'
-        )
+        openOverlayWith(<Remove address={address} source="ledger" />, 'small')
       }
       openConfirmHandler={() =>
         openOverlayWith(

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/renderer/utils/ImportUtils';
 import { HardwareAddress } from '@app/library/Hardware/HardwareAddress';
 import { Remove } from '../Addresses/Remove';
-import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
 import { useState } from 'react';
 import type { LedgerAddressProps } from '../types';
@@ -24,12 +23,10 @@ export const Address = ({
   orderData,
   setSection,
 }: LedgerAddressProps) => {
-  // State for account name.
-  const [accountNameState, setAccountNameState] = useState<string>(accountName);
   const { openOverlayWith } = useOverlay();
 
-  // Getter for account's processing flag.
-  const { getStatusForAccount } = useAccountStatuses();
+  // State for account name.
+  const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
   const renameHandler = (who: string, newName: string) => {
@@ -43,13 +40,13 @@ export const Address = ({
   return (
     <HardwareAddress
       key={index}
+      source={source}
       address={address}
       index={index}
       accountName={accountNameState}
       renameHandler={renameHandler}
       isImported={isImported}
       orderData={orderData}
-      isProcessing={getStatusForAccount(address, source) || false}
       openRemoveHandler={() =>
         openOverlayWith(
           <Remove

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -59,12 +59,7 @@ export const Address = ({
       }
       openConfirmHandler={() =>
         openOverlayWith(
-          <Confirm
-            address={address}
-            setAddresses={setAddresses}
-            name={accountNameState}
-            source="ledger"
-          />,
+          <Confirm address={address} name={accountNameState} source="ledger" />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -17,7 +17,6 @@ export const Address = ({
   address,
   accountName,
   source,
-  setAddresses,
   index,
   isImported,
   orderData,
@@ -58,12 +57,7 @@ export const Address = ({
       }
       openDeleteHandler={() =>
         openOverlayWith(
-          <Delete
-            setAddresses={setAddresses}
-            address={address}
-            source="ledger"
-            setSection={setSection}
-          />
+          <Delete address={address} source="ledger" setSection={setSection} />
         )
       }
     />

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -119,7 +119,7 @@ export const Manage = ({
                               j
                             ) => (
                               <Address
-                                key={address}
+                                key={`address_${name}`}
                                 address={address}
                                 source={'ledger'}
                                 accountName={name}

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -28,7 +28,6 @@ import type { LedgerLocalAddress } from '@/types/accounts';
 
 export const Manage = ({
   addresses,
-  setAddresses,
   isImporting,
   statusCodes,
   toggleImport,
@@ -123,7 +122,6 @@ export const Manage = ({
                                 address={address}
                                 source={'ledger'}
                                 accountName={name}
-                                setAddresses={setAddresses}
                                 index={index}
                                 isImported={isImported}
                                 orderData={{

--- a/src/renderer/screens/Import/Ledger/index.tsx
+++ b/src/renderer/screens/Import/Ledger/index.tsx
@@ -162,7 +162,6 @@ export const ImportLedger = ({
   ) : (
     <Manage
       addresses={addresses}
-      setAddresses={setAddresses}
       isImporting={isImporting}
       toggleImport={toggleImport}
       statusCodes={statusCodes}

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -49,11 +49,7 @@ export const Address = ({
       renameHandler={renameHandler}
       openRemoveHandler={() =>
         openOverlayWith(
-          <Remove
-            setAddresses={setAddresses}
-            address={address}
-            source="read-only"
-          />,
+          <Remove address={address} source="read-only" />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -60,7 +60,6 @@ export const Address = ({
       openConfirmHandler={() =>
         openOverlayWith(
           <Confirm
-            setAddresses={setAddresses}
             address={address}
             name={accountNameState}
             source="read-only"

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -9,7 +9,6 @@ import {
   renameLocalAccount,
 } from '@/renderer/utils/ImportUtils';
 import { Remove } from '../Addresses/Remove';
-import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
 import { useState } from 'react';
 import type { AddressProps } from '../Addresses/types';
@@ -24,12 +23,10 @@ export const Address = ({
   setSection,
   orderData,
 }: AddressProps) => {
-  // State for account name.
-  const [accountNameState, setAccountNameState] = useState<string>(accountName);
   const { openOverlayWith } = useOverlay();
 
-  // Getter for account's processing flag.
-  const { getStatusForAccount } = useAccountStatuses();
+  // State for account name.
+  const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
   const renameHandler = (who: string, newName: string) => {
@@ -44,9 +41,9 @@ export const Address = ({
     <HardwareAddress
       key={index}
       address={address}
+      source={source}
       isImported={isImported}
       orderData={orderData}
-      isProcessing={getStatusForAccount(address, source) || false}
       index={index}
       accountName={accountNameState}
       renameHandler={renameHandler}

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -18,7 +18,6 @@ export const Address = ({
   source,
   index,
   accountName,
-  setAddresses,
   isImported,
   setSection,
   orderData,
@@ -66,7 +65,6 @@ export const Address = ({
       openDeleteHandler={() =>
         openOverlayWith(
           <Delete
-            setAddresses={setAddresses}
             address={address}
             source="read-only"
             setSection={setSection}

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -11,8 +11,10 @@ import { checkAddress } from '@polkadot/util-crypto';
 import { Config as ConfigImport } from '@/config/processes/import';
 import { DragClose } from '@/renderer/library/DragClose';
 import { ellipsisFn, unescape } from '@w3ux/utils';
-import { Flip, toast } from 'react-toastify';
-import { getSortedLocalAddresses } from '@/renderer/utils/ImportUtils';
+import {
+  getSortedLocalAddresses,
+  renderToast,
+} from '@/renderer/utils/ImportUtils';
 import { HeaderWrapper, ContentWrapper } from '@app/screens/Wrappers';
 import { Identicon } from '@/renderer/library/Identicon';
 import { Wrapper } from '@/renderer/library/Hardware/HardwareAddress/Wrapper';
@@ -89,46 +91,6 @@ export const Manage = ({
   /// Gets the next non-imported address index.
   const getNextAddressIndex = () =>
     !addresses.length ? 0 : addresses[addresses.length - 1].index + 1;
-
-  /// Utility to render a toastify notification.
-  type ToastType = 'success' | 'error';
-
-  const renderToast = (text: string, toastType: ToastType, toastId: string) => {
-    switch (toastType) {
-      case 'success': {
-        toast.success(text, {
-          position: 'top-center',
-          autoClose: 3000,
-          hideProgressBar: true,
-          closeOnClick: false,
-          closeButton: false,
-          pauseOnHover: false,
-          draggable: false,
-          progress: undefined,
-          theme: 'dark',
-          transition: Flip,
-          toastId,
-        });
-        break;
-      }
-      case 'error': {
-        toast.error(text, {
-          position: 'top-center',
-          autoClose: 3000,
-          hideProgressBar: true,
-          closeOnClick: false,
-          closeButton: false,
-          pauseOnHover: false,
-          draggable: false,
-          progress: undefined,
-          theme: 'dark',
-          transition: Flip,
-          toastId,
-        });
-        break;
-      }
-    }
-  };
 
   // Validate input and add address to local storage.
   const onImport = () => {

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -249,7 +249,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                                     key={`address_${name}`}
                                     accountName={name}
                                     source={'read-only'}
-                                    setAddresses={setAddresses}
                                     address={address}
                                     index={index}
                                     isImported={isImported || false}

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -63,11 +63,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
     )
   );
 
-  /// Cancel button clicked for address field.
-  const onCancel = () => {
-    setEditName('');
-  };
-
   /// Verify that the address is compatible with the supported networks.
   const validateAddress = (address: string) => {
     for (const prefix of [0, 2, 42]) {
@@ -100,7 +95,19 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
   const getNextAddressIndex = () =>
     !addresses.length ? 0 : addresses[addresses.length - 1].index + 1;
 
-  // Validate input and add address to local storage.
+  /// Cancel button clicked for address field.
+  const onCancel = () => {
+    setEditName('');
+  };
+
+  // Input change handler.
+  const onChange = (e: FormEvent<HTMLInputElement>) => {
+    let val = e.currentTarget.value || '';
+    val = unescape(val);
+    setEditName(val);
+  };
+
+  /// Handle import button click.
   const onImport = () => {
     const trimmed = editName.trim();
 
@@ -138,13 +145,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
 
     // Set processing flag to true and import via main renderer.
     handleImportAddress(trimmed, 'read-only', accountName);
-  };
-
-  // Input change handler.
-  const onChange = (e: FormEvent<HTMLInputElement>) => {
-    let val = e.currentTarget.value || '';
-    val = unescape(val);
-    setEditName(val);
   };
 
   return (
@@ -246,7 +246,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                                   j
                                 ) => (
                                   <Address
-                                    key={address}
+                                    key={`address_${name}`}
                                     accountName={name}
                                     source={'read-only'}
                                     setAddresses={setAddresses}

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -40,7 +40,7 @@ export const Manage = ({
   const [editName, setEditName] = useState<string>('');
   const { insertAccountStatus } = useAccountStatuses();
 
-  // Active accordion indices for account subscription tasks categories.
+  /// Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
     number[]
   >(
@@ -52,12 +52,13 @@ export const Manage = ({
       (_, index) => index
     )
   );
-  // Cancel button clicked for address field.
+
+  /// Cancel button clicked for address field.
   const onCancel = () => {
     setEditName('');
   };
 
-  // Verify that the address is compatible with the supported networks.
+  /// Verify that the address is compatible with the supported networks.
   const validateAddress = (address: string) => {
     for (const prefix of [0, 2, 42]) {
       const result = checkAddress(address, prefix);
@@ -74,7 +75,7 @@ export const Manage = ({
     return false;
   };
 
-  // Verify that the address is not already imported.
+  /// Verify that the address is not already imported.
   const isAlreadyImported = (address: string): boolean => {
     for (const next of addresses) {
       if (next.address === address) {
@@ -85,47 +86,59 @@ export const Manage = ({
     return false;
   };
 
-  // Gets the next non-imported address index.
+  /// Gets the next non-imported address index.
   const getNextAddressIndex = () =>
     !addresses.length ? 0 : addresses[addresses.length - 1].index + 1;
+
+  /// Utility to render a toastify notification.
+  type ToastType = 'success' | 'error';
+
+  const renderToast = (text: string, toastType: ToastType, toastId: string) => {
+    switch (toastType) {
+      case 'success': {
+        toast.success(text, {
+          position: 'top-center',
+          autoClose: 3000,
+          hideProgressBar: true,
+          closeOnClick: false,
+          closeButton: false,
+          pauseOnHover: false,
+          draggable: false,
+          progress: undefined,
+          theme: 'dark',
+          transition: Flip,
+          toastId,
+        });
+        break;
+      }
+      case 'error': {
+        toast.error(text, {
+          position: 'top-center',
+          autoClose: 3000,
+          hideProgressBar: true,
+          closeOnClick: false,
+          closeButton: false,
+          pauseOnHover: false,
+          draggable: false,
+          progress: undefined,
+          theme: 'dark',
+          transition: Flip,
+          toastId,
+        });
+        break;
+      }
+    }
+  };
 
   // Validate input and add address to local storage.
   const onImport = () => {
     const trimmed = editName.trim();
 
     if (isAlreadyImported(trimmed)) {
-      // Render error alert.
-      toast.error('Address is already imported.', {
-        position: 'top-center',
-        autoClose: 3000,
-        hideProgressBar: true,
-        closeOnClick: false,
-        closeButton: false,
-        pauseOnHover: false,
-        draggable: false,
-        progress: undefined,
-        theme: 'dark',
-        transition: Flip,
-        toastId: `toast-${trimmed}`, // prevent duplicate alerts
-      });
-
+      renderToast('Address is already imported.', 'error', `toast-${trimmed}`);
       return;
     } else if (!validateAddress(trimmed)) {
-      // Render error alert.
-      toast.error('Bad account name.', {
-        position: 'top-center',
-        autoClose: 3000,
-        hideProgressBar: true,
-        closeOnClick: false,
-        closeButton: false,
-        pauseOnHover: false,
-        draggable: false,
-        progress: undefined,
-        theme: 'dark',
-        transition: Flip,
-        toastId: `toast-${trimmed}`, // prevent duplicate alerts
-      });
-
+      renderToast('Bad account name.', 'error', `toast-${trimmed}`);
       return;
     }
 
@@ -148,20 +161,12 @@ export const Manage = ({
     // Add account status entry.
     insertAccountStatus(trimmed, 'read-only');
 
-    // Render success alert.
-    toast.success('Address addred successfully.', {
-      position: 'top-center',
-      autoClose: 3000,
-      hideProgressBar: true,
-      closeOnClick: false,
-      closeButton: false,
-      pauseOnHover: false,
-      draggable: false,
-      progress: undefined,
-      theme: 'dark',
-      transition: Flip,
-      toastId: `toast-${trimmed}`, // prevent duplicate alerts
-    });
+    // TODO: Set processing flag to true.
+
+    // TODO: Send import data to main renderer.
+
+    // TODO: Render success alert when account is imported.
+    renderToast('Address added successfully', 'success', `toast-${trimmed}`);
   };
 
   // Input change handler.

--- a/src/renderer/screens/Import/ReadOnly/index.tsx
+++ b/src/renderer/screens/Import/ReadOnly/index.tsx
@@ -2,25 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Manage } from './Manage';
-import { useAddresses } from '@/renderer/contexts/import/Addresses';
 import type { AnyFunction } from '@w3ux/utils/types';
 
 export const ImportReadOnly = ({
-  section,
   setSection,
 }: {
   section: number;
   setSection: AnyFunction;
-}) => {
-  // Get read-only addresses from local storage.
-  const { readOnlyAddresses, setReadOnlyAddresses } = useAddresses();
-
-  return (
-    <Manage
-      section={section}
-      setSection={setSection}
-      addresses={readOnlyAddresses}
-      setAddresses={setReadOnlyAddresses}
-    />
-  );
-};
+}) => <Manage setSection={setSection} />;

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -48,14 +48,7 @@ export const Address = ({
       accountName={accountNameState}
       renameHandler={renameHandler}
       openRemoveHandler={() =>
-        openOverlayWith(
-          <Remove
-            setAddresses={setAddresses}
-            address={address}
-            source="vault"
-          />,
-          'small'
-        )
+        openOverlayWith(<Remove address={address} source="vault" />, 'small')
       }
       openConfirmHandler={() =>
         openOverlayWith(

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -18,7 +18,6 @@ export const Address = ({
   source,
   index,
   accountName,
-  setAddresses,
   isImported,
   setSection,
   orderData,
@@ -58,12 +57,7 @@ export const Address = ({
       }
       openDeleteHandler={() =>
         openOverlayWith(
-          <Delete
-            setAddresses={setAddresses}
-            address={address}
-            source="vault"
-            setSection={setSection}
-          />
+          <Delete address={address} source="vault" setSection={setSection} />
         )
       }
     />

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -59,12 +59,7 @@ export const Address = ({
       }
       openConfirmHandler={() =>
         openOverlayWith(
-          <Confirm
-            setAddresses={setAddresses}
-            address={address}
-            name={accountNameState}
-            source="vault"
-          />,
+          <Confirm address={address} name={accountNameState} source="vault" />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/renderer/utils/ImportUtils';
 import { HardwareAddress } from '@app/library/Hardware/HardwareAddress';
 import { Remove } from '../Addresses/Remove';
-import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
 import { useState } from 'react';
 import type { AddressProps } from '../Addresses/types';
@@ -24,12 +23,10 @@ export const Address = ({
   setSection,
   orderData,
 }: AddressProps) => {
-  // State for account name.
-  const [accountNameState, setAccountNameState] = useState<string>(accountName);
   const { openOverlayWith } = useOverlay();
 
-  // Getter for account's processing flag.
-  const { getStatusForAccount } = useAccountStatuses();
+  // State for account name.
+  const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
   const renameHandler = (who: string, newName: string) => {
@@ -44,9 +41,9 @@ export const Address = ({
     <HardwareAddress
       key={index}
       address={address}
+      source={source}
       isImported={isImported}
       orderData={orderData}
-      isProcessing={getStatusForAccount(address, source) || false}
       index={index}
       accountName={accountNameState}
       renameHandler={renameHandler}

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -29,7 +29,6 @@ import type { ManageVaultProps } from '../types';
 
 export const Manage = ({
   setSection,
-  //section,
   addresses,
   setAddresses,
 }: ManageVaultProps) => {
@@ -113,7 +112,7 @@ export const Manage = ({
                             {chainAddresses.map(
                               ({ address, index, isImported, name }, j) => (
                                 <Address
-                                  key={address}
+                                  key={`address_${name}`}
                                   accountName={name}
                                   source={'vault'}
                                   setAddresses={setAddresses}

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -115,7 +115,6 @@ export const Manage = ({
                                   key={`address_${name}`}
                                   accountName={name}
                                   source={'vault'}
-                                  setAddresses={setAddresses}
                                   address={address}
                                   index={index}
                                   isImported={isImported || false}

--- a/src/renderer/screens/Import/Vault/Reader.tsx
+++ b/src/renderer/screens/Import/Vault/Reader.tsx
@@ -15,10 +15,12 @@ import { ScanWrapper } from '@/renderer/library/QRCode/Wrappers';
 import type { Html5Qrcode } from 'html5-qrcode';
 import type { LocalAddress } from '@/types/accounts';
 import type { ReaderVaultProps } from '../types';
+import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
 
 export const Reader = ({ addresses, setAddresses }: ReaderVaultProps) => {
   const { setStatus: setOverlayStatus } = useOverlay();
   const { insertAccountStatus } = useAccountStatuses();
+  const { handleImportAddress } = useImportHandler();
 
   // Check whether initial render.
   const initialRender = useRef<boolean>(true);
@@ -78,13 +80,15 @@ export const Reader = ({ addresses, setAddresses }: ReaderVaultProps) => {
 
   // Handle new vault address to local storage and close overlay.
   const handleVaultImport = (address: string) => {
+    const accountName = ellipsisFn(address);
+
     const newAddresses = addresses
       .filter((a: LocalAddress) => a.address !== address)
       .concat({
         index: getNextAddressIndex(),
         address,
         isImported: false,
-        name: ellipsisFn(address),
+        name: accountName,
         source: 'vault',
       });
 
@@ -95,6 +99,9 @@ export const Reader = ({ addresses, setAddresses }: ReaderVaultProps) => {
 
     // Add account status entry.
     insertAccountStatus(address, 'vault');
+
+    // Set processing flag to true and import via main renderer.
+    handleImportAddress(address, 'vault', accountName);
   };
 
   // Gets the next non-imported address index.

--- a/src/renderer/screens/Import/index.tsx
+++ b/src/renderer/screens/Import/index.tsx
@@ -62,15 +62,15 @@ export const Import: React.FC = () => {
             flexGrow: 1,
           }}
         >
-          {source === 'ledger' && (
+          <div className={source === 'ledger' ? 'show' : 'hide'}>
             <ImportLedger section={section} setSection={setSection} />
-          )}
-          {source === 'vault' && (
+          </div>
+          <div className={source === 'vault' ? 'show' : 'hide'}>
             <ImportVault section={section} setSection={setSection} />
-          )}
-          {source === 'read-only' && (
+          </div>
+          <div className={source === 'read-only' ? 'show' : 'hide'}>
             <ImportReadOnly section={section} setSection={setSection} />
-          )}
+          </div>
         </div>
       </ModalMotionTwoSection>
     </ModalSection>

--- a/src/renderer/screens/Import/index.tsx
+++ b/src/renderer/screens/Import/index.tsx
@@ -26,6 +26,9 @@ export const Import: React.FC = () => {
     }
   }, [section]);
 
+  const getShowClass = (target: AccountSource) =>
+    source === target ? 'show' : 'hide';
+
   return (
     <ModalSection type="carousel">
       <ModalMotionTwoSection
@@ -62,13 +65,13 @@ export const Import: React.FC = () => {
             flexGrow: 1,
           }}
         >
-          <div className={source === 'ledger' ? 'show' : 'hide'}>
+          <div className={getShowClass('ledger')}>
             <ImportLedger section={section} setSection={setSection} />
           </div>
-          <div className={source === 'vault' ? 'show' : 'hide'}>
+          <div className={getShowClass('vault')}>
             <ImportVault section={section} setSection={setSection} />
           </div>
-          <div className={source === 'read-only' ? 'show' : 'hide'}>
+          <div className={getShowClass('read-only')}>
             <ImportReadOnly section={section} setSection={setSection} />
           </div>
         </div>

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -44,7 +44,6 @@ export interface ImportLedgerManageProps {
   isImporting: boolean;
   statusCodes: LedgerResponse[];
   section: number;
-  setAddresses: AnyFunction;
   toggleImport: AnyFunction;
   cancelImport: AnyFunction;
   setSection: AnyFunction;
@@ -60,7 +59,6 @@ export interface LedgerAddressProps {
     curIndex: number;
     lastIndex: number;
   };
-  setAddresses: AnyFunction;
   setSection: AnyFunction;
 }
 

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -66,7 +66,4 @@ export interface LedgerAddressProps {
 
 export interface ManageReadOnlyProps {
   setSection: AnyFunction;
-  section: number;
-  addresses: LocalAddress[];
-  setAddresses: AnyFunction;
 }

--- a/src/renderer/theme/utils.scss
+++ b/src/renderer/theme/utils.scss
@@ -1,0 +1,9 @@
+/* Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+SPDX-License-Identifier: GPL-3.0-only */
+
+.show {
+  display: inherit;
+}
+.hide {
+  display: none;
+}

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -3,6 +3,7 @@
 
 import { Config as ConfigImport } from '@/config/processes/import';
 import { ellipsisFn } from '@w3ux/utils';
+import { Flip, toast } from 'react-toastify';
 import type {
   AccountSource,
   LedgerLocalAddress,
@@ -10,6 +11,53 @@ import type {
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
 import type { ChainID } from '@/types/chains';
+
+type ToastType = 'success' | 'error';
+
+/**
+ * @name renderToast
+ * @summary Utility to render a toastify notification.
+ */
+export const renderToast = (
+  text: string,
+  toastType: ToastType,
+  toastId: string
+) => {
+  switch (toastType) {
+    case 'success': {
+      toast.success(text, {
+        position: 'top-center',
+        autoClose: 3000,
+        hideProgressBar: true,
+        closeOnClick: false,
+        closeButton: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark',
+        transition: Flip,
+        toastId,
+      });
+      break;
+    }
+    case 'error': {
+      toast.error(text, {
+        position: 'top-center',
+        autoClose: 3000,
+        hideProgressBar: true,
+        closeOnClick: false,
+        closeButton: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark',
+        transition: Flip,
+        toastId,
+      });
+      break;
+    }
+  }
+};
 
 /**
  * @name renameLocalAccount


### PR DESCRIPTION
# Summary

This PR implements automatic account importing and lifts account management logic to contexts.

- [x] Automatically import read-only accounts upon clicking the `Add` button for a valid address.
- [x] Automatically import vault accounts.
- [x] Correct overlay text when importing or removing an account.