### PR TITLE
fix: debugging tasks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,7 @@ import type {
   SubscriptionTask,
   IntervalSubscription,
 } from '@/types/subscriptions';
+import { version } from '../package.json';
 
 const debug = MainDebug;
 
@@ -106,6 +107,20 @@ unhandled({
 
 // Initialise Electron store.
 export const store = new Store();
+
+// Clear the store if it's the first time opening this version.
+// TODO: Implement data migration between versions.
+if (!store.has('version')) {
+  store.clear();
+  (store as Record<string, AnyJson>).set('version', version);
+} else {
+  const stored = (store as Record<string, AnyJson>).get('version') as string;
+
+  if (stored !== version) {
+    store.clear();
+    (store as Record<string, AnyJson>).set('version', version);
+  }
+}
 
 // Report dismissed event to renderer.
 // TODO: move to a Utils file.

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -7,6 +7,7 @@ import { getAddressChainId } from '@/renderer/Utils';
 import { createContext, useContext } from 'react';
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useAddresses } from '@app/contexts/import/Addresses';
+import { useConnections } from '@app/contexts/common/Connections';
 import type { ImportHandlerContextInterface } from './types';
 import type {
   AccountSource,
@@ -26,6 +27,7 @@ export const ImportHandlerProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { isConnected } = useConnections();
   const { setStatusForAccount } = useAccountStatuses();
   const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
     useAddresses();
@@ -37,7 +39,7 @@ export const ImportHandlerProvider = ({
     accountName: string
   ) => {
     // Set processing flag for account.
-    setStatusForAccount(address, source, true);
+    setStatusForAccount(address, source, isConnected ? true : false);
 
     // Process account import in main renderer.
     if (source === 'vault') {
@@ -57,7 +59,9 @@ export const ImportHandlerProvider = ({
   ) => {
     setReadOnlyAddresses((prev: LocalAddress[]) => {
       const newAddresses: LocalAddress[] = prev.map((a: LocalAddress) =>
-        a.address === address ? { ...a, isImported: true } : a
+        a.address === address
+          ? { ...a, isImported: isConnected ? true : false }
+          : a
       );
 
       localStorage.setItem(
@@ -68,7 +72,9 @@ export const ImportHandlerProvider = ({
       return newAddresses;
     });
 
-    postAddressToMainWindow(address, source, accountName);
+    if (isConnected) {
+      postAddressToMainWindow(address, source, accountName);
+    }
   };
 
   /// Handle a vault address import.
@@ -80,7 +86,9 @@ export const ImportHandlerProvider = ({
     // Update import window's managed address state and local storage.
     setVaultAddresses((prev: LocalAddress[]) => {
       const newAddresses = prev.map((a: LocalAddress) =>
-        a.address === address ? { ...a, isImported: true } : a
+        a.address === address
+          ? { ...a, isImported: isConnected ? true : false }
+          : a
       );
 
       localStorage.setItem(
@@ -91,7 +99,9 @@ export const ImportHandlerProvider = ({
       return newAddresses;
     });
 
-    postAddressToMainWindow(address, source, accountName);
+    if (isConnected) {
+      postAddressToMainWindow(address, source, accountName);
+    }
   };
 
   /// Handle a ledger address import.

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -143,7 +143,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
     // Add account status entry.
     insertAccountStatus(trimmed, 'read-only');
 
-    // Set processing flag to true and import via main renderer.
+    // Set processing flag to true if online and import via main renderer.
     handleImportAddress(trimmed, 'read-only', accountName);
   };
 


### PR DESCRIPTION
# Summary

- **Clear the Electron store when a new Polkadot Live version is opened for the first time.**
  Doing this will prevent any compatibility issues between persisted data from previous versions and updated data structures in the newer version. A `TODO` has been added for implementing a data migration system between versions. 

- **Don't fetch account data on import if the app is offline.**
  When a Vault or read only account is imported, the app will only fetch its data and send it to the main window if it's in online mode. This is because an internet connection is required to fetch the account's data.