### PR TITLE
feat: polkassembly api toggle setting

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -158,6 +158,14 @@ export const HelpConfig: HelpItems = [
     ],
   },
   {
+    key: 'help:settings:enablePolkassembly',
+    title: 'Enable Polkassembly Data',
+    definition: [
+      'Use the Polkassembly API to fetch OpenGov metadata including proposal titles and descriptions.',
+      'It is recommended to have this setting on if you wish to browse and subscribe to OpenGov referenda.',
+    ],
+  },
+  {
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -61,6 +61,7 @@ export class Config {
         appShowOnAllWorkspaces: true,
         appShowDebuggingSubscriptions: false,
         appEnableAutomaticSubscriptions: true,
+        appEnablePolkassemblyApi: true,
       };
 
       // Persist default settings to store and return them.

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -30,8 +30,16 @@ export const SettingsList: SettingItem[] = [
     title: 'Silence OS Notifications',
   },
   {
-    action: 'settings:execute:showDebuggingSubscriptions',
+    action: 'settings:execute:enablePolkassembly',
     category: 'General',
+    enabled: false,
+    helpKey: 'help:settings:enablePolkassembly',
+    settingType: 'switch',
+    title: 'Enable Polkassembly Data',
+  },
+  {
+    action: 'settings:execute:showDebuggingSubscriptions',
+    category: 'Subscriptions',
     enabled: false,
     helpKey: 'help:settings:showDebuggingSubscriptions',
     settingType: 'switch',
@@ -39,19 +47,11 @@ export const SettingsList: SettingItem[] = [
   },
   {
     action: 'settings:execute:enableAutomaticSubscriptions',
-    category: 'General',
+    category: 'Subscriptions',
     enabled: false,
     helpKey: 'help:settings:enableAutomaticSubscriptions',
     settingType: 'switch',
     title: 'Enable Automatic Subscriptions',
-  },
-  {
-    action: 'settings:execute:enablePolkassembly',
-    category: 'General',
-    enabled: false,
-    helpKey: 'help:settings:enablePolkassembly',
-    settingType: 'switch',
-    title: 'Enable Polkassembly Data',
   },
   {
     action: 'settings:execute:importData',

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -46,6 +46,14 @@ export const SettingsList: SettingItem[] = [
     title: 'Enable Automatic Subscriptions',
   },
   {
+    action: 'settings:execute:enablePolkassembly',
+    category: 'General',
+    enabled: false,
+    helpKey: 'help:settings:enablePolkassembly',
+    settingType: 'switch',
+    title: 'Enable Polkassembly Data',
+  },
+  {
     action: 'settings:execute:importData',
     category: 'Backup',
     buttonIcon: faFileImport,

--- a/src/main.ts
+++ b/src/main.ts
@@ -489,9 +489,10 @@ app.whenReady().then(async () => {
 
   // Toggle an app setting.
   ipcMain.on('app:setting:toggle', (_, action: SettingAction) => {
+    const settings = ConfigMain.getAppSettings();
+
     switch (action) {
       case 'settings:execute:showDebuggingSubscriptions': {
-        const settings = ConfigMain.getAppSettings();
         const flag = !settings.appShowDebuggingSubscriptions;
         settings.appShowDebuggingSubscriptions = flag;
 
@@ -500,27 +501,27 @@ app.whenReady().then(async () => {
         break;
       }
       case 'settings:execute:silenceOsNotifications': {
-        const settings = ConfigMain.getAppSettings();
         const flag = !settings.appSilenceOsNotifications;
         settings.appSilenceOsNotifications = flag;
-
-        const key = ConfigMain.settingsStorageKey;
-        (store as Record<string, AnyData>).set(key, settings);
         break;
       }
       case 'settings:execute:enableAutomaticSubscriptions': {
-        const settings = ConfigMain.getAppSettings();
         const flag = !settings.appEnableAutomaticSubscriptions;
         settings.appEnableAutomaticSubscriptions = flag;
-
-        const key = ConfigMain.settingsStorageKey;
-        (store as Record<string, AnyData>).set(key, settings);
+        break;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        const flag = !settings.appEnablePolkassemblyApi;
+        settings.appEnablePolkassemblyApi = flag;
         break;
       }
       default: {
         break;
       }
     }
+
+    const key = ConfigMain.settingsStorageKey;
+    (store as Record<string, AnyData>).set(key, settings);
   });
 
   /**

--- a/src/renderer/contexts/common/Help/types.ts
+++ b/src/renderer/contexts/common/Help/types.ts
@@ -62,6 +62,7 @@ export type HelpItemKey =
   | 'help:settings:exportData'
   | 'help:settings:showDebuggingSubscriptions'
   | 'help:settings:enableAutomaticSubscriptions'
+  | 'help:settings:enablePolkassembly'
   | 'help:openGov:track'
   | 'help:openGov:origin'
   | 'help:openGov:maxDeciding'

--- a/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -15,4 +15,5 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   handleToggleSilenceOsNotifications: () => {},
   handleToggleShowDebuggingSubscriptions: () => {},
   handleToggleEnableAutomaticSubscriptions: () => {},
+  handleToggleEnablePolkassemblyApi: () => {},
 };

--- a/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -9,6 +9,7 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   silenceOsNotifications: false,
   showDebuggingSubscriptions: false,
   enableAutomaticSubscriptions: true,
+  enablePolkassemblyApi: true,
   setSilenceOsNotifications: (b) => {},
   handleDockedToggle: () => {},
   handleToggleSilenceOsNotifications: () => {},

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -32,6 +32,10 @@ export const AppSettingsProvider = ({
   const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
     useState<boolean>(true);
 
+  /// Enable Polkassembly API.
+  const [enablePolkassemblyApi, setEnablePolkassemblyApi] =
+    useState<boolean>(true);
+
   // Get settings from main and initialise state.
   useEffect(() => {
     const initSettings = async () => {
@@ -40,6 +44,7 @@ export const AppSettingsProvider = ({
         appSilenceOsNotifications,
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
+        appEnablePolkassemblyApi,
       } = await window.myAPI.getAppSettings();
 
       // Set cached notifications flag in renderer config.
@@ -53,6 +58,7 @@ export const AppSettingsProvider = ({
       setSilenceOsNotifications(appSilenceOsNotifications);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
+      setEnablePolkassemblyApi(appEnablePolkassemblyApi);
     };
 
     initSettings();
@@ -107,6 +113,7 @@ export const AppSettingsProvider = ({
         silenceOsNotifications,
         showDebuggingSubscriptions,
         enableAutomaticSubscriptions,
+        enablePolkassemblyApi,
         handleDockedToggle,
         handleToggleSilenceOsNotifications,
         handleToggleShowDebuggingSubscriptions,

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -106,6 +106,12 @@ export const AppSettingsProvider = ({
     window.myAPI.toggleSetting('settings:execute:enableAutomaticSubscriptions');
   };
 
+  /// Handle toggling enable Polkassembly API.
+  const handleToggleEnablePolkassemblyApi = () => {
+    setEnablePolkassemblyApi(!enablePolkassemblyApi);
+    window.myAPI.toggleSetting('settings:execute:enablePolkassembly');
+  };
+
   return (
     <AppSettingsContext.Provider
       value={{
@@ -118,6 +124,7 @@ export const AppSettingsProvider = ({
         handleToggleSilenceOsNotifications,
         handleToggleShowDebuggingSubscriptions,
         handleToggleEnableAutomaticSubscriptions,
+        handleToggleEnablePolkassemblyApi,
         setSilenceOsNotifications,
       }}
     >

--- a/src/renderer/contexts/main/AppSettings/types.ts
+++ b/src/renderer/contexts/main/AppSettings/types.ts
@@ -6,6 +6,7 @@ export interface AppSettingsContextInterface {
   silenceOsNotifications: boolean;
   showDebuggingSubscriptions: boolean;
   enableAutomaticSubscriptions: boolean;
+  enablePolkassemblyApi: boolean;
   setSilenceOsNotifications: (b: boolean) => void;
   handleDockedToggle: () => void;
   handleToggleSilenceOsNotifications: () => void;

--- a/src/renderer/contexts/main/AppSettings/types.ts
+++ b/src/renderer/contexts/main/AppSettings/types.ts
@@ -12,4 +12,5 @@ export interface AppSettingsContextInterface {
   handleToggleSilenceOsNotifications: () => void;
   handleToggleShowDebuggingSubscriptions: () => void;
   handleToggleEnableAutomaticSubscriptions: () => void;
+  handleToggleEnablePolkassemblyApi: () => void;
 }

--- a/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
-import { createContext, useContext, useRef, useState } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import type { ChainID } from '@/types/chains';
 import type { ActiveReferendaInfo } from '@/types/openGov';
@@ -22,6 +22,17 @@ export const PolkassemblyProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const [usePolkassemblyApi, setUsePolkassemblyApi] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchSetting = async () => {
+      const { appEnablePolkassemblyApi } = await window.myAPI.getAppSettings();
+      setUsePolkassemblyApi(appEnablePolkassemblyApi);
+    };
+
+    fetchSetting();
+  }, []);
+
   const [proposals, setProposals] = useState<PolkassemblyProposal[]>([]);
   const [fetchingProposals, setFetchingProposals] = useState(false);
   const proposalsRef = useRef<PolkassemblyProposal[]>([]);
@@ -76,9 +87,11 @@ export const PolkassemblyProvider = ({
     <PolkassemblyContext.Provider
       value={{
         proposals,
-        fetchingProposals,
         getProposal,
         fetchProposals,
+        fetchingProposals,
+        usePolkassemblyApi,
+        setUsePolkassemblyApi,
       }}
     >
       {children}

--- a/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -19,4 +19,6 @@ export interface PolkassemblyContextInterface {
     chainId: ChainID,
     referenda: ActiveReferendaInfo[]
   ) => Promise<void>;
+  usePolkassemblyApi: boolean;
+  setUsePolkassemblyApi: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -23,7 +23,7 @@ export const ReferendaProvider = ({
   children: React.ReactNode;
 }) => {
   const { isConnected } = useConnections();
-  const { fetchProposals } = usePolkassembly();
+  const { fetchProposals, setUsePolkassemblyApi } = usePolkassembly();
 
   /// Ref to indiciate if referenda data has been fetched.
   const dataCachedRef = useRef(false);
@@ -70,8 +70,14 @@ export const ReferendaProvider = ({
   const receiveReferendaData = async (info: ActiveReferendaInfo[]) => {
     setReferenda(info);
 
-    // TODO: Fetch proposals if Polkassembly enabled.
-    await fetchProposals(activeReferendaChainId, info);
+    // Get Polkassembly enabled setting.
+    const { appEnablePolkassemblyApi } = await window.myAPI.getAppSettings();
+    setUsePolkassemblyApi(appEnablePolkassemblyApi);
+
+    // Fetch proposal metadata if Polkassembly enabled.
+    if (appEnablePolkassemblyApi) {
+      await fetchProposals(activeReferendaChainId, info);
+    }
 
     dataCachedRef.current = true;
     setFetchingReferenda(false);

--- a/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -26,6 +26,7 @@ export const SettingFlagsProvider = ({
     useState(false);
   const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
     useState(true);
+  const [enablePolkassemblyApi, setEnablePolkassemblyApi] = useState(true);
 
   /// Fetch settings from store and set state.
   useEffect(() => {
@@ -36,6 +37,7 @@ export const SettingFlagsProvider = ({
         appShowOnAllWorkspaces,
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
+        appEnablePolkassemblyApi,
       } = await window.myAPI.getAppSettings();
 
       setWindowDocked(appDocked);
@@ -43,6 +45,7 @@ export const SettingFlagsProvider = ({
       setShowOnAllWorkspaces(appShowOnAllWorkspaces);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
+      setEnablePolkassemblyApi(appEnablePolkassemblyApi);
     };
 
     initSettings();
@@ -67,6 +70,9 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:enableAutomaticSubscriptions': {
         return enableAutomaticSubscriptions;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        return enablePolkassemblyApi;
       }
       default: {
         return true;
@@ -97,6 +103,10 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:enableAutomaticSubscriptions': {
         setEnableAutomaticSubscriptions(!enableAutomaticSubscriptions);
+        break;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        setEnablePolkassemblyApi(!enablePolkassemblyApi);
         break;
       }
       default: {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -58,6 +58,7 @@ export const useMainMessagePorts = () => {
     handleToggleSilenceOsNotifications,
     handleToggleShowDebuggingSubscriptions,
     handleToggleEnableAutomaticSubscriptions,
+    handleToggleEnablePolkassemblyApi,
   } = useAppSettings();
 
   const { setAccountSubscriptions, updateAccountNameInTasks, updateTask } =
@@ -738,6 +739,10 @@ export const useMainMessagePorts = () => {
             }
             case 'settings:execute:enableAutomaticSubscriptions': {
               handleEnableAutomaticSubscriptions();
+              break;
+            }
+            case 'settings:execute:enablePolkassembly': {
+              handleToggleEnablePolkassemblyApi();
               break;
             }
             case 'settings:execute:exportData': {

--- a/src/renderer/library/Accordion/types.ts
+++ b/src/renderer/library/Accordion/types.ts
@@ -5,7 +5,7 @@ import type { AnyFunction } from '@w3ux/utils/types';
 
 export interface AccordionProps {
   children: React.ReactNode;
-  multiple: boolean | string;
+  multiple?: boolean | string;
   defaultIndex: number | number[];
   indicesRef?: React.MutableRefObject<number[]>;
   setExternalIndices?: AnyFunction;

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -46,7 +46,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
     removeIntervalSubscription,
   } = useTaskHandler();
 
-  const { fetchingProposals, getProposal } = usePolkassembly();
+  const { getProposal, usePolkassemblyApi } = usePolkassembly();
   const proposalData = getProposal(referendaId);
 
   /// Whether subscriptions are showing.
@@ -83,15 +83,17 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
               <FontAwesomeIcon icon={faHashtag} transform={'shrink-0'} />
               {referendum.referendaId}
             </span>
-            {fetchingProposals || !proposalData ? (
-              <h4 className="mw-20">{renderOrigin(referendum)}</h4>
-            ) : (
+            {usePolkassemblyApi ? (
               <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <h4 className="mw-20">{getProposalTitle(proposalData)}</h4>
+                <h4 className="mw-20">
+                  {proposalData ? getProposalTitle(proposalData) : ''}
+                </h4>
                 <p style={{ margin: 0, fontSize: '0.9rem' }}>
                   {renderOrigin(referendum)}
                 </p>
               </div>
+            ) : (
+              <h4 className="mw-20">{renderOrigin(referendum)}</h4>
             )}
           </div>
         </div>

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -51,8 +51,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     getCategorisedReferenda,
   } = useReferenda();
 
-  const { fetchingProposals, proposals } = usePolkassembly();
-  console.log(fetchingProposals);
+  const { usePolkassemblyApi } = usePolkassembly();
 
   const { isSubscribedToReferendum, isNotSubscribedToAny } =
     useReferendaSubscriptions();
@@ -403,9 +402,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                 <div className="left">
                   <div className="heading">ID</div>
                   <div className="heading">
-                    {fetchingProposals || !proposals.length
-                      ? 'Origin'
-                      : 'Title and Origin'}
+                    {usePolkassemblyApi ? 'Title and Origin' : 'Origin'}
                   </div>
                 </div>
                 <div className="right">

--- a/src/renderer/screens/Settings/index.tsx
+++ b/src/renderer/screens/Settings/index.tsx
@@ -15,8 +15,8 @@ import { useState } from 'react';
 import { Config as ConfigSettings } from '@/config/processes/settings';
 import { useSettingsMessagePorts } from '@/renderer/hooks/useSettingsMessagePorts';
 import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCaretHeaders';
-import type { SettingItem } from './types';
 import { Scrollable } from '@/renderer/utils/common';
+import type { SettingItem } from './types';
 
 export const Settings: React.FC = () => {
   // Set up port communication for `settings` window.

--- a/src/renderer/screens/Settings/index.tsx
+++ b/src/renderer/screens/Settings/index.tsx
@@ -23,16 +23,15 @@ export const Settings: React.FC = () => {
   useSettingsMessagePorts();
 
   /// Active accordion indices for settings panels.
-  const [accordionActiveIndices, setAccordionActiveIndices] = useState<
-    number[]
-  >([0, 1]);
+  const [accordionActiveIndices, setAccordionActiveIndices] =
+    useState<number>(0);
 
   /// Return a map of settings organised by their category.
   const getSortedSettings = () => {
     const map = new Map<string, SettingItem[]>();
 
     // Insert categories in a desired order.
-    for (const category of ['General', 'Backup']) {
+    for (const category of ['General', 'Subscriptions', 'Backup']) {
       map.set(category, []);
     }
 
@@ -78,7 +77,6 @@ export const Settings: React.FC = () => {
       <Scrollable $footerHeight={4} style={{ paddingTop: 0, paddingBottom: 0 }}>
         <ContentWrapper>
           <Accordion
-            multiple
             defaultIndex={accordionActiveIndices}
             setExternalIndices={setAccordionActiveIndices}
           >

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -10,6 +10,7 @@ export interface PersistedSettings {
   appShowOnAllWorkspaces: boolean;
   appShowDebuggingSubscriptions: boolean;
   appEnableAutomaticSubscriptions: boolean;
+  appEnablePolkassemblyApi: boolean;
 }
 
 export type SettingAction =

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -19,7 +19,8 @@ export type SettingAction =
   | 'settings:execute:importData'
   | 'settings:execute:exportData'
   | 'settings:execute:showDebuggingSubscriptions'
-  | 'settings:execute:enableAutomaticSubscriptions';
+  | 'settings:execute:enableAutomaticSubscriptions'
+  | 'settings:execute:enablePolkassembly';
 
 export interface SettingItem {
   action: SettingAction;


### PR DESCRIPTION
# Summary

This PR adds an app setting called `Enable Polkassembly Data`. 

When this setting is turned on, Polkadot Live uses the Polkassembly API to fetch proposal metadata, such as titles and descriptions of proposals.

When this setting is turned off, no such proposal metadata will be retrieved, and referenda will be listed with less information.

Users may prefer to turn this setting off to speed up fetching referenda, or not use a centralised API.