### PR TITLE
fix: debugging polish iteration

### DIFF
--- a/src/renderer/screens/Home/Events/NoEvents.tsx
+++ b/src/renderer/screens/Home/Events/NoEvents.tsx
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { faBoxOpen, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { faBoxOpen } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { NoEventsWrapper } from './Wrappers';
 
@@ -11,17 +11,5 @@ export const NoEvents = () => (
       <FontAwesomeIcon icon={faBoxOpen} transform="grow-10" />
     </h1>
     <h3>No New Events</h3>
-    <h4>
-      <a
-        href="/import"
-        onClick={(e) => {
-          e.preventDefault();
-          window.myAPI.openWindow('import');
-        }}
-      >
-        Import more accounts{' '}
-        <FontAwesomeIcon icon={faChevronRight} transform="shrink-6" />
-      </a>
-    </h4>
   </NoEventsWrapper>
 );

--- a/src/renderer/screens/Home/Events/Wrappers.tsx
+++ b/src/renderer/screens/Home/Events/Wrappers.tsx
@@ -14,7 +14,7 @@ export const Wrapper = styled.div`
 `;
 
 export const NoEventsWrapper = styled.div`
-  margin-top: 6rem;
+  margin-top: 6.75rem;
   z-index: 1;
 
   button {
@@ -29,6 +29,7 @@ export const NoEventsWrapper = styled.div`
   h3 {
     text-align: center;
     margin: 2rem 0 1rem 0;
+    font-size: 1.2rem;
   }
   h5 {
     text-align: center;

--- a/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -44,7 +44,7 @@ export const Accounts = ({
 
   /// Categorise addresses by their chain ID, sort by name.
   const getSortedAddresses = () => {
-    const sorted = new Map<ChainID, FlattenedAccountData[]>();
+    const sorted = new Map<ChainID | 'Empty', FlattenedAccountData[]>();
 
     // Insert map keys in a certain order.
     for (const chainId of ['Polkadot', 'Kusama', 'Westend'] as ChainID[]) {
@@ -73,12 +73,17 @@ export const Accounts = ({
     // Remove any empty entries.
     const redundantEntries: ChainID[] = [];
     for (const [chainId, chainAddresses] of sorted.entries()) {
-      chainAddresses.length === 0 && redundantEntries.push(chainId);
+      chainAddresses.length === 0 && redundantEntries.push(chainId as ChainID);
     }
 
     redundantEntries.forEach((chainId) => {
       sorted.delete(chainId);
     });
+
+    // Add a single `Empty` key if there are no accounts to render.
+    if (sorted.size === 0) {
+      sorted.set('Empty', []);
+    }
 
     return sorted;
   };
@@ -161,14 +166,6 @@ export const Accounts = ({
 
   return (
     <AccountsWrapper>
-      <div
-        style={{
-          display: addresses.length === 0 ? 'inherit' : 'none',
-          padding: '0 0.5rem',
-        }}
-      >
-        <NoAccounts />
-      </div>
       <div>
         <Accordion
           multiple
@@ -180,59 +177,67 @@ export const Accounts = ({
             ([chainId, chainAddresses], k) => (
               <AccordionItem key={`${chainId}_accounts`}>
                 <AccordionCaretHeader
-                  title={`${chainId} Accounts`}
+                  title={
+                    chainId === 'Empty' ? 'Accounts' : `${chainId} Accounts`
+                  }
                   itemIndex={k}
                 />
                 <AccordionPanel>
-                  <div style={{ padding: '0 0.75rem' }}>
-                    <div className="flex-column">
-                      {chainAddresses.map(
-                        (
-                          { address, name }: FlattenedAccountData,
-                          j: number
-                        ) => (
-                          <AccountWrapper
-                            whileHover={{ scale: 1.01 }}
-                            key={`manage_account_${j}`}
-                          >
-                            <button
-                              type="button"
-                              onClick={() => handleClickAccount(name, address)}
-                            ></button>
-                            <div className="inner">
-                              <div>
-                                <span
-                                  style={{
-                                    zIndex: 2,
-                                    cursor: 'default',
-                                  }}
-                                  className="icon tooltip tooltip-trigger-element"
-                                  data-tooltip-text={ellipsisFn(address, 16)}
-                                  onMouseMove={() =>
-                                    setTooltipTextAndOpen(
-                                      ellipsisFn(address, 16),
-                                      'right'
-                                    )
-                                  }
-                                >
-                                  <Identicon value={address} size={26} />
-                                </span>
-                                <div className="content">
-                                  <h3>{name}</h3>
+                  <div style={{ padding: '0.5rem 0.75rem 0' }}>
+                    {chainId === 'Empty' ? (
+                      <NoAccounts />
+                    ) : (
+                      <div className="flex-column">
+                        {chainAddresses.map(
+                          (
+                            { address, name }: FlattenedAccountData,
+                            j: number
+                          ) => (
+                            <AccountWrapper
+                              whileHover={{ scale: 1.01 }}
+                              key={`manage_account_${j}`}
+                            >
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  handleClickAccount(name, address)
+                                }
+                              ></button>
+                              <div className="inner">
+                                <div>
+                                  <span
+                                    style={{
+                                      zIndex: 2,
+                                      cursor: 'default',
+                                    }}
+                                    className="icon tooltip tooltip-trigger-element"
+                                    data-tooltip-text={ellipsisFn(address, 16)}
+                                    onMouseMove={() =>
+                                      setTooltipTextAndOpen(
+                                        ellipsisFn(address, 16),
+                                        'right'
+                                      )
+                                    }
+                                  >
+                                    <Identicon value={address} size={26} />
+                                  </span>
+                                  <div className="content">
+                                    <h3>{name}</h3>
+                                  </div>
+                                </div>
+                                <div>
+                                  <ButtonText
+                                    text=""
+                                    iconRight={faChevronRight}
+                                    iconTransform="shrink-3"
+                                  />
                                 </div>
                               </div>
-                              <div>
-                                <ButtonText
-                                  text=""
-                                  iconRight={faChevronRight}
-                                  iconTransform="shrink-3"
-                                />
-                              </div>
-                            </div>
-                          </AccountWrapper>
-                        )
-                      )}
-                    </div>
+                            </AccountWrapper>
+                          )
+                        )}
+                      </div>
+                    )}
                   </div>
                 </AccordionPanel>
               </AccordionItem>

--- a/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -12,7 +12,6 @@ import { Config as ConfigOpenGov } from '@/config/processes/openGov';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import {
   faCaretLeft,
-  faDownFromDottedLine,
   faGripDots,
   faLayerGroup,
   faLineHeight,
@@ -37,6 +36,7 @@ import { useReferendaSubscriptions } from '@/renderer/contexts/openGov/Referenda
 import type { ReferendaProps } from '../types';
 import { usePolkassembly } from '@/renderer/contexts/openGov/Polkassembly';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
+import { faArrowsRotate } from '@fortawesome/pro-light-svg-icons';
 
 export const Referenda = ({ setSection }: ReferendaProps) => {
   const { isConnected } = useConnections();
@@ -360,7 +360,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                 isActive={true}
                 isDisabled={fetchingReferenda || !isConnected}
                 onClick={() => handleRefetchReferenda()}
-                faIcon={faDownFromDottedLine}
+                faIcon={faArrowsRotate}
                 fixedWidth={false}
               />
             </div>
@@ -442,10 +442,6 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
       <StatsFooter $chainId={chainId}>
         <div>
           <section className="left">
-            <div className="footer-stat">
-              <h2>Chain:</h2>
-              <span>{chainId}</span>
-            </div>
             <div className="footer-stat">
               <h2>Active Referenda:</h2>
               <span style={{ minWidth: '14px' }}>

--- a/src/renderer/screens/OpenGov/Tracks/TrackRow.tsx
+++ b/src/renderer/screens/OpenGov/Tracks/TrackRow.tsx
@@ -51,20 +51,18 @@ export const TrackRow = ({ track }: TrackRowProps) => {
         </div>
         <div className="right">
           <div className="stat-wrapper">
-            <span>Deposit</span>
-            <h4 className="mw-84">
+            <h4 style={{ minWidth: '160px' }}>
               {formatChainUnits(track.decisionDeposit, chainId)}
             </h4>
           </div>
           <div className="stat-wrapper">
-            <span>Max Deciding</span>
-            <h4 className="mw-45">{track.maxDeciding}</h4>
+            <h4 style={{ minWidth: '130px' }}>{track.maxDeciding}</h4>
           </div>
           <div
             className={`expand-btn-wrapper ${chainId === 'Polkadot' ? 'polkadot-bg' : 'kusama-bg'}`}
             onClick={() => setExpanded(!expanded)}
           >
-            <h4>Metrics</h4>
+            <h4>Timeline</h4>
             <div className="expand-btn">
               <FontAwesomeIcon
                 icon={expanded ? faAngleUp : faAngleDown}

--- a/src/renderer/screens/OpenGov/Tracks/Wrappers.ts
+++ b/src/renderer/screens/OpenGov/Tracks/Wrappers.ts
@@ -73,10 +73,10 @@ export const StickyHeadings = styled.div`
         min-width: 154px;
       }
       div:nth-child(2) {
-        min-width: 144px;
+        min-width: 140px;
       }
       div:nth-child(3) {
-        min-width: 84px;
+        min-width: 90px;
       }
     }
   }

--- a/src/renderer/screens/OpenGov/Tracks/index.tsx
+++ b/src/renderer/screens/OpenGov/Tracks/index.tsx
@@ -126,8 +126,8 @@ export const Tracks = ({ setSection }: TracksProps) => {
                       </div>
                       <div className="right">
                         <div className="heading">Decision Deposit</div>
-                        <div className="heading">Max. Ongoing</div>
-                        <div className="heading">Metrics</div>
+                        <div className="heading">Max Deciding</div>
+                        <div className="heading">Timeline</div>
                       </div>
                     </div>
                   </StickyHeadings>
@@ -153,10 +153,6 @@ export const Tracks = ({ setSection }: TracksProps) => {
       <StatsFooter $chainId={chainId}>
         <div>
           <section className="left">
-            <div className="footer-stat">
-              <h2>Chain:</h2>
-              <span>{chainId}</span>
-            </div>
             <div className="footer-stat">
               <h2>Total Tracks:</h2>
               <span>{tracks.length}</span>

--- a/src/renderer/screens/OpenGov/index.tsx
+++ b/src/renderer/screens/OpenGov/index.tsx
@@ -20,7 +20,7 @@ import { useReferenda } from '@/renderer/contexts/openGov/Referenda';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
 import { useTreasury } from '@/renderer/contexts/openGov/Treasury';
 import { IconWrapper, OpenGovCard, TreasuryStats } from './Wrappers';
-import { faInfo, faDownFromDottedLine } from '@fortawesome/pro-solid-svg-icons';
+import { faInfo } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import type { ChainID } from '@/types/chains';
@@ -31,6 +31,7 @@ import {
   SortControlButton,
   renderPlaceholders,
 } from '@/renderer/utils/common';
+import { faArrowsRotate } from '@fortawesome/pro-light-svg-icons';
 
 export const OpenGov: React.FC = () => {
   /// Set up port communication for `openGov` window.
@@ -310,7 +311,7 @@ export const OpenGov: React.FC = () => {
                           isActive={true}
                           isDisabled={fetchingTreasuryData || !isConnected}
                           onClick={() => refetchTreasuryStats()}
-                          faIcon={faDownFromDottedLine}
+                          faIcon={faArrowsRotate}
                           fixedWidth={false}
                         />
                       </div>

--- a/src/renderer/utils/common.tsx
+++ b/src/renderer/utils/common.tsx
@@ -498,7 +498,8 @@ export const formatChainUnits = (units: string, chainId: ChainID) => {
     chainUnits(chainId)
   )
     .toFixed(2)
-    .replace(/(\.\d*?[1-9])0+|\.0*$/, '$1');
+    .replace(/(\.\d*?[1-9])0+|\.0*$/, '$1')
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
   return `${formatted} ${chainCurrency(chainId)}`;
 };

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -341,7 +341,7 @@ const loadUrlWithRoute = (
     window.loadURL(
       `file://${path.join(
         __dirname,
-        `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html#/${route}`
+        `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html#${route}`
       )}`
     );
   }


### PR DESCRIPTION
# Summary

## Checklist

- [x] Fix production window URL (remove `/` after hash in URL. 
The renderer's index file could not be loaded on Windows with the slash present. Omitting the slash successfully loads the renderer's content on Windows and macOS platforms.

#### Before

```typescript
window.loadURL(`file://${path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html#/${route}`)}`);
```

#### After

```typescript
window.loadURL(`file://${path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html#${route}`)}`);
```

## Other

- Some miscellaneous polish and UI cleanup, including in the OpenGov window.