### PR TITLE
fix: referenda parsing

### DIFF
--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -105,7 +105,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     const referendumIds = new Set(
       dynamicIntervalTasksState
         .map(({ referendumId }) => referendumId || -1)
-        .sort()
+        .sort((a, b) => a - b)
         .reverse()
     );
 

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -413,7 +413,9 @@ export const useMainMessagePorts = () => {
       if (isObject(info) && 'Ongoing' in info) {
         // Instantiate and push next referenda to state.
         const next: ActiveReferendaInfo = {
-          referendaId: parseInt((storageKey.toHuman() as string[])[0]),
+          referendaId: parseInt(
+            rmCommas((storageKey.toHuman() as string[])[0])
+          ),
           Ongoing: {
             ...info.Ongoing,
           },


### PR DESCRIPTION
# Summary

Referenda with IDs of 1000 and above are received as a string with thousand-separated commas. This PR removes commas from received referenda IDs, parsing the data correctly.