### PR TITLE
feat: referenda info overlay

### DIFF
--- a/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -37,6 +37,7 @@ export const ReferendaProvider = ({
   /// Chain ID for currently rendered referenda.
   const [activeReferendaChainId, setActiveReferendaChainId] =
     useState<ChainID>('Polkadot');
+  const activeReferendaChainRef = useRef(activeReferendaChainId);
 
   /// Initiate feching referenda data.
   const fetchReferendaData = (chainId: ChainID) => {
@@ -49,6 +50,7 @@ export const ReferendaProvider = ({
     }
 
     setActiveReferendaChainId(chainId);
+    activeReferendaChainRef.current = chainId;
     setFetchingReferenda(true);
 
     ConfigOpenGov.portOpenGov.postMessage({
@@ -76,7 +78,7 @@ export const ReferendaProvider = ({
 
     // Fetch proposal metadata if Polkassembly enabled.
     if (appEnablePolkassemblyApi) {
-      await fetchProposals(activeReferendaChainId, info);
+      await fetchProposals(activeReferendaChainRef.current, info);
     }
 
     dataCachedRef.current = true;

--- a/src/renderer/screens/OpenGov/Referenda/InfoOverlay.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/InfoOverlay.tsx
@@ -1,0 +1,31 @@
+// Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
+import { MoreOverlay } from './Wrappers';
+import { Scrollable } from '@/renderer/utils/common';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
+import type { PolkassemblyProposal } from '@/renderer/contexts/openGov/Polkassembly/types';
+
+interface InfoOverlayProps {
+  proposalData: PolkassemblyProposal;
+}
+
+export const InfoOverlay = ({ proposalData }: InfoOverlayProps) => {
+  const { setStatus } = useOverlay();
+
+  return (
+    <MoreOverlay>
+      <Scrollable style={{ height: 'auto', padding: '1rem' }}>
+        <div className="content">
+          <h1>{proposalData?.title}</h1>
+
+          <div className="outer-wrapper">
+            <div className="description">{proposalData?.content}</div>
+          </div>
+          <ButtonPrimaryInvert text="Close" onClick={() => setStatus(0)} />
+        </div>
+      </Scrollable>
+    </MoreOverlay>
+  );
+};

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { intervalTasks as allIntervalTasks } from '@/config/subscriptions/interval';
-import { MoreButton, MoreOverlay, ReferendumRowWrapper } from './Wrappers';
+import { MoreButton, ReferendumRowWrapper, TitleWithOrigin } from './Wrappers';
 import { renderOrigin } from '@/renderer/utils/openGovUtils';
 import { ellipsisFn } from '@w3ux/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -25,22 +25,18 @@ import {
   faPlus,
   faPlusLarge,
 } from '@fortawesome/pro-solid-svg-icons';
-import {
-  ControlsWrapper,
-  Scrollable,
-  SortControlButton,
-} from '@/renderer/utils/common';
+import { ControlsWrapper, SortControlButton } from '@/renderer/utils/common';
+import { InfoOverlay } from './InfoOverlay';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
 import type { ReferendumRowProps } from '../types';
 import type { PolkassemblyProposal } from '@/renderer/contexts/openGov/Polkassembly/types';
-import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 
 export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const { referendaId } = referendum;
 
   const { setTooltipTextAndOpen } = useTooltip();
   const { openHelp } = useHelp();
-  const { openOverlayWith, setStatus } = useOverlay();
+  const { openOverlayWith } = useOverlay();
 
   const { activeReferendaChainId: chainId } = useReferenda();
   const { isSubscribedToTask, allSubscriptionsAdded } =
@@ -81,6 +77,10 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
     );
   };
 
+  const handleMoreClick = () => {
+    openOverlayWith(<InfoOverlay proposalData={proposalData!} />, 'large');
+  };
+
   return (
     <ReferendumRowWrapper>
       <div className="content-wrapper">
@@ -91,50 +91,15 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
               {referendum.referendaId}
             </span>
             {usePolkassemblyApi ? (
-              <div style={{ display: 'flex', flexDirection: 'column' }}>
-                <h4 className="mw-20">
-                  {proposalData ? getProposalTitle(proposalData) : ''}
-                </h4>
-                <div
-                  style={{
-                    display: 'flex',
-                    columnGap: '0.5rem',
-                    alignItems: 'center',
-                  }}
-                >
-                  <p style={{ margin: 0, fontSize: '0.9rem' }}>
-                    {renderOrigin(referendum)}
-                  </p>
-                  <MoreButton
-                    onClick={() =>
-                      openOverlayWith(
-                        <MoreOverlay>
-                          <Scrollable
-                            style={{ height: 'auto', padding: '1rem' }}
-                          >
-                            <div className="content">
-                              <h1>{proposalData?.title}</h1>
-
-                              <div className="outer-wrapper">
-                                <div className="description">
-                                  {proposalData?.content}
-                                </div>
-                              </div>
-                              <ButtonPrimaryInvert
-                                text="Close"
-                                onClick={() => setStatus(0)}
-                              />
-                            </div>
-                          </Scrollable>
-                        </MoreOverlay>,
-                        'large'
-                      )
-                    }
-                  >
+              <TitleWithOrigin>
+                <h4>{proposalData ? getProposalTitle(proposalData) : ''}</h4>
+                <div>
+                  <p>{renderOrigin(referendum)}</p>
+                  <MoreButton onClick={() => handleMoreClick()}>
                     More
                   </MoreButton>
                 </div>
-              </div>
+              </TitleWithOrigin>
             ) : (
               <h4 className="mw-20">{renderOrigin(referendum)}</h4>
             )}

--- a/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { intervalTasks as allIntervalTasks } from '@/config/subscriptions/interval';
-import { ReferendumRowWrapper } from './Wrappers';
+import { MoreButton, MoreOverlay, ReferendumRowWrapper } from './Wrappers';
 import { renderOrigin } from '@/renderer/utils/openGovUtils';
+import { ellipsisFn } from '@w3ux/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faHashtag } from '@fortawesome/pro-light-svg-icons';
 import { useReferenda } from '@/renderer/contexts/openGov/Referenda';
 import { useReferendaSubscriptions } from '@/renderer/contexts/openGov/ReferendaSubscriptions';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
-import { faHashtag } from '@fortawesome/pro-light-svg-icons';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import { useState } from 'react';
 import { useTaskHandler } from '@/renderer/contexts/openGov/TaskHandler';
@@ -23,17 +25,22 @@ import {
   faPlus,
   faPlusLarge,
 } from '@fortawesome/pro-solid-svg-icons';
-import { ControlsWrapper, SortControlButton } from '@/renderer/utils/common';
+import {
+  ControlsWrapper,
+  Scrollable,
+  SortControlButton,
+} from '@/renderer/utils/common';
 import type { HelpItemKey } from '@/renderer/contexts/common/Help/types';
 import type { ReferendumRowProps } from '../types';
 import type { PolkassemblyProposal } from '@/renderer/contexts/openGov/Polkassembly/types';
-import { ellipsisFn } from '@w3ux/utils';
+import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 
 export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const { referendaId } = referendum;
 
   const { setTooltipTextAndOpen } = useTooltip();
   const { openHelp } = useHelp();
+  const { openOverlayWith, setStatus } = useOverlay();
 
   const { activeReferendaChainId: chainId } = useReferenda();
   const { isSubscribedToTask, allSubscriptionsAdded } =
@@ -88,9 +95,45 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
                 <h4 className="mw-20">
                   {proposalData ? getProposalTitle(proposalData) : ''}
                 </h4>
-                <p style={{ margin: 0, fontSize: '0.9rem' }}>
-                  {renderOrigin(referendum)}
-                </p>
+                <div
+                  style={{
+                    display: 'flex',
+                    columnGap: '0.5rem',
+                    alignItems: 'center',
+                  }}
+                >
+                  <p style={{ margin: 0, fontSize: '0.9rem' }}>
+                    {renderOrigin(referendum)}
+                  </p>
+                  <MoreButton
+                    onClick={() =>
+                      openOverlayWith(
+                        <MoreOverlay>
+                          <Scrollable
+                            style={{ height: 'auto', padding: '1rem' }}
+                          >
+                            <div className="content">
+                              <h1>{proposalData?.title}</h1>
+
+                              <div className="outer-wrapper">
+                                <div className="description">
+                                  {proposalData?.content}
+                                </div>
+                              </div>
+                              <ButtonPrimaryInvert
+                                text="Close"
+                                onClick={() => setStatus(0)}
+                              />
+                            </div>
+                          </Scrollable>
+                        </MoreOverlay>,
+                        'large'
+                      )
+                    }
+                  >
+                    More
+                  </MoreButton>
+                </div>
               </div>
             ) : (
               <h4 className="mw-20">{renderOrigin(referendum)}</h4>

--- a/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -5,10 +5,74 @@ import styled from 'styled-components';
 
 /**
  * Provides the following styled components:
+ *   MoreButton
  *   NoteWrapper
  *   ReferendaGroup
  *   ReferendumRowWrapper
  */
+
+export const MoreButton = styled.button`
+  font-size: 0.85rem;
+  background-color: var(--border-primary-color);
+  padding: 1px 6px;
+  border-radius: 1.25rem;
+  transition: background-color 0.2s ease-out;
+
+  &:hover {
+    background-color: var(--border-mid-color);
+  }
+`;
+
+export const MoreOverlay = styled.div`
+  width: 100%;
+  padding: 1rem 1rem;
+  border: 1px solid var(--border-primary-color);
+  background-color: var(--background-default);
+  z-index: 20;
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    row-gap: 1.5rem;
+
+    h1 {
+      font-size: 1.25rem;
+      text-align: center;
+    }
+
+    .outer-wrapper {
+      --border-style: 1px solid #1f1f1f;
+      border-top: var(--border-style);
+      border-bottom: var(--border-style);
+
+      background-color: #111;
+      padding: 0.75rem;
+      max-width: 100%;
+
+      .description {
+        padding: 1rem;
+        white-space: pre-wrap;
+        position: relative;
+        max-height: 240px;
+        overflow-y: auto;
+        overflow-x: hidden;
+        font-size: 1.05rem;
+        line-height: 1.6rem;
+
+        &::-webkit-scrollbar {
+          width: 5px;
+        }
+        &::-webkit-scrollbar-track {
+          background-color: #101010;
+        }
+        &::-webkit-scrollbar-thumb {
+          background-color: #212121;
+        }
+      }
+    }
+  }
+`;
 
 export const NoteWrapper = styled.div`
   padding: 0.75rem 1.5rem;

--- a/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -5,11 +5,32 @@ import styled from 'styled-components';
 
 /**
  * Provides the following styled components:
+ *   TitleWithOrigin
  *   MoreButton
+ *   MoreOverlay
  *   NoteWrapper
  *   ReferendaGroup
  *   ReferendumRowWrapper
  */
+
+export const TitleWithOrigin = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  h4 {
+    min-width: 18px;
+  }
+  div:nth-of-type(1) {
+    display: flex;
+    column-gap: 0.5rem;
+    align-items: center;
+
+    p {
+      margin: 0;
+      font-size: 0.9rem;
+    }
+  }
+`;
 
 export const MoreButton = styled.button`
   font-size: 0.85rem;

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -36,10 +36,12 @@ import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCare
 import { useReferendaSubscriptions } from '@/renderer/contexts/openGov/ReferendaSubscriptions';
 import type { ReferendaProps } from '../types';
 import { usePolkassembly } from '@/renderer/contexts/openGov/Polkassembly';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
 
 export const Referenda = ({ setSection }: ReferendaProps) => {
   const { isConnected } = useConnections();
   const { setTooltipTextAndOpen } = useTooltip();
+  const { status: overlayStatus } = useOverlay();
 
   const {
     referenda,
@@ -397,7 +399,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
 
           {/* Sticky Headings */}
           {!groupingOn && !fetchingReferenda && (
-            <StickyHeadings>
+            <StickyHeadings style={{ opacity: overlayStatus === 0 ? 1 : 0 }}>
               <div className="content-wrapper">
                 <div className="left">
                   <div className="heading">ID</div>


### PR DESCRIPTION
# Summary

Initial implementation of an overlay that displays a referendum's title and description in raw text format.

This overlay is opened after clicking the `More` button for a referendum when the Polkassembly API is enabled.