### PR TITLE
chore: account import iteration

### DIFF
--- a/src/renderer/contexts/import/Addresses/defaults.ts
+++ b/src/renderer/contexts/import/Addresses/defaults.ts
@@ -12,4 +12,5 @@ export const defaultAddressesContext: AddressesContextInterface = {
   setReadOnlyAddresses: (a) => {},
   setVaultAddresses: (a) => {},
   importAccountJson: (a) => {},
+  isAlreadyImported: () => false,
 };

--- a/src/renderer/contexts/import/Addresses/index.tsx
+++ b/src/renderer/contexts/import/Addresses/index.tsx
@@ -52,6 +52,24 @@ export const AddressesProvider = ({
     return parsed;
   });
 
+  /// Check if an address has already been imported.
+  const isAlreadyImported = (address: string): boolean => {
+    const checkAll = <T extends { address: string }>(
+      items: T[],
+      target: string
+    ): boolean =>
+      items.reduce(
+        (acc, cur) => (acc ? acc : cur.address === target ? true : false),
+        false
+      );
+
+    return (
+      checkAll(ledgerAddresses, address) ||
+      checkAll(vaultAddresses, address) ||
+      checkAll(readOnlyAddresses, address)
+    );
+  };
+
   /// Add account from received AccountJson data.
   const importAccountJson = (json: LocalAddress) => {
     const { address, source } = json;
@@ -99,6 +117,7 @@ export const AddressesProvider = ({
         setReadOnlyAddresses,
         setVaultAddresses,
         importAccountJson,
+        isAlreadyImported,
       }}
     >
       {children}

--- a/src/renderer/contexts/import/Addresses/types.ts
+++ b/src/renderer/contexts/import/Addresses/types.ts
@@ -13,4 +13,5 @@ export interface AddressesContextInterface {
   setReadOnlyAddresses: React.Dispatch<React.SetStateAction<LocalAddress[]>>;
   setVaultAddresses: React.Dispatch<React.SetStateAction<LocalAddress[]>>;
   importAccountJson: (a: LocalAddress) => void;
+  isAlreadyImported: (address: string) => boolean;
 }

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -115,7 +115,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
       renderToast('Address is already imported.', 'error', `toast-${trimmed}`);
       return;
     } else if (!validateAddress(trimmed)) {
-      renderToast('Bad account name.', 'error', `toast-${trimmed}`);
+      renderToast('Invalid Address.', 'error', `toast-${trimmed}`);
       return;
     }
 

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -42,8 +42,11 @@ import type { LocalAddress } from '@/types/accounts';
 import type { ManageReadOnlyProps } from '../types';
 
 export const Manage = ({ setSection }: ManageReadOnlyProps) => {
-  const { readOnlyAddresses: addresses, setReadOnlyAddresses: setAddresses } =
-    useAddresses();
+  const {
+    readOnlyAddresses: addresses,
+    setReadOnlyAddresses: setAddresses,
+    isAlreadyImported,
+  } = useAddresses();
   const { insertAccountStatus } = useAccountStatuses();
   const { handleImportAddress } = useImportHandler();
 
@@ -74,17 +77,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
         if (isValid) {
           return true;
         }
-      }
-    }
-
-    return false;
-  };
-
-  /// Verify that the address is not already imported.
-  const isAlreadyImported = (address: string): boolean => {
-    for (const next of addresses) {
-      if (next.address === address) {
-        return true;
       }
     }
 


### PR DESCRIPTION
# Summary

- [x] Fix error message when empty or invalid address entered in read-only input field.
- [x] All imported accounts checked (for each import method) when checking for existing accounts.
  - Can no longer import an address that has already been imported via another import method.