### PR TITLE
feat: polkassembly api integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@w3ux/utils": "^0.0.2",
     "@zondax/ledger-substrate": "^0.41.3",
     "auto-launch": "^5.0.6",
+    "axios": "^1.7.2",
     "bignumber.js": "^9.1.2",
     "date-fns": "^3.3.1",
     "electron-localshortcut": "^3.2.1",

--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -158,6 +158,14 @@ export const HelpConfig: HelpItems = [
     ],
   },
   {
+    key: 'help:settings:enablePolkassembly',
+    title: 'Enable Polkassembly Data',
+    definition: [
+      'Use the Polkassembly API to fetch OpenGov metadata including proposal titles and descriptions.',
+      'It is recommended to have this setting on if you wish to browse and subscribe to OpenGov referenda.',
+    ],
+  },
+  {
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -61,6 +61,7 @@ export class Config {
         appShowOnAllWorkspaces: true,
         appShowDebuggingSubscriptions: false,
         appEnableAutomaticSubscriptions: true,
+        appEnablePolkassemblyApi: true,
       };
 
       // Persist default settings to store and return them.

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -30,8 +30,16 @@ export const SettingsList: SettingItem[] = [
     title: 'Silence OS Notifications',
   },
   {
-    action: 'settings:execute:showDebuggingSubscriptions',
+    action: 'settings:execute:enablePolkassembly',
     category: 'General',
+    enabled: false,
+    helpKey: 'help:settings:enablePolkassembly',
+    settingType: 'switch',
+    title: 'Enable Polkassembly Data',
+  },
+  {
+    action: 'settings:execute:showDebuggingSubscriptions',
+    category: 'Subscriptions',
     enabled: false,
     helpKey: 'help:settings:showDebuggingSubscriptions',
     settingType: 'switch',
@@ -39,7 +47,7 @@ export const SettingsList: SettingItem[] = [
   },
   {
     action: 'settings:execute:enableAutomaticSubscriptions',
-    category: 'General',
+    category: 'Subscriptions',
     enabled: false,
     helpKey: 'help:settings:enableAutomaticSubscriptions',
     settingType: 'switch',

--- a/src/main.ts
+++ b/src/main.ts
@@ -489,9 +489,10 @@ app.whenReady().then(async () => {
 
   // Toggle an app setting.
   ipcMain.on('app:setting:toggle', (_, action: SettingAction) => {
+    const settings = ConfigMain.getAppSettings();
+
     switch (action) {
       case 'settings:execute:showDebuggingSubscriptions': {
-        const settings = ConfigMain.getAppSettings();
         const flag = !settings.appShowDebuggingSubscriptions;
         settings.appShowDebuggingSubscriptions = flag;
 
@@ -500,27 +501,27 @@ app.whenReady().then(async () => {
         break;
       }
       case 'settings:execute:silenceOsNotifications': {
-        const settings = ConfigMain.getAppSettings();
         const flag = !settings.appSilenceOsNotifications;
         settings.appSilenceOsNotifications = flag;
-
-        const key = ConfigMain.settingsStorageKey;
-        (store as Record<string, AnyData>).set(key, settings);
         break;
       }
       case 'settings:execute:enableAutomaticSubscriptions': {
-        const settings = ConfigMain.getAppSettings();
         const flag = !settings.appEnableAutomaticSubscriptions;
         settings.appEnableAutomaticSubscriptions = flag;
-
-        const key = ConfigMain.settingsStorageKey;
-        (store as Record<string, AnyData>).set(key, settings);
+        break;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        const flag = !settings.appEnablePolkassemblyApi;
+        settings.appEnablePolkassemblyApi = flag;
         break;
       }
       default: {
         break;
       }
     }
+
+    const key = ConfigMain.settingsStorageKey;
+    (store as Record<string, AnyData>).set(key, settings);
   });
 
   /**

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -36,6 +36,7 @@ import { TreasuryProvider } from './contexts/openGov/Treasury';
 import { ReferendaProvider } from './contexts/openGov/Referenda';
 import { ReferendaSubscriptionsProvider } from './contexts/openGov/ReferendaSubscriptions';
 import { TaskHandlerProvider } from './contexts/openGov/TaskHandler';
+import { PolkassemblyProvider } from './contexts/openGov/Polkassembly';
 
 // Other imports.
 import { Theme } from './Theme';
@@ -99,6 +100,7 @@ const getProvidersForWindow = () => {
         TracksProvider,
         TreasuryProvider,
         ReferendaProvider,
+        PolkassemblyProvider, // Requires useReferenda
         ReferendaSubscriptionsProvider,
         TaskHandlerProvider
       )(Theme);

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -99,8 +99,8 @@ const getProvidersForWindow = () => {
         ConnectionsProvider,
         TracksProvider,
         TreasuryProvider,
-        ReferendaProvider,
-        PolkassemblyProvider, // Requires useReferenda
+        PolkassemblyProvider,
+        ReferendaProvider, // Requires usePolkassembly
         ReferendaSubscriptionsProvider,
         TaskHandlerProvider
       )(Theme);

--- a/src/renderer/contexts/common/Help/types.ts
+++ b/src/renderer/contexts/common/Help/types.ts
@@ -62,6 +62,7 @@ export type HelpItemKey =
   | 'help:settings:exportData'
   | 'help:settings:showDebuggingSubscriptions'
   | 'help:settings:enableAutomaticSubscriptions'
+  | 'help:settings:enablePolkassembly'
   | 'help:openGov:track'
   | 'help:openGov:origin'
   | 'help:openGov:maxDeciding'

--- a/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -9,9 +9,11 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   silenceOsNotifications: false,
   showDebuggingSubscriptions: false,
   enableAutomaticSubscriptions: true,
+  enablePolkassemblyApi: true,
   setSilenceOsNotifications: (b) => {},
   handleDockedToggle: () => {},
   handleToggleSilenceOsNotifications: () => {},
   handleToggleShowDebuggingSubscriptions: () => {},
   handleToggleEnableAutomaticSubscriptions: () => {},
+  handleToggleEnablePolkassemblyApi: () => {},
 };

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -32,6 +32,10 @@ export const AppSettingsProvider = ({
   const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
     useState<boolean>(true);
 
+  /// Enable Polkassembly API.
+  const [enablePolkassemblyApi, setEnablePolkassemblyApi] =
+    useState<boolean>(true);
+
   // Get settings from main and initialise state.
   useEffect(() => {
     const initSettings = async () => {
@@ -40,6 +44,7 @@ export const AppSettingsProvider = ({
         appSilenceOsNotifications,
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
+        appEnablePolkassemblyApi,
       } = await window.myAPI.getAppSettings();
 
       // Set cached notifications flag in renderer config.
@@ -53,6 +58,7 @@ export const AppSettingsProvider = ({
       setSilenceOsNotifications(appSilenceOsNotifications);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
+      setEnablePolkassemblyApi(appEnablePolkassemblyApi);
     };
 
     initSettings();
@@ -100,6 +106,12 @@ export const AppSettingsProvider = ({
     window.myAPI.toggleSetting('settings:execute:enableAutomaticSubscriptions');
   };
 
+  /// Handle toggling enable Polkassembly API.
+  const handleToggleEnablePolkassemblyApi = () => {
+    setEnablePolkassemblyApi(!enablePolkassemblyApi);
+    window.myAPI.toggleSetting('settings:execute:enablePolkassembly');
+  };
+
   return (
     <AppSettingsContext.Provider
       value={{
@@ -107,10 +119,12 @@ export const AppSettingsProvider = ({
         silenceOsNotifications,
         showDebuggingSubscriptions,
         enableAutomaticSubscriptions,
+        enablePolkassemblyApi,
         handleDockedToggle,
         handleToggleSilenceOsNotifications,
         handleToggleShowDebuggingSubscriptions,
         handleToggleEnableAutomaticSubscriptions,
+        handleToggleEnablePolkassemblyApi,
         setSilenceOsNotifications,
       }}
     >

--- a/src/renderer/contexts/main/AppSettings/types.ts
+++ b/src/renderer/contexts/main/AppSettings/types.ts
@@ -6,9 +6,11 @@ export interface AppSettingsContextInterface {
   silenceOsNotifications: boolean;
   showDebuggingSubscriptions: boolean;
   enableAutomaticSubscriptions: boolean;
+  enablePolkassemblyApi: boolean;
   setSilenceOsNotifications: (b: boolean) => void;
   handleDockedToggle: () => void;
   handleToggleSilenceOsNotifications: () => void;
   handleToggleShowDebuggingSubscriptions: () => void;
   handleToggleEnableAutomaticSubscriptions: () => void;
+  handleToggleEnablePolkassemblyApi: () => void;
 }

--- a/src/renderer/contexts/openGov/Polkassembly/axios.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/axios.ts
@@ -13,8 +13,11 @@ export class AxiosPool {
   private static _axiosApi = axios.create();
   private static _pending = 0;
 
-  static MAX_REQUEST_COUNT = 5;
-  static INTERVAL_MS = 100;
+  private static MAX_REQUEST_COUNT = 5;
+  private static INTERVAL_MS = 10;
+
+  /// Total number of proposals to fetch.
+  static target = 0;
 
   /// Accessors
   static get api(): AxiosInstance {

--- a/src/renderer/contexts/openGov/Polkassembly/axios.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/axios.ts
@@ -7,6 +7,9 @@ import type { AxiosInstance } from 'axios';
 /**
  * Set up an Axios instance that limits the amount of requests it can process
  * at a given time.
+ *
+ * @todo Throw away class if it's not to be used in the initial stable version
+ * of Polkadot live.
  */
 export class AxiosPool {
   /// Data

--- a/src/renderer/contexts/openGov/Polkassembly/axios.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/axios.ts
@@ -1,0 +1,56 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import axios from 'axios';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Set up an Axios instance that limits the amount of requests it can process
+ * at a given time.
+ */
+export class AxiosPool {
+  /// Data
+  private static _axiosApi = axios.create();
+  private static _pending = 0;
+
+  static MAX_REQUEST_COUNT = 5;
+  static INTERVAL_MS = 100;
+
+  /// Accessors
+  static get api(): AxiosInstance {
+    return this._axiosApi;
+  }
+
+  /// Initialise
+  static initialise() {
+    console.log('>> Initialise axios pool');
+
+    // Axios request interceptor.
+    this._axiosApi.interceptors.request.use(
+      (config) =>
+        new Promise((resolve) => {
+          const interval = setInterval(() => {
+            if (this._pending < this.MAX_REQUEST_COUNT) {
+              this._pending++;
+              clearInterval(interval);
+              resolve(config);
+            }
+          }, this.INTERVAL_MS);
+        })
+    );
+
+    // Axios response interceptor.
+    this._axiosApi.interceptors.response.use(
+      (response) => {
+        this._pending = Math.max(0, this._pending - 1);
+        return Promise.resolve(response);
+      },
+      (error) => {
+        this._pending = Math.max(0, this._pending - 1);
+        return Promise.reject(error);
+      }
+    );
+  }
+}
+
+AxiosPool.initialise();

--- a/src/renderer/contexts/openGov/Polkassembly/defaults.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/defaults.ts
@@ -5,5 +5,6 @@
 import type { PolkassemblyContextInterface } from './types';
 
 export const defaultPolkassemblyContext: PolkassemblyContextInterface = {
-  proposals: null,
+  proposals: [],
+  fetchingProposals: false,
 };

--- a/src/renderer/contexts/openGov/Polkassembly/defaults.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/defaults.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { PolkassemblyContextInterface } from './types';
+
+export const defaultPolkassemblyContext: PolkassemblyContextInterface = {
+  proposals: null,
+};

--- a/src/renderer/contexts/openGov/Polkassembly/defaults.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/defaults.ts
@@ -8,4 +8,5 @@ export const defaultPolkassemblyContext: PolkassemblyContextInterface = {
   proposals: [],
   fetchingProposals: false,
   getProposal: () => null,
+  fetchProposals: () => new Promise(() => {}),
 };

--- a/src/renderer/contexts/openGov/Polkassembly/defaults.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/defaults.ts
@@ -7,4 +7,5 @@ import type { PolkassemblyContextInterface } from './types';
 export const defaultPolkassemblyContext: PolkassemblyContextInterface = {
   proposals: [],
   fetchingProposals: false,
+  getProposal: () => null,
 };

--- a/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
-import { useReferenda } from '../Referenda';
+import { createContext, useContext, useRef, useState } from 'react';
 import axios from 'axios';
+import type { ChainID } from '@/types/chains';
+import type { ActiveReferendaInfo } from '@/types/openGov';
 import type {
   PolkassemblyContextInterface,
   PolkassemblyProposal,
@@ -21,60 +22,51 @@ export const PolkassemblyProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { activeReferendaChainId, referenda, fetchingReferenda } =
-    useReferenda();
-
   const [proposals, setProposals] = useState<PolkassemblyProposal[]>([]);
   const [fetchingProposals, setFetchingProposals] = useState(false);
   const proposalsRef = useRef<PolkassemblyProposal[]>([]);
 
   /// Fetch proposal data after referenda have been loaded in referenda context.
-  useEffect(() => {
-    if (fetchingReferenda) {
-      return;
-    }
-
+  const fetchProposals = async (
+    chainId: ChainID,
+    referenda: ActiveReferendaInfo[]
+  ) => {
     setFetchingProposals(true);
 
-    // Fetch proposal data using Polkassembly API.
-    const fetchProposals = async () => {
-      // Create Axios instance with base URL to Polkassembly API.
-      const axiosApi = axios.create({
-        baseURL: `https://api.polkassembly.io/api/v1/`,
-      });
+    // Create Axios instance with base URL to Polkassembly API.
+    const axiosApi = axios.create({
+      baseURL: `https://api.polkassembly.io/api/v1/`,
+    });
 
-      // Header requires `polkadot` or `kusama`.
-      const network = (activeReferendaChainId as string).toLowerCase();
+    // Header requires `polkadot` or `kusama`.
+    const network = (chainId as string).toLowerCase();
 
-      // Make asynchronous requests to Polkassembly API for each referenda.
-      const results = await Promise.all(
-        referenda.map(({ referendaId }) =>
-          axiosApi.get(
-            `/posts/on-chain-post?postId=${referendaId}&proposalType=referendums_v2`,
-            {
-              maxBodyLength: Infinity,
-              headers: { 'x-network': network },
-            }
-          )
+    // Make asynchronous requests to Polkassembly API for each referenda.
+    const results = await Promise.all(
+      referenda.map(({ referendaId }) =>
+        axiosApi.get(
+          `/posts/on-chain-post?postId=${referendaId}&proposalType=referendums_v2`,
+          {
+            maxBodyLength: Infinity,
+            headers: { 'x-network': network },
+          }
         )
-      );
+      )
+    );
 
-      // Store fetched proposals in state and render in OpenGov window.
-      const collection: PolkassemblyProposal[] = [];
+    // Store fetched proposals in state and render in OpenGov window.
+    const collection: PolkassemblyProposal[] = [];
 
-      for (const response of results) {
-        const { content, post_id, status, title } = response.data;
-        collection.push({ title, postId: post_id, content, status });
-      }
+    for (const response of results) {
+      const { content, post_id, status, title } = response.data;
+      collection.push({ title, postId: post_id, content, status });
+    }
 
-      // Set context state.
-      setProposals([...collection]);
-      setFetchingProposals(false);
-      proposalsRef.current = [...collection];
-    };
-
-    fetchProposals();
-  }, [fetchingReferenda]);
+    // Set context state.
+    setProposals([...collection]);
+    setFetchingProposals(false);
+    proposalsRef.current = [...collection];
+  };
 
   /// Get polkassembly proposal via referendum id.
   const getProposal = (referendumId: number): PolkassemblyProposal | null =>
@@ -86,6 +78,7 @@ export const PolkassemblyProvider = ({
         proposals,
         fetchingProposals,
         getProposal,
+        fetchProposals,
       }}
     >
       {children}

--- a/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
-import { createContext, useContext, useRef, useState } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import type { ChainID } from '@/types/chains';
 import type { ActiveReferendaInfo } from '@/types/openGov';
@@ -22,6 +22,17 @@ export const PolkassemblyProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const [usePolkassemblyApi, setUsePolkassemblyApi] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchSetting = async () => {
+      const { appEnablePolkassemblyApi } = await window.myAPI.getAppSettings();
+      setUsePolkassemblyApi(appEnablePolkassemblyApi);
+    };
+
+    fetchSetting();
+  }, []);
+
   const [proposals, setProposals] = useState<PolkassemblyProposal[]>([]);
   const [fetchingProposals, setFetchingProposals] = useState(false);
   const proposalsRef = useRef<PolkassemblyProposal[]>([]);
@@ -76,9 +87,11 @@ export const PolkassemblyProvider = ({
     <PolkassemblyContext.Provider
       value={{
         proposals,
-        fetchingProposals,
         getProposal,
         fetchProposals,
+        fetchingProposals,
+        usePolkassemblyApi,
+        setUsePolkassemblyApi,
       }}
     >
       {children}

--- a/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -76,11 +76,16 @@ export const PolkassemblyProvider = ({
     fetchProposals();
   }, [fetchingReferenda]);
 
+  /// Get polkassembly proposal via referendum id.
+  const getProposal = (referendumId: number): PolkassemblyProposal | null =>
+    proposals.find(({ postId }) => postId === referendumId) || null;
+
   return (
     <PolkassemblyContext.Provider
       value={{
         proposals,
         fetchingProposals,
+        getProposal,
       }}
     >
       {children}

--- a/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -1,0 +1,42 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { createContext, useContext, useEffect } from 'react';
+import type { PolkassemblyContextInterface } from './types';
+import { useReferenda } from '../Referenda';
+
+export const PolkassemblyContext = createContext<PolkassemblyContextInterface>(
+  defaults.defaultPolkassemblyContext
+);
+
+export const usePolkassembly = () => useContext(PolkassemblyContext);
+
+export const PolkassemblyProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { referenda, fetchingReferenda } = useReferenda();
+
+  /// Fetch proposal data after referenda have been loaded in referenda context.
+  useEffect(() => {
+    if (fetchingReferenda) {
+      return;
+    }
+
+    // TODO: Fetch proposal data using Polkassembly API.
+    const referendaIds = referenda.map(({ referendaId }) => referendaId);
+    console.log(referendaIds);
+  }, [fetchingReferenda]);
+
+  return (
+    <PolkassemblyContext.Provider
+      value={{
+        proposals: null,
+      }}
+    >
+      {children}
+    </PolkassemblyContext.Provider>
+  );
+};

--- a/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -1,6 +1,9 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { ChainID } from '@/types/chains';
+import type { ActiveReferendaInfo } from '@/types/openGov';
+
 export interface PolkassemblyProposal {
   title: string;
   postId: number;
@@ -12,4 +15,8 @@ export interface PolkassemblyContextInterface {
   proposals: PolkassemblyProposal[];
   fetchingProposals: boolean;
   getProposal: (referendumId: number) => PolkassemblyProposal | null;
+  fetchProposals: (
+    chainId: ChainID,
+    referenda: ActiveReferendaInfo[]
+  ) => Promise<void>;
 }

--- a/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -19,4 +19,6 @@ export interface PolkassemblyContextInterface {
     chainId: ChainID,
     referenda: ActiveReferendaInfo[]
   ) => Promise<void>;
+  usePolkassemblyApi: boolean;
+  setUsePolkassemblyApi: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -1,8 +1,14 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyData } from '@/types/misc';
+export interface PolkassemblyProposal {
+  title: string;
+  postId: number;
+  content: string;
+  status: string;
+}
 
 export interface PolkassemblyContextInterface {
-  proposals: AnyData;
+  proposals: PolkassemblyProposal[];
+  fetchingProposals: boolean;
 }

--- a/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -11,4 +11,5 @@ export interface PolkassemblyProposal {
 export interface PolkassemblyContextInterface {
   proposals: PolkassemblyProposal[];
   fetchingProposals: boolean;
+  getProposal: (referendumId: number) => PolkassemblyProposal | null;
 }

--- a/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -1,0 +1,8 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AnyData } from '@/types/misc';
+
+export interface PolkassemblyContextInterface {
+  proposals: AnyData;
+}

--- a/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -8,7 +8,7 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   referenda: [],
   fetchingReferenda: false,
   activeReferendaChainId: 'Polkadot',
-  receiveReferendaData: (i) => {},
+  receiveReferendaData: (i) => new Promise(() => {}),
   fetchReferendaData: (c) => {},
   refetchReferenda: () => {},
   setReferenda: (r) => {},

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -23,7 +23,7 @@ export const ReferendaProvider = ({
   children: React.ReactNode;
 }) => {
   const { isConnected } = useConnections();
-  const { fetchProposals } = usePolkassembly();
+  const { fetchProposals, setUsePolkassemblyApi } = usePolkassembly();
 
   /// Ref to indiciate if referenda data has been fetched.
   const dataCachedRef = useRef(false);
@@ -70,8 +70,14 @@ export const ReferendaProvider = ({
   const receiveReferendaData = async (info: ActiveReferendaInfo[]) => {
     setReferenda(info);
 
-    // TODO: Fetch proposals if Polkassembly enabled.
-    await fetchProposals(activeReferendaChainId, info);
+    // Get Polkassembly enabled setting.
+    const { appEnablePolkassemblyApi } = await window.myAPI.getAppSettings();
+    setUsePolkassemblyApi(appEnablePolkassemblyApi);
+
+    // Fetch proposal metadata if Polkassembly enabled.
+    if (appEnablePolkassemblyApi) {
+      await fetchProposals(activeReferendaChainId, info);
+    }
 
     dataCachedRef.current = true;
     setFetchingReferenda(false);

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -6,6 +6,7 @@ import { Config as ConfigOpenGov } from '@/config/processes/openGov';
 import { createContext, useContext, useRef, useState } from 'react';
 import { getOrderedOrigins } from '@/renderer/utils/openGovUtils';
 import { useConnections } from '@app/contexts/common/Connections';
+import { usePolkassembly } from '../Polkassembly';
 import type { ChainID } from '@/types/chains';
 import type { ReferendaContextInterface } from './types';
 import type { ActiveReferendaInfo } from '@/types/openGov';
@@ -22,6 +23,7 @@ export const ReferendaProvider = ({
   children: React.ReactNode;
 }) => {
   const { isConnected } = useConnections();
+  const { fetchProposals } = usePolkassembly();
 
   /// Ref to indiciate if referenda data has been fetched.
   const dataCachedRef = useRef(false);
@@ -65,10 +67,14 @@ export const ReferendaProvider = ({
   };
 
   /// Set state after receiving referenda data from main renderer.
-  const receiveReferendaData = (info: ActiveReferendaInfo[]) => {
+  const receiveReferendaData = async (info: ActiveReferendaInfo[]) => {
     setReferenda(info);
-    setFetchingReferenda(false);
+
+    // TODO: Fetch proposals if Polkassembly enabled.
+    await fetchProposals(activeReferendaChainId, info);
+
     dataCachedRef.current = true;
+    setFetchingReferenda(false);
   };
 
   /// Get all referenda sorted by desc or asc.

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -37,6 +37,7 @@ export const ReferendaProvider = ({
   /// Chain ID for currently rendered referenda.
   const [activeReferendaChainId, setActiveReferendaChainId] =
     useState<ChainID>('Polkadot');
+  const activeReferendaChainRef = useRef(activeReferendaChainId);
 
   /// Initiate feching referenda data.
   const fetchReferendaData = (chainId: ChainID) => {
@@ -49,6 +50,7 @@ export const ReferendaProvider = ({
     }
 
     setActiveReferendaChainId(chainId);
+    activeReferendaChainRef.current = chainId;
     setFetchingReferenda(true);
 
     ConfigOpenGov.portOpenGov.postMessage({
@@ -76,7 +78,7 @@ export const ReferendaProvider = ({
 
     // Fetch proposal metadata if Polkassembly enabled.
     if (appEnablePolkassemblyApi) {
-      await fetchProposals(activeReferendaChainId, info);
+      await fetchProposals(activeReferendaChainRef.current, info);
     }
 
     dataCachedRef.current = true;

--- a/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/src/renderer/contexts/openGov/Referenda/types.ts
@@ -10,7 +10,7 @@ export interface ReferendaContextInterface {
   activeReferendaChainId: ChainID;
   fetchReferendaData: (chainId: ChainID) => void;
   refetchReferenda: () => void;
-  receiveReferendaData: (info: ActiveReferendaInfo[]) => void;
+  receiveReferendaData: (info: ActiveReferendaInfo[]) => Promise<void>;
   setReferenda: (referenda: ActiveReferendaInfo[]) => void;
   setFetchingReferenda: (flag: boolean) => void;
   getSortedActiveReferenda: (

--- a/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -26,6 +26,7 @@ export const SettingFlagsProvider = ({
     useState(false);
   const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
     useState(true);
+  const [enablePolkassemblyApi, setEnablePolkassemblyApi] = useState(true);
 
   /// Fetch settings from store and set state.
   useEffect(() => {
@@ -36,6 +37,7 @@ export const SettingFlagsProvider = ({
         appShowOnAllWorkspaces,
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
+        appEnablePolkassemblyApi,
       } = await window.myAPI.getAppSettings();
 
       setWindowDocked(appDocked);
@@ -43,6 +45,7 @@ export const SettingFlagsProvider = ({
       setShowOnAllWorkspaces(appShowOnAllWorkspaces);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
+      setEnablePolkassemblyApi(appEnablePolkassemblyApi);
     };
 
     initSettings();
@@ -67,6 +70,9 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:enableAutomaticSubscriptions': {
         return enableAutomaticSubscriptions;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        return enablePolkassemblyApi;
       }
       default: {
         return true;
@@ -97,6 +103,10 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:enableAutomaticSubscriptions': {
         setEnableAutomaticSubscriptions(!enableAutomaticSubscriptions);
+        break;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        setEnablePolkassemblyApi(!enablePolkassemblyApi);
         break;
       }
       default: {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -58,6 +58,7 @@ export const useMainMessagePorts = () => {
     handleToggleSilenceOsNotifications,
     handleToggleShowDebuggingSubscriptions,
     handleToggleEnableAutomaticSubscriptions,
+    handleToggleEnablePolkassemblyApi,
   } = useAppSettings();
 
   const { setAccountSubscriptions, updateAccountNameInTasks, updateTask } =
@@ -738,6 +739,10 @@ export const useMainMessagePorts = () => {
             }
             case 'settings:execute:enableAutomaticSubscriptions': {
               handleEnableAutomaticSubscriptions();
+              break;
+            }
+            case 'settings:execute:enablePolkassembly': {
+              handleToggleEnablePolkassemblyApi();
               break;
             }
             case 'settings:execute:exportData': {

--- a/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -36,7 +36,7 @@ export const useOpenGovMessagePorts = () => {
       case 'main-openGov:openGov': {
         ConfigOpenGov.portOpenGov = e.ports[0];
 
-        ConfigOpenGov.portOpenGov.onmessage = (ev: MessageEvent) => {
+        ConfigOpenGov.portOpenGov.onmessage = async (ev: MessageEvent) => {
           // Message received from `main`.
           switch (ev.data.task) {
             case 'openGov:connection:status': {
@@ -51,7 +51,7 @@ export const useOpenGovMessagePorts = () => {
             case 'openGov:referenda:receive': {
               const { json } = ev.data.data;
               const parsed: ActiveReferendaInfo[] = JSON.parse(json);
-              receiveReferendaData(parsed);
+              await receiveReferendaData(parsed);
               break;
             }
             case 'openGov:treasury:set': {

--- a/src/renderer/library/Accordion/types.ts
+++ b/src/renderer/library/Accordion/types.ts
@@ -5,7 +5,7 @@ import type { AnyFunction } from '@w3ux/utils/types';
 
 export interface AccordionProps {
   children: React.ReactNode;
-  multiple: boolean | string;
+  multiple?: boolean | string;
   defaultIndex: number | number[];
   indicesRef?: React.MutableRefObject<number[]>;
   setExternalIndices?: AnyFunction;

--- a/src/renderer/screens/OpenGov/Referenda/InfoOverlay.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/InfoOverlay.tsx
@@ -1,0 +1,31 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
+import { MoreOverlay } from './Wrappers';
+import { Scrollable } from '@/renderer/utils/common';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
+import type { PolkassemblyProposal } from '@/renderer/contexts/openGov/Polkassembly/types';
+
+interface InfoOverlayProps {
+  proposalData: PolkassemblyProposal;
+}
+
+export const InfoOverlay = ({ proposalData }: InfoOverlayProps) => {
+  const { setStatus } = useOverlay();
+
+  return (
+    <MoreOverlay>
+      <Scrollable style={{ height: 'auto', padding: '1rem' }}>
+        <div className="content">
+          <h1>{proposalData?.title}</h1>
+
+          <div className="outer-wrapper">
+            <div className="description">{proposalData?.content}</div>
+          </div>
+          <ButtonPrimaryInvert text="Close" onClick={() => setStatus(0)} />
+        </div>
+      </Scrollable>
+    </MoreOverlay>
+  );
+};

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -46,7 +46,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
     removeIntervalSubscription,
   } = useTaskHandler();
 
-  const { fetchingProposals, getProposal } = usePolkassembly();
+  const { getProposal, usePolkassemblyApi } = usePolkassembly();
   const proposalData = getProposal(referendaId);
 
   /// Whether subscriptions are showing.
@@ -83,15 +83,17 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
               <FontAwesomeIcon icon={faHashtag} transform={'shrink-0'} />
               {referendum.referendaId}
             </span>
-            {fetchingProposals || !proposalData ? (
-              <h4 className="mw-20">{renderOrigin(referendum)}</h4>
-            ) : (
+            {usePolkassemblyApi ? (
               <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <h4 className="mw-20">{getProposalTitle(proposalData)}</h4>
+                <h4 className="mw-20">
+                  {proposalData ? getProposalTitle(proposalData) : ''}
+                </h4>
                 <p style={{ margin: 0, fontSize: '0.9rem' }}>
                   {renderOrigin(referendum)}
                 </p>
               </div>
+            ) : (
+              <h4 className="mw-20">{renderOrigin(referendum)}</h4>
             )}
           </div>
         </div>

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { intervalTasks as allIntervalTasks } from '@/config/subscriptions/interval';
-import { ReferendumRowWrapper } from './Wrappers';
+import { MoreButton, ReferendumRowWrapper, TitleWithOrigin } from './Wrappers';
 import { renderOrigin } from '@/renderer/utils/openGovUtils';
+import { ellipsisFn } from '@w3ux/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHashtag } from '@fortawesome/pro-light-svg-icons';
 import { useReferenda } from '@/renderer/contexts/openGov/Referenda';
 import { useReferendaSubscriptions } from '@/renderer/contexts/openGov/ReferendaSubscriptions';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
-import { faHashtag } from '@fortawesome/pro-light-svg-icons';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import { useState } from 'react';
 import { useTaskHandler } from '@/renderer/contexts/openGov/TaskHandler';
@@ -24,16 +26,17 @@ import {
   faPlusLarge,
 } from '@fortawesome/pro-solid-svg-icons';
 import { ControlsWrapper, SortControlButton } from '@/renderer/utils/common';
+import { InfoOverlay } from './InfoOverlay';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
 import type { ReferendumRowProps } from '../types';
 import type { PolkassemblyProposal } from '@/renderer/contexts/openGov/Polkassembly/types';
-import { ellipsisFn } from '@w3ux/utils';
 
 export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const { referendaId } = referendum;
 
   const { setTooltipTextAndOpen } = useTooltip();
   const { openHelp } = useHelp();
+  const { openOverlayWith } = useOverlay();
 
   const { activeReferendaChainId: chainId } = useReferenda();
   const { isSubscribedToTask, allSubscriptionsAdded } =
@@ -74,6 +77,10 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
     );
   };
 
+  const handleMoreClick = () => {
+    openOverlayWith(<InfoOverlay proposalData={proposalData!} />, 'large');
+  };
+
   return (
     <ReferendumRowWrapper>
       <div className="content-wrapper">
@@ -84,14 +91,15 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
               {referendum.referendaId}
             </span>
             {usePolkassemblyApi ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <h4 className="mw-20">
-                  {proposalData ? getProposalTitle(proposalData) : ''}
-                </h4>
-                <p style={{ margin: 0, fontSize: '0.9rem' }}>
-                  {renderOrigin(referendum)}
-                </p>
-              </div>
+              <TitleWithOrigin>
+                <h4>{proposalData ? getProposalTitle(proposalData) : ''}</h4>
+                <div>
+                  <p>{renderOrigin(referendum)}</p>
+                  <MoreButton onClick={() => handleMoreClick()}>
+                    More
+                  </MoreButton>
+                </div>
+              </TitleWithOrigin>
             ) : (
               <h4 className="mw-20">{renderOrigin(referendum)}</h4>
             )}

--- a/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -5,10 +5,95 @@ import styled from 'styled-components';
 
 /**
  * Provides the following styled components:
+ *   TitleWithOrigin
+ *   MoreButton
+ *   MoreOverlay
  *   NoteWrapper
  *   ReferendaGroup
  *   ReferendumRowWrapper
  */
+
+export const TitleWithOrigin = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  h4 {
+    min-width: 18px;
+  }
+  div:nth-of-type(1) {
+    display: flex;
+    column-gap: 0.5rem;
+    align-items: center;
+
+    p {
+      margin: 0;
+      font-size: 0.9rem;
+    }
+  }
+`;
+
+export const MoreButton = styled.button`
+  font-size: 0.85rem;
+  background-color: var(--border-primary-color);
+  padding: 1px 6px;
+  border-radius: 1.25rem;
+  transition: background-color 0.2s ease-out;
+
+  &:hover {
+    background-color: var(--border-mid-color);
+  }
+`;
+
+export const MoreOverlay = styled.div`
+  width: 100%;
+  padding: 1rem 1rem;
+  border: 1px solid var(--border-primary-color);
+  background-color: var(--background-default);
+  z-index: 20;
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    row-gap: 1.5rem;
+
+    h1 {
+      font-size: 1.25rem;
+      text-align: center;
+    }
+
+    .outer-wrapper {
+      --border-style: 1px solid #1f1f1f;
+      border-top: var(--border-style);
+      border-bottom: var(--border-style);
+
+      background-color: #111;
+      padding: 0.75rem;
+      max-width: 100%;
+
+      .description {
+        padding: 1rem;
+        white-space: pre-wrap;
+        position: relative;
+        max-height: 240px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        font-size: 1.05rem;
+        line-height: 1.6rem;
+
+        &::-webkit-scrollbar {
+          width: 5px;
+        }
+        &::-webkit-scrollbar-track {
+          background-color: #101010;
+        }
+        &::-webkit-scrollbar-thumb {
+          background-color: #212121;
+        }
+      }
+    }
+  }
+`;
 
 export const NoteWrapper = styled.div`
   padding: 0.75rem 1.5rem;

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -36,10 +36,12 @@ import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCare
 import { useReferendaSubscriptions } from '@/renderer/contexts/openGov/ReferendaSubscriptions';
 import type { ReferendaProps } from '../types';
 import { usePolkassembly } from '@/renderer/contexts/openGov/Polkassembly';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
 
 export const Referenda = ({ setSection }: ReferendaProps) => {
   const { isConnected } = useConnections();
   const { setTooltipTextAndOpen } = useTooltip();
+  const { status: overlayStatus } = useOverlay();
 
   const {
     referenda,
@@ -397,7 +399,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
 
           {/* Sticky Headings */}
           {!groupingOn && !fetchingReferenda && (
-            <StickyHeadings>
+            <StickyHeadings style={{ opacity: overlayStatus === 0 ? 1 : 0 }}>
               <div className="content-wrapper">
                 <div className="left">
                   <div className="heading">ID</div>

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -453,11 +453,6 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                 {fetchingReferenda ? '-' : referenda.length}
               </span>
             </div>
-            {fetchingProposals && (
-              <div className="footer-stat animate-fade">
-                <h2>Fetching from Polkassembly...</h2>
-              </div>
-            )}
           </section>
         </div>
       </StatsFooter>

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -35,6 +35,7 @@ import {
 import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCaretHeaders';
 import { useReferendaSubscriptions } from '@/renderer/contexts/openGov/ReferendaSubscriptions';
 import type { ReferendaProps } from '../types';
+import { usePolkassembly } from '@/renderer/contexts/openGov/Polkassembly';
 
 export const Referenda = ({ setSection }: ReferendaProps) => {
   const { isConnected } = useConnections();
@@ -49,6 +50,9 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     getSortedActiveReferenda,
     getCategorisedReferenda,
   } = useReferenda();
+
+  const { fetchingProposals, proposals } = usePolkassembly();
+  console.log(fetchingProposals);
 
   const { isSubscribedToReferendum, isNotSubscribedToAny } =
     useReferendaSubscriptions();
@@ -398,7 +402,11 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
               <div className="content-wrapper">
                 <div className="left">
                   <div className="heading">ID</div>
-                  <div className="heading">Origin</div>
+                  <div className="heading">
+                    {fetchingProposals || !proposals.length
+                      ? 'Origin'
+                      : 'Title and Origin'}
+                  </div>
                 </div>
                 <div className="right">
                   <div className="heading">Portal Links</div>
@@ -445,6 +453,11 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                 {fetchingReferenda ? '-' : referenda.length}
               </span>
             </div>
+            {fetchingProposals && (
+              <div className="footer-stat animate-fade">
+                <h2>Fetching from Polkassembly...</h2>
+              </div>
+            )}
           </section>
         </div>
       </StatsFooter>

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -51,8 +51,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     getCategorisedReferenda,
   } = useReferenda();
 
-  const { fetchingProposals, proposals } = usePolkassembly();
-  console.log(fetchingProposals);
+  const { usePolkassemblyApi } = usePolkassembly();
 
   const { isSubscribedToReferendum, isNotSubscribedToAny } =
     useReferendaSubscriptions();
@@ -403,9 +402,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                 <div className="left">
                   <div className="heading">ID</div>
                   <div className="heading">
-                    {fetchingProposals || !proposals.length
-                      ? 'Origin'
-                      : 'Title and Origin'}
+                    {usePolkassemblyApi ? 'Title and Origin' : 'Origin'}
                   </div>
                 </div>
                 <div className="right">

--- a/src/renderer/screens/Settings/index.tsx
+++ b/src/renderer/screens/Settings/index.tsx
@@ -15,24 +15,23 @@ import { useState } from 'react';
 import { Config as ConfigSettings } from '@/config/processes/settings';
 import { useSettingsMessagePorts } from '@/renderer/hooks/useSettingsMessagePorts';
 import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCaretHeaders';
-import type { SettingItem } from './types';
 import { Scrollable } from '@/renderer/utils/common';
+import type { SettingItem } from './types';
 
 export const Settings: React.FC = () => {
   // Set up port communication for `settings` window.
   useSettingsMessagePorts();
 
   /// Active accordion indices for settings panels.
-  const [accordionActiveIndices, setAccordionActiveIndices] = useState<
-    number[]
-  >([0, 1]);
+  const [accordionActiveIndices, setAccordionActiveIndices] =
+    useState<number>(0);
 
   /// Return a map of settings organised by their category.
   const getSortedSettings = () => {
     const map = new Map<string, SettingItem[]>();
 
     // Insert categories in a desired order.
-    for (const category of ['General', 'Backup']) {
+    for (const category of ['General', 'Subscriptions', 'Backup']) {
       map.set(category, []);
     }
 
@@ -78,7 +77,6 @@ export const Settings: React.FC = () => {
       <Scrollable $footerHeight={4} style={{ paddingTop: 0, paddingBottom: 0 }}>
         <ContentWrapper>
           <Accordion
-            multiple
             defaultIndex={accordionActiveIndices}
             setExternalIndices={setAccordionActiveIndices}
           >

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -10,6 +10,7 @@ export interface PersistedSettings {
   appShowOnAllWorkspaces: boolean;
   appShowDebuggingSubscriptions: boolean;
   appEnableAutomaticSubscriptions: boolean;
+  appEnablePolkassemblyApi: boolean;
 }
 
 export type SettingAction =
@@ -19,7 +20,8 @@ export type SettingAction =
   | 'settings:execute:importData'
   | 'settings:execute:exportData'
   | 'settings:execute:showDebuggingSubscriptions'
-  | 'settings:execute:enableAutomaticSubscriptions';
+  | 'settings:execute:enableAutomaticSubscriptions'
+  | 'settings:execute:enablePolkassembly';
 
 export interface SettingItem {
   action: SettingAction;

--- a/src/renderer/theme/utils.scss
+++ b/src/renderer/theme/utils.scss
@@ -7,3 +7,11 @@ SPDX-License-Identifier: GPL-3.0-only */
 .hide {
   display: none;
 }
+
+@keyframes fadeIn { 
+  from { opacity: 0.6; } 
+}
+.animate-fade {
+  opacity: 0.8;
+  animation: fadeIn 1s infinite alternate;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,6 +3529,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
+  languageName: node
+  linkType: hard
+
 "at-least-node@npm:^1.0.0":
   version: 1.0.0
   resolution: "at-least-node@npm:1.0.0"
@@ -3569,6 +3576,17 @@ __metadata:
   dependencies:
     possible-typed-array-names: "npm:^1.0.0"
   checksum: d07226ef4f87daa01bd0fe80f8f310982e345f372926da2e5296aecc25c41cab440916bbaa4c5e1034b453af3392f67df5961124e4b586df1e99793a1374bdb2
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "axios@npm:1.7.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.0"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: cbd47ce380fe045313364e740bb03b936420b8b5558c7ea36a4563db1258c658f05e40feb5ddd41f6633fdd96d37ac2a76f884dad599c5b0224b4c451b3fa7ae
   languageName: node
   linkType: hard
 
@@ -4335,6 +4353,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: "npm:~1.0.0"
+  checksum: 0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
 "commander@npm:^4.1.1":
   version: 4.1.1
   resolution: "commander@npm:4.1.1"
@@ -4768,6 +4795,13 @@ __metadata:
     escodegen: "npm:^2.1.0"
     esprima: "npm:^4.0.1"
   checksum: e48d8a651edeb512a648711a09afec269aac6de97d442a4bb9cf121a66877e0eec11b9727100a10252335c0666ae1c84a8bc1e3a3f47788742c975064d2c7b1c
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
   languageName: node
   linkType: hard
 
@@ -6253,6 +6287,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.6
+  resolution: "follow-redirects@npm:1.15.6"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -6276,6 +6320,17 @@ __metadata:
   version: 2.1.4
   resolution: "form-data-encoder@npm:2.1.4"
   checksum: 4c06ae2b79ad693a59938dc49ebd020ecb58e4584860a90a230f80a68b026483b022ba5e4143cff06ae5ac8fd446a0b500fabc87bbac3d1f62f2757f8dabcaf7
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    mime-types: "npm:^2.1.12"
+  checksum: cb6f3ac49180be03ff07ba3ff125f9eba2ff0b277fb33c7fc47569fc5e616882c5b1c69b9904c4c4187e97dd0419dd03b134174756f296dec62041e6527e2c6e
   languageName: node
   linkType: hard
 
@@ -8461,7 +8516,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -9716,6 +9771,7 @@ __metadata:
     "@wdio/types": "npm:^8.32.2"
     "@zondax/ledger-substrate": "npm:^0.41.3"
     auto-launch: "npm:^5.0.6"
+    axios: "npm:^1.7.2"
     bignumber.js: "npm:^9.1.2"
     date-fns: "npm:^3.3.1"
     debug: "npm:^4.3.4"


### PR DESCRIPTION
# Summary

This PR integrates the Polkassembly API into the OpenGov window to fetch proposal metadata. This metadata includes off-chain information about submitted referenda, such as its title and description.

The settings window includes a new switch labeled `Enable Polkassembly Data`, which allows users to turn on and off usage of the Polkassembly API. The app fetches proposal data faster if the switch is turned off and the Polkassembly API is not being used. On the other hand, the Polkassembly API is required to render proposal titles and descriptions - data that is not stored on-chain. 

With the Polkassembly API enabled, the user is able to click a `More` button for listed referenda. When clicked, an overlay renders the referendum's full title and description in a raw text format. The overlay is an initial solution to render basic proposal metadata, and will be improved in upcoming PRs.

## Merged PRs

[feat: polkassembly api toggle setting](https://github.com/polkadot-live/polkadot-live-app/pull/559)
This PR adds an app setting to enable or disable fetching data using the centralised Polkassembly API.

[feat: referenda info overlay](https://github.com/polkadot-live/polkadot-live-app/pull/560)
Initial implementation of an overlay that displays a referendum's title and description in raw text format.