### PR TITLE
fix: platform specifics

### DIFF
--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -12,6 +12,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:dockedWindow',
     settingType: 'switch',
     title: 'Docked Window',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:showOnAllWorkspaces',
@@ -20,6 +21,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:showOnAllWorkspaces',
     settingType: 'switch',
     title: 'Show On All Workspaces',
+    platforms: ['darwin'],
   },
   {
     action: 'settings:execute:silenceOsNotifications',
@@ -28,6 +30,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:silenceOsNotifications',
     settingType: 'switch',
     title: 'Silence OS Notifications',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:enablePolkassembly',
@@ -36,6 +39,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:enablePolkassembly',
     settingType: 'switch',
     title: 'Enable Polkassembly Data',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:hideDockIcon',
@@ -44,6 +48,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:hideDockIcon',
     settingType: 'switch',
     title: 'Hide Dock Icon',
+    platforms: ['darwin'],
   },
   {
     action: 'settings:execute:showDebuggingSubscriptions',
@@ -52,6 +57,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:showDebuggingSubscriptions',
     settingType: 'switch',
     title: 'Show Debugging Subscriptions',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:enableAutomaticSubscriptions',
@@ -60,6 +66,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:enableAutomaticSubscriptions',
     settingType: 'switch',
     title: 'Enable Automatic Subscriptions',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:keepOutdatedEvents',
@@ -68,6 +75,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:keepOutdatedEvents',
     settingType: 'switch',
     title: 'Keep Outdated Events',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:importData',
@@ -78,6 +86,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:importData',
     settingType: 'button',
     title: 'Import Accounts',
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:exportData',
@@ -88,5 +97,6 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:exportData',
     settingType: 'button',
     title: 'Export Accounts',
+    platforms: ['darwin', 'win32'],
   },
 ];

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,6 +106,7 @@ unhandled({
 
 // Initialise Electron store.
 export const store = new Store();
+store.delete('app_settings');
 
 // Report dismissed event to renderer.
 // TODO: move to a Utils file.
@@ -462,6 +463,11 @@ app.whenReady().then(async () => {
 
     storePointer.set(key, JSON.stringify(updated));
   });
+
+  /**
+   * Platform
+   */
+  ipcMain.handle('app:platform:get', async () => process.platform as string);
 
   /**
    * Websockets

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,6 @@ unhandled({
 
 // Initialise Electron store.
 export const store = new Store();
-store.delete('app_settings');
 
 // Report dismissed event to renderer.
 // TODO: move to a Utils file.

--- a/src/main.ts
+++ b/src/main.ts
@@ -539,6 +539,10 @@ app.whenReady().then(async () => {
   ipcMain.handle('app:settings:get', async () => ConfigMain.getAppSettings());
 
   ipcMain.on('app:set:workspaceVisibility', () => {
+    if (!['darwin', 'linux'].includes(process.platform)) {
+      return;
+    }
+
     // Get new flag.
     const settings = ConfigMain.getAppSettings();
     const flag = !settings.appShowOnAllWorkspaces;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -60,6 +60,11 @@ export const API: PreloadAPI = {
   },
 
   /**
+   * Platform
+   */
+  getOsPlatform: async () => await ipcRenderer.invoke('app:platform:get'),
+
+  /**
    * Workspaces (Developer Console)
    */
   fetchPersistedWorkspaces: async () =>

--- a/src/renderer/library/Footer/Wrapper.ts
+++ b/src/renderer/library/Footer/Wrapper.ts
@@ -15,9 +15,9 @@ export const FooterWrapper = styled.div`
   bottom: 0;
   left: 0;
   height: 3rem;
-  z-index: 5;
   overflow: hidden;
   padding-top: 0.5rem;
+  z-index: 20;
 
   section {
     width: 100%;
@@ -51,7 +51,6 @@ export const FooterWrapper = styled.div`
   &.expanded {
     height: calc(100% - 35px); // minus height of header
     border-top: none;
-    z-index: 2;
 
     .status {
       height: 4rem;

--- a/src/renderer/library/Header/Wrapper.ts
+++ b/src/renderer/library/Header/Wrapper.ts
@@ -15,7 +15,7 @@ export const HeaderWrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 5;
+  z-index: 30;
 
   .content-wrapper {
     display: flex;

--- a/src/renderer/library/Menu/Wrapper.tsx
+++ b/src/renderer/library/Menu/Wrapper.tsx
@@ -7,7 +7,7 @@ export const MenuWrapper = styled.div`
   position: absolute;
   right: 0;
   top: 2.25rem;
-  z-index: 50;
+  z-index: 30;
 
   display: flex;
   flex-flow: column nowrap;

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -203,7 +203,7 @@ export const Accounts = ({
                               <div>
                                 <span
                                   style={{
-                                    zIndex: 100,
+                                    zIndex: 2,
                                     cursor: 'default',
                                   }}
                                   className="icon tooltip tooltip-trigger-element"

--- a/src/renderer/screens/Home/Wrappers.ts
+++ b/src/renderer/screens/Home/Wrappers.ts
@@ -106,20 +106,20 @@ export const NoAccountsWrapper = styled.div`
   background: rgb(126, 61, 90);
   background: linear-gradient(
     45deg,
-    rgb(48 13 28) 0%,
-    rgb(88 47 66) 50%,
-    rgb(56 16 33) 101%
+    rgb(100 33 62) 0%,
+    rgb(126 40 80) 50%,
+    rgb(124 49 82) 101%
   );
   filter: brightness(75%);
 
   button {
     z-index: 1;
     padding: 0.5rem 1.75rem !important;
-    filter: brightness(120%);
+    filter: brightness(140%);
   }
   h4 {
     text-align: center;
-    filter: brightness(120%);
+    filter: brightness(140%);
   }
 `;
 

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -16,6 +16,8 @@ export interface PersistedSettings {
   appHideDockIcon: boolean;
 }
 
+export type OsPlatform = 'darwin' | 'linux' | 'win32';
+
 export type SettingAction =
   | 'settings:execute:dockedWindow'
   | 'settings:execute:showOnAllWorkspaces'
@@ -37,6 +39,7 @@ export interface SettingItem {
   settingType: string;
   buttonText?: string;
   buttonIcon?: IconProp;
+  platforms: OsPlatform[];
 }
 
 export interface SettingProps {

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -15,6 +15,8 @@ import type {
 import type { WorkspaceItem } from './developerConsole/workspaces';
 
 export interface PreloadAPI {
+  getOsPlatform: () => Promise<string>;
+
   fetchPersistedWorkspaces: () => Promise<WorkspaceItem[]>;
   deleteWorkspace: (serialised: string) => void;
   launchWorkspace: (serialised: string) => void;

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -41,7 +41,7 @@ export const createTray = () => {
 
   tray.setToolTip('Polkadot Live');
 
-  tray.addListener('mouse-up', () => {
+  tray.addListener('click', () => {
     try {
       WindowsController.toggleVisible('menu');
     } catch (e) {


### PR DESCRIPTION
# Summary

- [x] Make settings dynamic and render based on supported platform.
  - Settings to **Hide dock icon** and **Show on all workspaces** not displayed on Windows.  
- [x] Calculate docked window position based on platform.
  - **macOS:** Position under tray icon.
  - **Windows:** Snap to top-right corner of screen.

## Bug Fixes

- Fix `z-index` values for header and footer.
- Make `<NoAccounts />` component colours more vibrant.