### PR TITLE
feat: automatically subscribe setting

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -150,6 +150,14 @@ export const HelpConfig: HelpItems = [
     ],
   },
   {
+    key: 'help:settings:enableAutomaticSubscriptions',
+    title: 'Enable Automatic Subscriptions',
+    definition: [
+      'Automatically subscribe to all possible subscriptions for an account when importing it.',
+      'Turn this setting off if you prefer to have no subscriptions turned on for an account after importing it, and wish to turn on individual subscriptions manually.',
+    ],
+  },
+  {
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -60,6 +60,7 @@ export class Config {
         appSilenceOsNotifications: false,
         appShowOnAllWorkspaces: true,
         appShowDebuggingSubscriptions: false,
+        appEnableAutomaticSubscriptions: true,
       };
 
       // Persist default settings to store and return them.

--- a/src/config/processes/renderer.ts
+++ b/src/config/processes/renderer.ts
@@ -15,6 +15,7 @@ export class Config {
   // App settings handled by main renderer (use in callbacks).
   private static _silenceNotifications = false;
   private static _showDebuggingSubscriptions = false;
+  private static _enableAutomaticSubscriptions = true;
 
   // Flag set to `true` when app is switching to online mode.
   private static _switchingToOnlineMode = false;
@@ -93,6 +94,15 @@ export class Config {
 
   static set showDebuggingSubscriptions(flag: boolean) {
     Config._showDebuggingSubscriptions = flag;
+  }
+
+  // Accessors for `_enableAutomaticSubscriptions` flag.
+  static get enableAutomaticSubscriptions(): boolean {
+    return Config._enableAutomaticSubscriptions;
+  }
+
+  static set enableAutomaticSubscriptions(flag: boolean) {
+    Config._enableAutomaticSubscriptions = flag;
   }
 
   // Accessors for `_switchingToOnlineMode` flag.

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -38,6 +38,14 @@ export const SettingsList: SettingItem[] = [
     title: 'Show Debugging Subscriptions',
   },
   {
+    action: 'settings:execute:enableAutomaticSubscriptions',
+    category: 'General',
+    enabled: false,
+    helpKey: 'help:settings:enableAutomaticSubscriptions',
+    settingType: 'switch',
+    title: 'Enable Automatic Subscriptions',
+  },
+  {
     action: 'settings:execute:importData',
     category: 'Backup',
     buttonIcon: faFileImport,

--- a/src/main.ts
+++ b/src/main.ts
@@ -508,6 +508,15 @@ app.whenReady().then(async () => {
         (store as Record<string, AnyData>).set(key, settings);
         break;
       }
+      case 'settings:execute:enableAutomaticSubscriptions': {
+        const settings = ConfigMain.getAppSettings();
+        const flag = !settings.appEnableAutomaticSubscriptions;
+        settings.appEnableAutomaticSubscriptions = flag;
+
+        const key = ConfigMain.settingsStorageKey;
+        (store as Record<string, AnyData>).set(key, settings);
+        break;
+      }
       default: {
         break;
       }

--- a/src/renderer/contexts/common/Help/types.ts
+++ b/src/renderer/contexts/common/Help/types.ts
@@ -61,6 +61,7 @@ export type HelpItemKey =
   | 'help:settings:importData'
   | 'help:settings:exportData'
   | 'help:settings:showDebuggingSubscriptions'
+  | 'help:settings:enableAutomaticSubscriptions'
   | 'help:openGov:track'
   | 'help:openGov:origin'
   | 'help:openGov:maxDeciding'

--- a/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -8,8 +8,10 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   dockToggled: true,
   silenceOsNotifications: false,
   showDebuggingSubscriptions: false,
+  enableAutomaticSubscriptions: true,
   setSilenceOsNotifications: (b) => {},
   handleDockedToggle: () => {},
   handleToggleSilenceOsNotifications: () => {},
   handleToggleShowDebuggingSubscriptions: () => {},
+  handleToggleEnableAutomaticSubscriptions: () => {},
 };

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -28,6 +28,10 @@ export const AppSettingsProvider = ({
   const [showDebuggingSubscriptions, setShowDebuggingSubscriptions] =
     useState<boolean>(false);
 
+  /// Enable automatic subscriptions.
+  const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
+    useState<boolean>(true);
+
   // Get settings from main and initialise state.
   useEffect(() => {
     const initSettings = async () => {
@@ -35,6 +39,7 @@ export const AppSettingsProvider = ({
         appDocked,
         appSilenceOsNotifications,
         appShowDebuggingSubscriptions,
+        appEnableAutomaticSubscriptions,
       } = await window.myAPI.getAppSettings();
 
       // Set cached notifications flag in renderer config.
@@ -45,6 +50,7 @@ export const AppSettingsProvider = ({
       setDockToggled(appDocked);
       setSilenceOsNotifications(appSilenceOsNotifications);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
+      setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
     };
 
     initSettings();
@@ -81,15 +87,22 @@ export const AppSettingsProvider = ({
     window.myAPI.toggleSetting('settings:execute:showDebuggingSubscriptions');
   };
 
+  /// Handle toggling enable automatic subscriptions.
+  const handleToggleEnableAutomaticSubscriptions = () => {
+    setEnableAutomaticSubscriptions(!enableAutomaticSubscriptions);
+  };
+
   return (
     <AppSettingsContext.Provider
       value={{
         dockToggled,
         silenceOsNotifications,
         showDebuggingSubscriptions,
+        enableAutomaticSubscriptions,
         handleDockedToggle,
         handleToggleSilenceOsNotifications,
         handleToggleShowDebuggingSubscriptions,
+        handleToggleEnableAutomaticSubscriptions,
         setSilenceOsNotifications,
       }}
     >

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -89,7 +89,11 @@ export const AppSettingsProvider = ({
 
   /// Handle toggling enable automatic subscriptions.
   const handleToggleEnableAutomaticSubscriptions = () => {
-    setEnableAutomaticSubscriptions(!enableAutomaticSubscriptions);
+    setEnableAutomaticSubscriptions((prev) => {
+      const newFlag = !prev;
+      RendererConfig.enableAutomaticSubscriptions = newFlag;
+      return newFlag;
+    });
   };
 
   return (

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -45,6 +45,8 @@ export const AppSettingsProvider = ({
       // Set cached notifications flag in renderer config.
       RendererConfig.silenceNotifications = appSilenceOsNotifications;
       RendererConfig.showDebuggingSubscriptions = appShowDebuggingSubscriptions;
+      RendererConfig.enableAutomaticSubscriptions =
+        appEnableAutomaticSubscriptions;
 
       // Set settings state.
       setDockToggled(appDocked);

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -94,6 +94,8 @@ export const AppSettingsProvider = ({
       RendererConfig.enableAutomaticSubscriptions = newFlag;
       return newFlag;
     });
+
+    window.myAPI.toggleSetting('settings:execute:enableAutomaticSubscriptions');
   };
 
   return (

--- a/src/renderer/contexts/main/AppSettings/types.ts
+++ b/src/renderer/contexts/main/AppSettings/types.ts
@@ -5,8 +5,10 @@ export interface AppSettingsContextInterface {
   dockToggled: boolean;
   silenceOsNotifications: boolean;
   showDebuggingSubscriptions: boolean;
+  enableAutomaticSubscriptions: boolean;
   setSilenceOsNotifications: (b: boolean) => void;
   handleDockedToggle: () => void;
   handleToggleSilenceOsNotifications: () => void;
   handleToggleShowDebuggingSubscriptions: () => void;
+  handleToggleEnableAutomaticSubscriptions: () => void;
 }

--- a/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -24,6 +24,8 @@ export const SettingFlagsProvider = ({
   const [showOnAllWorkspaces, setShowOnAllWorkspaces] = useState(false);
   const [showDebuggingSubscriptions, setShowDebuggingSubscriptions] =
     useState(false);
+  const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
+    useState(true);
 
   /// Fetch settings from store and set state.
   useEffect(() => {
@@ -33,12 +35,14 @@ export const SettingFlagsProvider = ({
         appSilenceOsNotifications,
         appShowOnAllWorkspaces,
         appShowDebuggingSubscriptions,
+        appEnableAutomaticSubscriptions,
       } = await window.myAPI.getAppSettings();
 
       setWindowDocked(appDocked);
       setSilenceOsNotifications(appSilenceOsNotifications);
       setShowOnAllWorkspaces(appShowOnAllWorkspaces);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
+      setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
     };
 
     initSettings();
@@ -60,6 +64,9 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:showDebuggingSubscriptions': {
         return showDebuggingSubscriptions;
+      }
+      case 'settings:execute:enableAutomaticSubscriptions': {
+        return enableAutomaticSubscriptions;
       }
       default: {
         return true;
@@ -86,6 +93,10 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:showDebuggingSubscriptions': {
         setShowDebuggingSubscriptions(!showDebuggingSubscriptions);
+        break;
+      }
+      case 'settings:execute:enableAutomaticSubscriptions': {
+        setEnableAutomaticSubscriptions(!enableAutomaticSubscriptions);
         break;
       }
       default: {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -57,6 +57,7 @@ export const useMainMessagePorts = () => {
     handleDockedToggle,
     handleToggleSilenceOsNotifications,
     handleToggleShowDebuggingSubscriptions,
+    handleToggleEnableAutomaticSubscriptions,
   } = useAppSettings();
 
   const { setAccountSubscriptions, updateAccountNameInTasks, updateTask } =
@@ -638,6 +639,15 @@ export const useMainMessagePorts = () => {
   };
 
   /**
+   * @name handleEnableAutomaticSubscriptions
+   * @summary Handle toggling the handle automatic subscriptions setting.
+   */
+  const handleEnableAutomaticSubscriptions = () => {
+    handleToggleEnableAutomaticSubscriptions();
+    console.log('toggled automatic subscriptions...');
+  };
+
+  /**
    * @name handleReceivedPort
    * @summary Determines whether the received port is for the `main` or `import` window and
    * sets up message handlers accordingly.
@@ -727,6 +737,10 @@ export const useMainMessagePorts = () => {
             }
             case 'settings:execute:showDebuggingSubscriptions': {
               await handleDebuggingSubscriptions();
+              break;
+            }
+            case 'settings:execute:enableAutomaticSubscriptions': {
+              handleEnableAutomaticSubscriptions();
               break;
             }
             case 'settings:execute:exportData': {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -112,8 +112,7 @@ export const useMainMessagePorts = () => {
       await fetchNominatingDataForAccount(account);
     }
 
-    // Subscribe account to all possible subscriptions.
-    // TODO: Add app setting to toggle this behavior.
+    // Subscribe account to all possible subscriptions if setting enabled.
     if (account.queryMulti !== null) {
       const tasks =
         SubscriptionsController.getAllSubscriptionsForAccount(account);
@@ -128,15 +127,13 @@ export const useMainMessagePorts = () => {
         updateRenderedSubscriptions(task);
       }
 
-      // Subscribe to tasks.
-      await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
+      // Subscribe to tasks if app setting enabled.
+      ConfigRenderer.enableAutomaticSubscriptions &&
+        (await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti));
 
       // Update React subscriptions state.
       setSubscriptionsState();
     }
-
-    // Update React state.
-    setSubscriptionsState();
 
     // Add account to address context state.
     importAddress(chainId, source, address, name);

--- a/src/renderer/screens/Settings/index.tsx
+++ b/src/renderer/screens/Settings/index.tsx
@@ -44,6 +44,14 @@ export const Settings: React.FC = () => {
         : map.set(category, [{ ...setting }]);
     }
 
+    // Sort by label.
+    for (const [category, settings] of map.entries()) {
+      map.set(
+        category,
+        settings.sort((a, b) => a.title.localeCompare(b.title))
+      );
+    }
+
     return map;
   };
 

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -17,7 +17,8 @@ export type SettingAction =
   | 'settings:execute:silenceOsNotifications'
   | 'settings:execute:importData'
   | 'settings:execute:exportData'
-  | 'settings:execute:showDebuggingSubscriptions';
+  | 'settings:execute:showDebuggingSubscriptions'
+  | 'settings:execute:enableAutomaticSubscriptions';
 
 export interface SettingItem {
   action: SettingAction;

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -9,6 +9,7 @@ export interface PersistedSettings {
   appSilenceOsNotifications: boolean;
   appShowOnAllWorkspaces: boolean;
   appShowDebuggingSubscriptions: boolean;
+  appEnableAutomaticSubscriptions: boolean;
 }
 
 export type SettingAction =


### PR DESCRIPTION
# Summary

This PR implements an `Enable Automatic Subscriptions` setting which is enabled by default.

When turned on, all possible subscriptions will be turned on for an account after it is imported.

When turned off, no subscriptions will be turned on after an account is imported. 