### PR TITLE
chore: setting to keep or remove outdated events

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -166,6 +166,15 @@ export const HelpConfig: HelpItems = [
     ],
   },
   {
+    key: 'help:settings:keepOutdatedEvents',
+    title: 'Keep Outdated Events',
+    definition: [
+      'Turn this setting on if you wish to keep old event items upon receiving a new event item for subscriptions.',
+      'When disabled, outdated event items will be removed when a new event item of the same subscription is received.',
+      'Keep this setting enabled to track past event items for enabled subscriptions. Turning this setting off may be useful for users who have enabled many subscriptions, and only wish to see the most up-to-date notification data.',
+    ],
+  },
+  {
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -62,6 +62,7 @@ export class Config {
         appShowDebuggingSubscriptions: false,
         appEnableAutomaticSubscriptions: true,
         appEnablePolkassemblyApi: true,
+        appKeepOutdatedEvents: true,
       };
 
       // Persist default settings to store and return them.

--- a/src/config/processes/renderer.ts
+++ b/src/config/processes/renderer.ts
@@ -16,6 +16,7 @@ export class Config {
   private static _silenceNotifications = false;
   private static _showDebuggingSubscriptions = false;
   private static _enableAutomaticSubscriptions = true;
+  private static _keepOutdatedEvents = true;
 
   // Flag set to `true` when app is switching to online mode.
   private static _switchingToOnlineMode = false;
@@ -103,6 +104,15 @@ export class Config {
 
   static set enableAutomaticSubscriptions(flag: boolean) {
     Config._enableAutomaticSubscriptions = flag;
+  }
+
+  // Accessors for `_enableAutomaticSubscriptions` flag.
+  static get keepOutdatedEvents(): boolean {
+    return Config._keepOutdatedEvents;
+  }
+
+  static set keepOutdatedEvents(flag: boolean) {
+    Config._keepOutdatedEvents = flag;
   }
 
   // Accessors for `_switchingToOnlineMode` flag.

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -54,6 +54,14 @@ export const SettingsList: SettingItem[] = [
     title: 'Enable Automatic Subscriptions',
   },
   {
+    action: 'settings:execute:keepOutdatedEvents',
+    category: 'Subscriptions',
+    enabled: true,
+    helpKey: 'help:settings:keepOutdatedEvents',
+    settingType: 'switch',
+    title: 'Keep Outdated Events',
+  },
+  {
     action: 'settings:execute:importData',
     category: 'Backup',
     buttonIcon: faFileImport,

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,8 +242,11 @@ app.whenReady().then(async () => {
       notification: NotificationData | null,
       isOneShot: boolean
     ) => {
-      // Remove any outdated events of the same type.
-      EventsController.removeOutdatedEvents(e);
+      // Remove any outdated events of the same type, if setting enabled.
+      const { appKeepOutdatedEvents } = ConfigMain.getAppSettings();
+      if (!appKeepOutdatedEvents) {
+        EventsController.removeOutdatedEvents(e);
+      }
 
       // Persist new event to store.
       const { event: eventWithUid, wasPersisted } =

--- a/src/main.ts
+++ b/src/main.ts
@@ -515,6 +515,11 @@ app.whenReady().then(async () => {
         settings.appEnablePolkassemblyApi = flag;
         break;
       }
+      case 'settings:execute:keepOutdatedEvents': {
+        const flag = !settings.appKeepOutdatedEvents;
+        settings.appKeepOutdatedEvents = flag;
+        break;
+      }
       default: {
         break;
       }

--- a/src/renderer/contexts/common/Help/types.ts
+++ b/src/renderer/contexts/common/Help/types.ts
@@ -63,6 +63,7 @@ export type HelpItemKey =
   | 'help:settings:showDebuggingSubscriptions'
   | 'help:settings:enableAutomaticSubscriptions'
   | 'help:settings:enablePolkassembly'
+  | 'help:settings:keepOutdatedEvents'
   | 'help:openGov:track'
   | 'help:openGov:origin'
   | 'help:openGov:maxDeciding'

--- a/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -16,4 +16,5 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   handleToggleShowDebuggingSubscriptions: () => {},
   handleToggleEnableAutomaticSubscriptions: () => {},
   handleToggleEnablePolkassemblyApi: () => {},
+  handleToggleKeepOutdatedEvents: () => {},
 };

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -114,6 +114,13 @@ export const AppSettingsProvider = ({
     window.myAPI.toggleSetting('settings:execute:enablePolkassembly');
   };
 
+  /// Handle toggling keep outdated events setting.
+  const handleToggleKeepOutdatedEvents = () => {
+    const newFlag = !RendererConfig.keepOutdatedEvents;
+    RendererConfig.keepOutdatedEvents = newFlag;
+    window.myAPI.toggleSetting('settings:execute:keepOutdatedEvents');
+  };
+
   return (
     <AppSettingsContext.Provider
       value={{
@@ -127,6 +134,7 @@ export const AppSettingsProvider = ({
         handleToggleShowDebuggingSubscriptions,
         handleToggleEnableAutomaticSubscriptions,
         handleToggleEnablePolkassemblyApi,
+        handleToggleKeepOutdatedEvents,
         setSilenceOsNotifications,
       }}
     >

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -45,6 +45,7 @@ export const AppSettingsProvider = ({
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
         appEnablePolkassemblyApi,
+        appKeepOutdatedEvents,
       } = await window.myAPI.getAppSettings();
 
       // Set cached notifications flag in renderer config.
@@ -52,6 +53,7 @@ export const AppSettingsProvider = ({
       RendererConfig.showDebuggingSubscriptions = appShowDebuggingSubscriptions;
       RendererConfig.enableAutomaticSubscriptions =
         appEnableAutomaticSubscriptions;
+      RendererConfig.keepOutdatedEvents = appKeepOutdatedEvents;
 
       // Set settings state.
       setDockToggled(appDocked);

--- a/src/renderer/contexts/main/AppSettings/types.ts
+++ b/src/renderer/contexts/main/AppSettings/types.ts
@@ -13,4 +13,5 @@ export interface AppSettingsContextInterface {
   handleToggleShowDebuggingSubscriptions: () => void;
   handleToggleEnableAutomaticSubscriptions: () => void;
   handleToggleEnablePolkassemblyApi: () => void;
+  handleToggleKeepOutdatedEvents: () => void;
 }

--- a/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -27,6 +27,7 @@ export const SettingFlagsProvider = ({
   const [enableAutomaticSubscriptions, setEnableAutomaticSubscriptions] =
     useState(true);
   const [enablePolkassemblyApi, setEnablePolkassemblyApi] = useState(true);
+  const [keepOutdatedEvents, setKeepOutdatedEvents] = useState(true);
 
   /// Fetch settings from store and set state.
   useEffect(() => {
@@ -38,6 +39,7 @@ export const SettingFlagsProvider = ({
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
         appEnablePolkassemblyApi,
+        appKeepOutdatedEvents,
       } = await window.myAPI.getAppSettings();
 
       setWindowDocked(appDocked);
@@ -46,6 +48,7 @@ export const SettingFlagsProvider = ({
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
       setEnablePolkassemblyApi(appEnablePolkassemblyApi);
+      setKeepOutdatedEvents(appKeepOutdatedEvents);
     };
 
     initSettings();
@@ -73,6 +76,9 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:enablePolkassembly': {
         return enablePolkassemblyApi;
+      }
+      case 'settings:execute:keepOutdatedEvents': {
+        return keepOutdatedEvents;
       }
       default: {
         return true;
@@ -107,6 +113,10 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:enablePolkassembly': {
         setEnablePolkassemblyApi(!enablePolkassemblyApi);
+        break;
+      }
+      case 'settings:execute:keepOutdatedEvents': {
+        setKeepOutdatedEvents(!keepOutdatedEvents);
         break;
       }
       default: {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -59,6 +59,7 @@ export const useMainMessagePorts = () => {
     handleToggleShowDebuggingSubscriptions,
     handleToggleEnableAutomaticSubscriptions,
     handleToggleEnablePolkassemblyApi,
+    handleToggleKeepOutdatedEvents,
   } = useAppSettings();
 
   const { setAccountSubscriptions, updateAccountNameInTasks, updateTask } =
@@ -642,7 +643,6 @@ export const useMainMessagePorts = () => {
    */
   const handleEnableAutomaticSubscriptions = () => {
     handleToggleEnableAutomaticSubscriptions();
-    console.log('toggled automatic subscriptions...');
   };
 
   /**
@@ -743,6 +743,10 @@ export const useMainMessagePorts = () => {
             }
             case 'settings:execute:enablePolkassembly': {
               handleToggleEnablePolkassemblyApi();
+              break;
+            }
+            case 'settings:execute:keepOutdatedEvents': {
+              handleToggleKeepOutdatedEvents();
               break;
             }
             case 'settings:execute:exportData': {

--- a/src/renderer/screens/Home/Events/Wrappers.tsx
+++ b/src/renderer/screens/Home/Events/Wrappers.tsx
@@ -226,6 +226,7 @@ export const EventItem = styled(motion.div)`
     display: flex;
     align-items: center;
     justify-items: start;
+    overflow: hidden;
 
     .actions {
       display: flex;

--- a/src/renderer/screens/Home/index.tsx
+++ b/src/renderer/screens/Home/index.tsx
@@ -1,6 +1,7 @@
 // Copyright 2024 @rossbulat/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { Config as ConfigRenderer } from '@/config/processes/renderer';
 import { BodyInterfaceWrapper } from '@app/Wrappers';
 import { useAddresses } from '@/renderer/contexts/main/Addresses';
 import { useEvents } from '@/renderer/contexts/main/Events';
@@ -39,8 +40,10 @@ export const Home = () => {
     // Listen for event callbacks.
     window.myAPI.reportNewEvent(
       (_: IpcRendererEvent, eventData: EventCallback) => {
-        // Remove any outdated events in the state.
-        removeOutdatedEvents(eventData);
+        // Remove any outdated events in the state, if setting enabled.
+        if (!ConfigRenderer.keepOutdatedEvents) {
+          removeOutdatedEvents(eventData);
+        }
 
         // Add received event to state.
         addEvent({ ...eventData });

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -21,7 +21,8 @@ export type SettingAction =
   | 'settings:execute:exportData'
   | 'settings:execute:showDebuggingSubscriptions'
   | 'settings:execute:enableAutomaticSubscriptions'
-  | 'settings:execute:enablePolkassembly';
+  | 'settings:execute:enablePolkassembly'
+  | 'settings:execute:keepOutdatedEvents';
 
 export interface SettingItem {
   action: SettingAction;

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -11,6 +11,7 @@ export interface PersistedSettings {
   appShowDebuggingSubscriptions: boolean;
   appEnableAutomaticSubscriptions: boolean;
   appEnablePolkassemblyApi: boolean;
+  appKeepOutdatedEvents: boolean;
 }
 
 export type SettingAction =

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -45,7 +45,7 @@ export const doRemoveOutdatedEvents = (
     // Extract data from next event.
     const { taskAction: nextTaskAction } = ev;
 
-    if (ev.who.origin === 'interval') {
+    if (ev.who.origin === 'interval' && event.who.origin === 'interval') {
       const { chainId: nextChainId } = ev.who.data as EventChainData;
       const { referendumId: nextReferendumId } = ev.data;
       const { referendumId } = event.data;
@@ -58,7 +58,7 @@ export const doRemoveOutdatedEvents = (
       ) {
         return false;
       }
-    } else if (ev.who.origin === 'account') {
+    } else if (ev.who.origin === 'account' && event.who.origin === 'account') {
       const { address: nextAddress, chainId: nextChainId } = ev.who
         .data as EventAccountData;
 


### PR DESCRIPTION
# Summary

This PR refactors the filtering logic when determining outdated events, and implements a new `Keep Outdated Events` setting.

When a new event is received by the main process, it firstly checks if any old event items of the subscription in question need removing. For example, when a new event item for the **Nomination Pool Rewards**  subscription is received, old event items for this subscription are removed (cleared from storage and the UI). The end result in this case is that the user will only be able to see the most recent event item on the UI.

However, certain users may wish to keep old event items in order to track past data. A new setting labelled `Keep Outdated Events` has been added to address this issue.

With the setting enabled, old event items will remain in the UI and managed by the application, when new event items are received. When the setting is turned off, only the latest event item for enabled subscriptions will be displayed in the UI.

The `Keep Outdated Events` setting is enabled by default.