### PR TITLE
chore: action items ui iteration

### DIFF
--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -100,7 +100,9 @@ export const Item = memo(function Item({ event }: ItemProps) {
     actions.filter(({ uri }) => isValidHttpUrl(uri));
 
   // Flag to determine of primary actions exist for this event.
-  const hasPrimaryActions: boolean = getPrimaryActions().length > 0;
+  const hasPrimaryActions: boolean =
+    getPrimaryActions().length > 0 && source !== 'read-only';
+
   const hasSecondaryActions: boolean = getSecondaryActions().length > 0;
 
   // Flag indicating if action buttons are showing.

--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -153,7 +153,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
             className="dismiss-btn"
             onClick={async () => await handleDismissEvent()}
           >
-            <FontAwesomeIcon icon={faTimes} />
+            <FontAwesomeIcon icon={faTimes} transform={'shrink-2'} />
           </div>
 
           {/* Expand actions button */}
@@ -164,7 +164,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
             >
               <FontAwesomeIcon
                 icon={showActions ? faAngleUp : faAngleDown}
-                transform={'shrink-0'}
+                transform={'shrink-2'}
               />
             </div>
           )}

--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -174,9 +174,9 @@ export const Item = memo(function Item({ event }: ItemProps) {
               </div>
             </section>
 
-            {/* Render primary actions */}
-            {getPrimaryActions().length > 0 && (
+            {actions.length > 0 && (
               <section className="actions-wrapper">
+                {/* Render primary actions */}
                 <div className="actions">
                   {getPrimaryActions().map((action, i) => {
                     const { text } = action;
@@ -227,6 +227,12 @@ export const Item = memo(function Item({ event }: ItemProps) {
                       );
                     }
                   })}
+
+                  {/* Render secondary actions menu */}
+                  <ButtonMonoInvert
+                    text="More"
+                    onClick={() => console.log('todo')}
+                  />
                 </div>
               </section>
             )}

--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -85,6 +85,14 @@ export const Item = memo(function Item({ event }: ItemProps) {
   const showIconTooltip = () =>
     event.category !== 'openGov' && event.category !== 'debugging';
 
+  // Get primary actions that will always be rendered.
+  const getPrimaryActions = () =>
+    actions.filter(({ uri }) => !isValidHttpUrl(uri));
+
+  // Get secondary actions for rendering in actions menu.
+  const getSecondaryActions = () =>
+    actions.filter(({ uri }) => isValidHttpUrl(uri));
+
   return (
     <AnimatePresence>
       {/* Event item wrapper */}
@@ -166,33 +174,15 @@ export const Item = memo(function Item({ event }: ItemProps) {
               </div>
             </section>
 
-            {/* Render actions */}
-            {actions.length > 0 && (
-              <motion.section
-                className="actions-wrapper"
-                initial={{ height: 0 }}
-                animate={showActions ? 'open' : 'closed'}
-                variants={actionsVariants}
-                transition={{ type: 'spring', duration: 0.25, bounce: 0 }}
-              >
+            {/* Render primary actions */}
+            {getPrimaryActions().length > 0 && (
+              <section className="actions-wrapper">
                 <div className="actions">
-                  {actions.map((action, i) => {
-                    const { uri, text } = action;
+                  {getPrimaryActions().map((action, i) => {
+                    const { text } = action;
                     action.txMeta && (action.txMeta.eventUid = event.uid);
 
-                    const isUrl = isValidHttpUrl(uri);
-                    if (isUrl) {
-                      return (
-                        <ButtonMonoInvert
-                          key={`action_${uid}_${i}`}
-                          text={text || ''}
-                          iconRight={faExternalLinkAlt}
-                          onClick={() => {
-                            window.myAPI.openBrowserURL(uri);
-                          }}
-                        />
-                      );
-                    } else if (source === 'ledger') {
+                    if (source === 'ledger') {
                       return (
                         <div
                           key={`action_${uid}_${i}`}
@@ -236,6 +226,35 @@ export const Item = memo(function Item({ event }: ItemProps) {
                         />
                       );
                     }
+                  })}
+                </div>
+              </section>
+            )}
+
+            {/* Render secondary actions */}
+            {actions.length > 0 && (
+              <motion.section
+                className="actions-wrapper"
+                initial={{ height: 0 }}
+                animate={showActions ? 'open' : 'closed'}
+                variants={actionsVariants}
+                transition={{ type: 'spring', duration: 0.25, bounce: 0 }}
+              >
+                <div className="actions">
+                  {getSecondaryActions().map((action, i) => {
+                    const { uri, text } = action;
+                    action.txMeta && (action.txMeta.eventUid = event.uid);
+
+                    return (
+                      <ButtonMonoInvert
+                        key={`action_${uid}_${i}`}
+                        text={text || ''}
+                        iconRight={faExternalLinkAlt}
+                        onClick={() => {
+                          window.myAPI.openBrowserURL(uri);
+                        }}
+                      />
+                    );
                   })}
                 </div>
               </motion.section>

--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -81,7 +81,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
   }, [display]);
 
   // Variants for actions section.
-  const actionsSlideVariants = {
+  const actionsVariants = {
     openLeft: { height: 'auto', marginLeft: 0 },
     openRight: { height: 'auto', marginLeft: '-100%' },
     closedLeft: { height: 0, marginLeft: 0 },
@@ -104,7 +104,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
   const hasSecondaryActions: boolean = getSecondaryActions().length > 0;
 
   // Flag indicating if action buttons are showing.
-  const [showActions, setShowActions] = useState(false);
+  const [showActions, setShowActions] = useState(hasPrimaryActions);
 
   const [activeSide, setActiveSide] = useState<ActionsActiveSide>(() =>
     hasPrimaryActions ? 'left' : hasSecondaryActions ? 'right' : 'left'
@@ -205,7 +205,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
                 className="actions-wrapper"
                 initial={{ marginLeft: 0 }}
                 animate={getActionsVariant()}
-                variants={actionsSlideVariants}
+                variants={actionsVariants}
                 transition={{ type: 'spring', duration: 0.25, bounce: 0 }}
               >
                 {/* Render primary actions */}

--- a/src/renderer/screens/Home/Events/Item.tsx
+++ b/src/renderer/screens/Home/Events/Item.tsx
@@ -162,7 +162,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
             >
               <FontAwesomeIcon
                 icon={showActions ? faAngleUp : faAngleDown}
-                transform={'shrink-2'}
+                transform={'shrink-0'}
               />
             </div>
           )}
@@ -264,6 +264,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
                     <ButtonMonoInvert
                       text="Links"
                       iconRight={faAngleRight}
+                      iconTransform="shrink-2"
                       onClick={() => setActiveSide('right')}
                     />
                   )}
@@ -273,6 +274,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
                     <ButtonMono
                       text=""
                       iconLeft={faAngleLeft}
+                      iconTransform="shrink-2"
                       onClick={() => setActiveSide('left')}
                     />
                   )}
@@ -286,6 +288,7 @@ export const Item = memo(function Item({ event }: ItemProps) {
                         key={`action_${uid}_${i}`}
                         text={text || ''}
                         iconRight={faExternalLinkAlt}
+                        iconTransform="shrink-2"
                         onClick={() => {
                           window.myAPI.openBrowserURL(uri);
                         }}

--- a/src/renderer/screens/Home/Events/Wrappers.tsx
+++ b/src/renderer/screens/Home/Events/Wrappers.tsx
@@ -80,47 +80,56 @@ export const EventItem = styled(motion.div)`
 
   // Dismiss button
   > .dismiss-btn {
+    --main-color: #4f4f4f;
     position: absolute;
     width: 2.2rem;
     height: 2.2rem;
+    opacity: 0.75;
     top: 1rem;
     right: 10px;
     transition: color 0.2s ease-out;
     padding: 0;
     border-radius: 0.65rem;
-    border: 1px solid var(--border-mid-color);
+    border: 1px solid var(--main-color);
     cursor: pointer;
 
     svg {
-      color: var(--border-mid-color);
+      color: var(--main-color);
     }
     &:hover {
-      border-color: #7e3333;
+      border-color: rgb(169 74 117);
       svg {
-        color: #7e3333;
+        color: rgb(169 74 117);
       }
     }
   }
 
   // Show actions buttons
   .show-actions-btn {
-    background-color: #953254;
+    //background-color: #953254;
+    --main-color: #4f4f4f;
     position: absolute;
+    border: 1px solid var(--main-color);
     top: 4rem;
     right: 10px;
     width: 2.2rem;
     height: 2.2rem;
-    opacity: 0.3;
+    opacity: 0.75;
     border-radius: 0.65rem;
     padding: 0;
     cursor: pointer;
-
     transition: opacity 0.1s ease-out;
-    &:hover {
-      opacity: 0.75;
-    }
+
     svg {
-      color: #f1f1f1;
+      color: var(--main-color);
+    }
+
+    &:hover {
+      border-color: rgb(169 74 117);
+      svg {
+        color: rgb(169 74 117);
+      }
+      opacity: 0.75;
     }
   }
 
@@ -239,6 +248,10 @@ export const EventItem = styled(motion.div)`
       .btn-mono-invert {
         border: 1px solid #a23b5e;
         color: #a23b5e;
+      }
+      button {
+        font-size: 0.95rem;
+        padding-top: 0.25rem;
       }
     }
   }

--- a/src/renderer/screens/Home/Events/Wrappers.tsx
+++ b/src/renderer/screens/Home/Events/Wrappers.tsx
@@ -213,12 +213,23 @@ export const EventItem = styled(motion.div)`
   }
   // Actions container
   .actions-wrapper {
+    width: 200%;
+    overflow-x: hidden;
+    display: flex;
+    align-items: center;
+    justify-items: start;
+
     .actions {
       display: flex;
       flex-direction: row;
+      justify-content: start;
       column-gap: 1rem;
-      margin: 1.5rem 0 0;
+      // even width for actions contaienrs.
+      flex-grow: 1;
+      flex-basis: 0;
+      margin: 1rem 0 0;
       overflow: hidden;
+      padding-left: 4.5rem;
 
       .btn-mono {
         background-color: #953254;

--- a/src/renderer/screens/Home/Events/Wrappers.tsx
+++ b/src/renderer/screens/Home/Events/Wrappers.tsx
@@ -106,7 +106,6 @@ export const EventItem = styled(motion.div)`
 
   // Show actions buttons
   .show-actions-btn {
-    //background-color: #953254;
     --main-color: #4f4f4f;
     position: absolute;
     border: 1px solid var(--main-color);

--- a/src/renderer/screens/Home/Events/Wrappers.tsx
+++ b/src/renderer/screens/Home/Events/Wrappers.tsx
@@ -82,14 +82,14 @@ export const EventItem = styled(motion.div)`
   > .dismiss-btn {
     --main-color: #4f4f4f;
     position: absolute;
-    width: 2.2rem;
-    height: 2.2rem;
+    width: 2rem;
+    height: 2rem;
     opacity: 0.75;
     top: 1rem;
     right: 10px;
     transition: color 0.2s ease-out;
     padding: 0;
-    border-radius: 0.65rem;
+    border-radius: 0.5rem;
     border: 1px solid var(--main-color);
     cursor: pointer;
 
@@ -112,10 +112,10 @@ export const EventItem = styled(motion.div)`
     border: 1px solid var(--main-color);
     top: 4rem;
     right: 10px;
-    width: 2.2rem;
-    height: 2.2rem;
+    width: 2rem;
+    height: 2rem;
     opacity: 0.75;
-    border-radius: 0.65rem;
+    border-radius: 0.5rem;
     padding: 0;
     cursor: pointer;
     transition: opacity 0.1s ease-out;


### PR DESCRIPTION
# Summary

- [x] Action buttons and event item button styling tweaks.
- [x] New sliding animation to switch between primary and secondary action buttons on an event item.
  - Primary actions are shown by default if they exist for an event item.
  - If an event item doesn't have any primary actions but has secondary action buttons, the actions container is collapsed and secondary actions (links) are shown when it's expanded.
  - Buttons to transition between showing primary and secondary buttons are rendered if necessary. 