### PR TITLE
fix: remove default app menu

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import {
   protocol,
   shell,
   systemPreferences,
+  Menu,
 } from 'electron';
 import { Config as ConfigMain } from './config/processes/main';
 import { executeLedgerLoop } from './ledger';
@@ -54,6 +55,12 @@ if (require('electron-squirrel-startup')) {
 const isTest = process.env.NODE_ENV === 'test';
 if (isTest) {
   require('wdio-electron-service/main');
+}
+
+// Hide application menu (mac OS) if DEBUG env variable doesn't exist.
+// NOTE: Showing window on all workspaces disables the application menu.
+if (process.platform === 'darwin' && !process.env.DEBUG) {
+  Menu.setApplicationMenu(null);
 }
 
 // Enable priviledges.

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -255,6 +255,9 @@ export const handleWindowOnIPC = (
       },
     });
 
+    // Hide menu bar on Linux and Windows.
+    setWindowMenuVisibility(window);
+
     registerLocalShortcut(window, 'CmdOrCtrl+Q', () =>
       WindowsController.close(name)
     );
@@ -417,4 +420,15 @@ export const setAllWorkspaceVisibilityForWindow = (windowId: string) => {
   const window = WindowsController.get(windowId);
   const { appShowOnAllWorkspaces } = ConfigMain.getAppSettings();
   window?.setVisibleOnAllWorkspaces(appShowOnAllWorkspaces);
+};
+
+/**
+ * @name setWindowMenuVisibility
+ * @summary Hide the window menu on Linux and Windows.
+ */
+const setWindowMenuVisibility = (window: BrowserWindow) => {
+  if (process.platform !== 'darwin') {
+    window.setAutoHideMenuBar(false);
+    window.setMenuBarVisibility(false);
+  }
 };


### PR DESCRIPTION
# Summary

The default Electron menu is only shown when the app is built with the `DEBUG` env variable defined. Otherwise, the application menu is set to `null`.

Example command for building the app in debug mode:

```
DEBUG=main:* yarn dev
``` 