### PR TITLE
chore: subscription components optimisation

### DIFF
--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -16,6 +16,7 @@ import { EventsProvider } from '@/renderer/contexts/main/Events';
 import { ManageProvider } from '@/renderer/contexts/main/Manage';
 import { SubscriptionsProvider } from '@app/contexts/main/Subscriptions';
 import { IntervalSubscriptionsProvider } from './contexts/main/IntervalSubscriptions';
+import { IntervalTasksManagerProvider } from './contexts/main/IntervalTasksManager';
 
 // Import window contexts.
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
@@ -59,6 +60,7 @@ const getProvidersForWindow = () => {
         SubscriptionsProvider,
         IntervalSubscriptionsProvider,
         ManageProvider,
+        IntervalTasksManagerProvider,
         EventsProvider,
         // Online status relies on other contexts being initialized.
         BootstrappingProvider

--- a/src/renderer/contexts/main/IntervalTasksManager/defaults.ts
+++ b/src/renderer/contexts/main/IntervalTasksManager/defaults.ts
@@ -1,0 +1,14 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { IntervalTasksManagerContextInterface } from './types';
+
+export const defaultIntervalTasksManagerContext: IntervalTasksManagerContextInterface =
+  {
+    handleIntervalToggle: async () => await new Promise(() => {}),
+    handleIntervalNativeCheckbox: async () => await new Promise(() => {}),
+    handleRemoveIntervalSubscription: async () => await new Promise(() => {}),
+    handleChangeIntervalDuration: async () => await new Promise(() => {}),
+    handleIntervalOneShot: async () => await new Promise(() => {}),
+  };

--- a/src/renderer/contexts/main/IntervalTasksManager/index.tsx
+++ b/src/renderer/contexts/main/IntervalTasksManager/index.tsx
@@ -1,0 +1,201 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Config as ConfigRenderer } from '@/config/processes/renderer';
+import { executeIntervaledOneShot } from '@/renderer/callbacks/intervaled';
+import { Flip, toast } from 'react-toastify';
+import { IntervalsController } from '@/controller/renderer/IntervalsController';
+import { createContext, useContext } from 'react';
+import { useBootstrapping } from '../Bootstrapping';
+import { useManage } from '../Manage';
+import { useIntervalSubscriptions } from '../IntervalSubscriptions';
+import type { AnyFunction } from '@/types/misc';
+import type { IntervalSubscription } from '@/types/subscriptions';
+import type { IntervalTasksManagerContextInterface } from './types';
+import type { ReactNode } from 'react';
+import * as defaults from './defaults';
+
+export const IntervalTasksManagerContext =
+  createContext<IntervalTasksManagerContextInterface>(
+    defaults.defaultIntervalTasksManagerContext
+  );
+
+export const useIntervalTasksManager = () =>
+  useContext(IntervalTasksManagerContext);
+
+export const IntervalTasksManagerProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const { online: isOnline } = useBootstrapping();
+  const { updateIntervalSubscription, removeIntervalSubscription } =
+    useIntervalSubscriptions();
+  const { tryUpdateDynamicIntervalTask, tryRemoveIntervalSubscription } =
+    useManage();
+
+  /// Handle toggling an interval subscription.
+  const handleIntervalToggle = async (task: IntervalSubscription) => {
+    // Invert task status.
+    const newStatus = task.status === 'enable' ? 'disable' : 'enable';
+    task.status = newStatus;
+
+    // Handle task in intervals controller.
+    newStatus === 'enable'
+      ? IntervalsController.insertSubscription(task)
+      : IntervalsController.removeSubscription(task);
+
+    // Update main renderer state.
+    updateIntervalSubscription(task);
+    tryUpdateDynamicIntervalTask(task);
+
+    // Update OpenGov renderer state.
+    ConfigRenderer.portToOpenGov.postMessage({
+      task: 'openGov:task:update',
+      data: {
+        serialized: JSON.stringify(task),
+      },
+    });
+
+    // Update persisted task in store.
+    await window.myAPI.updateIntervalTask(JSON.stringify(task));
+  };
+
+  /// Handle clicking os notifications toggle for interval subscriptions.
+  const handleIntervalNativeCheckbox = async (
+    task: IntervalSubscription,
+    flag: boolean
+  ) => {
+    const checked: boolean = flag;
+    task.enableOsNotifications = checked;
+
+    // Update task data in intervals controller.
+    IntervalsController.updateSubscription(task);
+
+    // Update main renderer state.
+    updateIntervalSubscription(task);
+    tryUpdateDynamicIntervalTask(task);
+
+    // Update OpenGov renderer state.
+    ConfigRenderer.portToOpenGov.postMessage({
+      task: 'openGov:task:update',
+      data: {
+        serialized: JSON.stringify(task),
+      },
+    });
+
+    // Update persisted task in store.
+    await window.myAPI.updateIntervalTask(JSON.stringify(task));
+  };
+
+  /// Handle removing an interval subscription.
+  const handleRemoveIntervalSubscription = async (
+    task: IntervalSubscription
+  ) => {
+    // Remove task from interval controller.
+    task.status === 'enable' &&
+      IntervalsController.removeSubscription(task, isOnline);
+
+    // Set status to disable.
+    task.status = 'disable';
+
+    // Remove task from necessary React state.
+    tryRemoveIntervalSubscription(task);
+    removeIntervalSubscription(task);
+
+    // Remove task from store.
+    await window.myAPI.removeIntervalTask(JSON.stringify(task));
+
+    // Send message to OpenGov window to update its subscription state.
+    ConfigRenderer.portToOpenGov.postMessage({
+      task: 'openGov:task:removed',
+      data: { serialized: JSON.stringify(task) },
+    });
+  };
+
+  /// Handle setting a new interval duration for the subscription.
+  const handleChangeIntervalDuration = async (
+    event: React.ChangeEvent<HTMLSelectElement>,
+    task: IntervalSubscription,
+    setIntervalSetting: (ticksToWait: number) => void
+  ) => {
+    const newSetting: number = parseInt(event.target.value);
+    const settingObj = IntervalsController.durations.find(
+      (setting) => setting.ticksToWait === newSetting
+    );
+
+    if (settingObj) {
+      // TODO: call useEffect in row component.
+      setIntervalSetting(newSetting);
+
+      // Update task state.
+      task.intervalSetting = settingObj;
+      updateIntervalSubscription(task);
+      tryUpdateDynamicIntervalTask(task);
+
+      // Update managed task in intervals controller.
+      IntervalsController.updateSubscription(task);
+
+      // Update state in OpenGov window.
+      ConfigRenderer.portToOpenGov.postMessage({
+        task: 'openGov:task:update',
+        data: {
+          serialized: JSON.stringify(task),
+        },
+      });
+
+      // Update persisted task in store.
+      await window.myAPI.updateIntervalTask(JSON.stringify(task));
+    }
+  };
+
+  /// Handle a one-shot event for a subscription task.
+  const handleIntervalOneShot = async (
+    task: IntervalSubscription,
+    setOneShotProcessing: AnyFunction
+  ) => {
+    setOneShotProcessing(true);
+    const { success, message } = await executeIntervaledOneShot(
+      task,
+      'one-shot'
+    );
+
+    if (!success) {
+      setOneShotProcessing(false);
+
+      // Render error alert.
+      toast.error(message ? message : 'Error', {
+        position: 'bottom-center',
+        autoClose: 3000,
+        hideProgressBar: true,
+        closeOnClick: true,
+        closeButton: false,
+        pauseOnHover: false,
+        draggable: false,
+        progress: undefined,
+        theme: 'dark',
+        transition: Flip,
+        toastId: 'toast-connection',
+      });
+    } else {
+      // Wait some time to avoid the spinner snapping.
+      setTimeout(() => {
+        setOneShotProcessing(false);
+      }, 550);
+    }
+  };
+
+  return (
+    <IntervalTasksManagerContext.Provider
+      value={{
+        handleIntervalToggle,
+        handleIntervalNativeCheckbox,
+        handleRemoveIntervalSubscription,
+        handleChangeIntervalDuration,
+        handleIntervalOneShot,
+      }}
+    >
+      {children}
+    </IntervalTasksManagerContext.Provider>
+  );
+};

--- a/src/renderer/contexts/main/IntervalTasksManager/types.ts
+++ b/src/renderer/contexts/main/IntervalTasksManager/types.ts
@@ -1,0 +1,25 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AnyFunction } from '@/types/misc';
+import type { IntervalSubscription } from '@/types/subscriptions';
+
+export interface IntervalTasksManagerContextInterface {
+  handleIntervalToggle: (task: IntervalSubscription) => Promise<void>;
+  handleIntervalNativeCheckbox: (
+    task: IntervalSubscription,
+    flag: boolean
+  ) => Promise<void>;
+  handleRemoveIntervalSubscription: (
+    task: IntervalSubscription
+  ) => Promise<void>;
+  handleChangeIntervalDuration: (
+    event: React.ChangeEvent<HTMLSelectElement>,
+    task: IntervalSubscription,
+    setIntervalSetting: (ticksToWait: number) => void
+  ) => Promise<void>;
+  handleIntervalOneShot: (
+    task: IntervalSubscription,
+    setOneShotProcessing: AnyFunction
+  ) => Promise<void>;
+}

--- a/src/renderer/contexts/main/Subscriptions/index.tsx
+++ b/src/renderer/contexts/main/Subscriptions/index.tsx
@@ -214,20 +214,20 @@ export const SubscriptionsProvider = ({
   };
 
   /// Execute queued subscription task.
-  const handleQueuedToggle = async (cached: WrappedSubscriptionTasks) => {
-    const p = async () => await toggleSubscription(cached);
+  const handleQueuedToggle = async (task: SubscriptionTask) => {
+    const p = async () => await toggleSubscription(task);
     TaskQueue.add(p);
   };
 
   /// Handle subscription task toggle.
-  const toggleSubscription = async (cached: WrappedSubscriptionTasks) => {
+  const toggleSubscription = async (task: SubscriptionTask) => {
     // Invert the task status.
-    const task: SubscriptionTask = { ...cached.tasks[0] };
-    task.status = task.status === 'enable' ? 'disable' : 'enable';
-    task.enableOsNotifications = task.status === 'enable' ? true : false;
+    const newStatus = task.status === 'enable' ? 'disable' : 'enable';
+    task.status = newStatus;
+    task.enableOsNotifications = newStatus === 'enable' ? true : false;
 
     // Send task and its associated data to backend.
-    switch (cached.type) {
+    switch (getTaskType(task)) {
       case 'chain': {
         // Subscribe to and persist task.
         await SubscriptionsController.subscribeChainTask(task);
@@ -258,7 +258,6 @@ export const SubscriptionsProvider = ({
 
         // Update react state.
         updateTask('account', task, task.account?.address);
-
         break;
       }
       default: {

--- a/src/renderer/contexts/main/Subscriptions/index.tsx
+++ b/src/renderer/contexts/main/Subscriptions/index.tsx
@@ -157,7 +157,6 @@ export const SubscriptionsProvider = ({
       return;
     }
 
-    // Switch subscription type.
     switch (getTaskType(tasks[0])) {
       case 'chain': {
         // Update persisted state and React state for tasks.

--- a/src/renderer/contexts/main/Subscriptions/types.ts
+++ b/src/renderer/contexts/main/Subscriptions/types.ts
@@ -19,7 +19,7 @@ export interface SubscriptionsContextInterface {
   getAccountSubscriptions: (a: string) => SubscriptionTask[];
   updateTask: (type: string, task: SubscriptionTask, address?: string) => void;
   updateAccountNameInTasks: (address: string, newName: string) => void;
-  handleQueuedToggle: (cached: WrappedSubscriptionTasks) => Promise<void>;
+  handleQueuedToggle: (task: SubscriptionTask) => Promise<void>;
   toggleCategoryTasks: (
     c: TaskCategory,
     i: boolean,

--- a/src/renderer/screens/Home/Manage/IntervalRow.tsx
+++ b/src/renderer/screens/Home/Manage/IntervalRow.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useBootstrapping } from '@/renderer/contexts/main/Bootstrapping';
 import { useHelp } from '@/renderer/contexts/common/Help';
+import { useIntervalTasksManager } from '@/renderer/contexts/main/IntervalTasksManager';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
 import { AccountWrapper } from './Wrappers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -22,18 +23,17 @@ import { getShortIntervalLabel } from '@/renderer/utils/renderingUtils';
 import type { AnyData } from '@/types/misc';
 import type { IntervalRowProps } from './types';
 
-export const IntervalRow = ({
-  task,
-  handleIntervalToggle,
-  handleIntervalNativeCheckbox,
-  handleChangeIntervalDuration,
-  handleIntervalOneShot,
-  handleRemoveIntervalSubscription,
-  isTaskDisabled,
-}: IntervalRowProps) => {
+export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
   const { openHelp } = useHelp();
   const { setTooltipTextAndOpen } = useTooltip();
   const { online: isConnected } = useBootstrapping();
+  const {
+    handleIntervalToggle,
+    handleIntervalNativeCheckbox,
+    handleRemoveIntervalSubscription,
+    handleChangeIntervalDuration,
+    handleIntervalOneShot,
+  } = useIntervalTasksManager();
 
   const [isToggled, setIsToggled] = useState<boolean>(task.status === 'enable');
   const [oneShotProcessing, setOneShotProcessing] = useState(false);
@@ -147,11 +147,7 @@ export const IntervalRow = ({
                 icon={faAnglesDown}
                 transform={'grow-4'}
                 onClick={async () =>
-                  await handleIntervalOneShot(
-                    task,
-                    nativeChecked,
-                    setOneShotProcessing
-                  )
+                  await handleIntervalOneShot(task, setOneShotProcessing)
                 }
               />
             )}

--- a/src/renderer/screens/Home/Manage/PermissionRow.tsx
+++ b/src/renderer/screens/Home/Manage/PermissionRow.tsx
@@ -27,14 +27,14 @@ export const PermissionRow = ({
   getDisabled,
   getTaskType,
 }: PermissionRowProps) => {
+  const { openHelp } = useHelp();
+  const { setTooltipTextAndOpen } = useTooltip();
+
   const [isToggled, setIsToggled] = useState<boolean>(task.status === 'enable');
   const [oneShotProcessing, setOneShotProcessing] = useState(false);
   const [nativeChecked, setNativeChecked] = useState(
     task.enableOsNotifications
   );
-
-  const { openHelp } = useHelp();
-  const { setTooltipTextAndOpen } = useTooltip();
 
   useEffect(() => {
     if (task.status === 'enable') {

--- a/src/renderer/screens/Home/Manage/PermissionRow.tsx
+++ b/src/renderer/screens/Home/Manage/PermissionRow.tsx
@@ -13,7 +13,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
-import { useManage } from '@/renderer/contexts/main/Manage';
 import {
   getTooltipClassForGroup,
   toolTipTextFor,
@@ -36,7 +35,6 @@ export const PermissionRow = ({
 
   const { openHelp } = useHelp();
   const { setTooltipTextAndOpen } = useTooltip();
-  const { renderedSubscriptions } = useManage();
 
   useEffect(() => {
     if (task.status === 'enable') {
@@ -47,11 +45,9 @@ export const PermissionRow = ({
     }
   }, [task.status]);
 
-  /// TODO: Optimize where native checkbox updates only when task's flag changes.
-  /// TODO: Remove dependency of `renderedSubscriptions` if possible.
   useEffect(() => {
     setNativeChecked(task.enableOsNotifications);
-  }, [renderedSubscriptions]);
+  }, [task.enableOsNotifications]);
 
   /// Handle clicking on OS Notifications toggle button.
   const handleOsNotificationClick = async () => {
@@ -181,17 +177,7 @@ export const PermissionRow = ({
               disabled={getDisabled(task)}
               handleToggle={async () => {
                 // Send an account or chain subscription task.
-                await handleToggle({
-                  type: getTaskType(task),
-                  tasks: [
-                    {
-                      ...task,
-                      actionArgs: task.actionArgs
-                        ? [...task.actionArgs]
-                        : undefined,
-                    },
-                  ],
-                });
+                await handleToggle(task);
               }}
             />
           </div>

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -12,7 +12,6 @@ import { AccordionCaretSwitchHeader } from '@app/library/Accordion/AccordionCare
 import { AccountsController } from '@/controller/renderer/AccountsController';
 import { ellipsisFn } from '@w3ux/utils';
 import { executeOneShot } from '@/renderer/callbacks/oneshots';
-import { executeIntervaledOneShot } from '@/renderer/callbacks/intervaled';
 import { Flip, toast } from 'react-toastify';
 import { PermissionRow } from './PermissionRow';
 import { IntervalsController } from '@/controller/renderer/IntervalsController';
@@ -37,6 +36,7 @@ import { useIntervalSubscriptions } from '@/renderer/contexts/main/IntervalSubsc
 
 /// Type imports.
 import type { AnyFunction } from '@/types/misc';
+import type { ChainID } from '@/types/chains';
 import type { PermissionsProps } from './types';
 import type {
   IntervalSubscription,
@@ -63,12 +63,10 @@ export const Permissions = ({
     dynamicIntervalTasksState,
     updateRenderedSubscriptions,
     tryUpdateDynamicIntervalTask,
-    tryRemoveIntervalSubscription,
     getCategorizedDynamicIntervals,
   } = useManage();
 
-  const { updateIntervalSubscription, removeIntervalSubscription } =
-    useIntervalSubscriptions();
+  const { updateIntervalSubscription } = useIntervalSubscriptions();
 
   /// Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
@@ -141,40 +139,6 @@ export const Permissions = ({
     );
   };
 
-  /// Handle toggling an interval subscription.
-  const handleIntervalToggle = async (task: IntervalSubscription) => {
-    // Invert task status.
-    const newStatus = task.status === 'enable' ? 'disable' : 'enable';
-    task.status = newStatus;
-
-    // Handle task in intervals controller.
-    switch (newStatus) {
-      case 'enable': {
-        IntervalsController.insertSubscription({ ...task });
-        break;
-      }
-      case 'disable': {
-        IntervalsController.removeSubscription({ ...task });
-        break;
-      }
-    }
-
-    // Update main renderer state.
-    updateIntervalSubscription({ ...task });
-    tryUpdateDynamicIntervalTask({ ...task });
-
-    // Update OpenGov renderer state.
-    ConfigRenderer.portToOpenGov.postMessage({
-      task: 'openGov:task:update',
-      data: {
-        serialized: JSON.stringify(task),
-      },
-    });
-
-    // Update persisted task in store.
-    await window.myAPI.updateIntervalTask(JSON.stringify(task));
-  };
-
   /// TODO: Add `toggleable` field on subscription task type.
   /// Determine whether the toggle should be disabled based on the
   /// task and account data.
@@ -209,7 +173,7 @@ export const Permissions = ({
   const getKey = (
     type: string,
     action: string,
-    chainId: string,
+    chainId: ChainID,
     address: string | undefined
   ) =>
     address
@@ -368,44 +332,6 @@ export const Permissions = ({
     }
   };
 
-  /// Handle a one-shot event for a subscription task.
-  const handleIntervalOneShot = async (
-    task: IntervalSubscription,
-    nativeChecked: boolean,
-    setOneShotProcessing: AnyFunction
-  ) => {
-    setOneShotProcessing(true);
-    task.enableOsNotifications = nativeChecked;
-    const { success, message } = await executeIntervaledOneShot(
-      task,
-      'one-shot'
-    );
-
-    if (!success) {
-      setOneShotProcessing(false);
-
-      // Render error alert.
-      toast.error(message ? message : 'Error', {
-        position: 'bottom-center',
-        autoClose: 3000,
-        hideProgressBar: true,
-        closeOnClick: true,
-        closeButton: false,
-        pauseOnHover: false,
-        draggable: false,
-        progress: undefined,
-        theme: 'dark',
-        transition: Flip,
-        toastId: 'toast-connection',
-      });
-    } else {
-      // Wait some time to avoid the spinner snapping.
-      setTimeout(() => {
-        setOneShotProcessing(false);
-      }, 550);
-    }
-  };
-
   /// Handle clicking the native checkbox.
   const handleNativeCheckbox = async (
     flag: boolean,
@@ -439,87 +365,6 @@ export const Permissions = ({
       if (account) {
         account.queryMulti?.setOsNotificationsFlag(task);
       }
-    }
-  };
-
-  /// Handle clicking native os notifications toggle for interval subscriptions.
-  const handleIntervalNativeCheckbox = async (
-    task: IntervalSubscription,
-    flag: boolean
-  ) => {
-    const checked: boolean = flag;
-    task.enableOsNotifications = checked;
-
-    // Update task data in intervals controller.
-    IntervalsController.updateSubscription({ ...task });
-
-    // Update main renderer state.
-    updateIntervalSubscription({ ...task });
-    tryUpdateDynamicIntervalTask({ ...task });
-
-    // Update OpenGov renderer state.
-    ConfigRenderer.portToOpenGov.postMessage({
-      task: 'openGov:task:update',
-      data: {
-        serialized: JSON.stringify(task),
-      },
-    });
-
-    // Update persisted task in store.
-    await window.myAPI.updateIntervalTask(JSON.stringify(task));
-  };
-
-  /// Handle removing an interval subscription.
-  const handleRemoveIntervalSubscription = async (
-    task: IntervalSubscription
-  ) => {
-    // Remove task from interval controller.
-    task.status === 'enable' &&
-      IntervalsController.removeSubscription({ ...task }, isOnline);
-    // Set status to disable.
-    task.status = 'disable';
-    // Remove task from dynamic manage state if necessary.
-    tryRemoveIntervalSubscription({ ...task });
-    // Remove task from React state for rendering.
-    removeIntervalSubscription({ ...task });
-    // Remove task from store.
-    await window.myAPI.removeIntervalTask(JSON.stringify(task));
-    // Send message to OpenGov window to update its subscription state.
-    ConfigRenderer.portToOpenGov.postMessage({
-      task: 'openGov:task:removed',
-      data: { serialized: JSON.stringify(task) },
-    });
-  };
-
-  /// Handle setting a new interval duration for the subscription.
-  const handleChangeIntervalDuration = async (
-    event: React.ChangeEvent<HTMLSelectElement>,
-    task: IntervalSubscription,
-    setIntervalSetting: (ticksToWait: number) => void
-  ) => {
-    const newSetting: number = parseInt(event.target.value);
-    const settingObj = IntervalsController.durations.find(
-      (setting) => setting.ticksToWait === newSetting
-    );
-
-    if (settingObj) {
-      setIntervalSetting(newSetting);
-
-      // Update task state.
-      task.intervalSetting = settingObj;
-      updateIntervalSubscription({ ...task });
-      tryUpdateDynamicIntervalTask({ ...task });
-      // Update managed task in intervals controller.
-      IntervalsController.updateSubscription({ ...task });
-      // Update state in OpenGov window.
-      ConfigRenderer.portToOpenGov.postMessage({
-        task: 'openGov:task:update',
-        data: {
-          serialized: JSON.stringify(task),
-        },
-      });
-      // Update persisted task in store.
-      await window.myAPI.updateIntervalTask(JSON.stringify(task));
     }
   };
 
@@ -622,13 +467,6 @@ export const Permissions = ({
                 {intervalTasks.map((task: IntervalSubscription, j: number) => (
                   <IntervalRow
                     key={`${j}_${task.referendumId}_${task.action}`}
-                    handleIntervalToggle={handleIntervalToggle}
-                    handleIntervalNativeCheckbox={handleIntervalNativeCheckbox}
-                    handleChangeIntervalDuration={handleChangeIntervalDuration}
-                    handleIntervalOneShot={handleIntervalOneShot}
-                    handleRemoveIntervalSubscription={
-                      handleRemoveIntervalSubscription
-                    }
                     isTaskDisabled={isIntervalTaskDisabled}
                     task={task}
                   />

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -42,7 +42,6 @@ import type {
   IntervalSubscription,
   SubscriptionTask,
   TaskCategory,
-  WrappedSubscriptionTasks,
 } from '@/types/subscriptions';
 
 export const Permissions = ({
@@ -125,12 +124,8 @@ export const Permissions = ({
   }, [activeChainId]);
 
   /// Handle a subscription toggle and update rendered subscription state.
-  const handleToggle = async (cached: WrappedSubscriptionTasks) => {
-    await handleQueuedToggle(cached);
-
-    // Update rendererd subscription tasks state.
-    const task = cached.tasks[0];
-    task.status = task.status === 'enable' ? 'disable' : 'enable';
+  const handleToggle = async (task: SubscriptionTask) => {
+    await handleQueuedToggle(task);
     updateRenderedSubscriptions(task);
   };
 

--- a/src/renderer/screens/Home/Manage/types.tsx
+++ b/src/renderer/screens/Home/Manage/types.tsx
@@ -46,23 +46,5 @@ export interface PermissionRowProps {
 
 export interface IntervalRowProps {
   task: IntervalSubscription;
-  handleIntervalToggle: (task: IntervalSubscription) => Promise<void>;
-  handleIntervalNativeCheckbox: (
-    task: IntervalSubscription,
-    flag: boolean
-  ) => Promise<void>;
-  handleChangeIntervalDuration: (
-    event: React.ChangeEvent<HTMLSelectElement>,
-    task: IntervalSubscription,
-    setIntervalSetting: (ticksToWait: number) => void
-  ) => void;
-  handleIntervalOneShot: (
-    task: IntervalSubscription,
-    nativeChecked: boolean,
-    setOneShotProcessing: (processing: boolean) => void
-  ) => Promise<void>;
-  handleRemoveIntervalSubscription: (
-    task: IntervalSubscription
-  ) => Promise<void>;
   isTaskDisabled: () => boolean;
 }

--- a/src/renderer/screens/Home/Manage/types.tsx
+++ b/src/renderer/screens/Home/Manage/types.tsx
@@ -7,7 +7,6 @@ import type {
   IntervalSubscription,
   SubscriptionTask,
   SubscriptionTaskType,
-  WrappedSubscriptionTasks,
 } from '@/types/subscriptions';
 
 export interface ManageProps {
@@ -42,7 +41,7 @@ export interface PermissionRowProps {
     task: SubscriptionTask,
     setNativeChecked: AnyFunction
   ) => Promise<void>;
-  handleToggle: (cached: WrappedSubscriptionTasks) => Promise<void>;
+  handleToggle: (task: SubscriptionTask) => Promise<void>;
 }
 
 export interface IntervalRowProps {


### PR DESCRIPTION
# Summary

- [x] Remove `WrappedSubscriptionTask` type from subscription toggling logic in favour of just passing a `SubscriptionTask`.
- [x] Fix "double rendering" bug for toggle switch where task `status` property was being set twice.

## Merged PRs

- [chore: interval subscription manager context (#598)](https://github.com/polkadot-live/polkadot-live-app/pull/598)
  Lifts interval subscription handler functions to a dedicated context.

- [fix: interval os notifications](https://github.com/polkadot-live/polkadot-live-app/pull/599)
  Refine logic for determining how to render OS notifications for interval subscriptions.