### PR TITLE
chore(accounts): local storage deprecation

### DIFF
--- a/src/config/processes/import.ts
+++ b/src/config/processes/import.ts
@@ -1,8 +1,6 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AccountSource } from '@/types/accounts';
-
 /**
  * @name Config
  * @summary Configuration class for the `import` window. Accessed in the import renderer.
@@ -10,29 +8,6 @@ import type { AccountSource } from '@/types/accounts';
 export class Config {
   // Cache the import window's message port to to facilitate communication to the `main` renderer.
   private static _portImport: MessagePort;
-
-  // Local storage keys.
-  private static _ledgerAddressesStorageKey = 'ledger_addresses';
-  private static _vaultAddressesStorageKey = 'vault_addresses';
-  private static _readOnlyAddressesStorageKey = 'read_only_addresses';
-
-  // Return the local storage key for corresponding source addresses.
-  static getStorageKey(source: AccountSource): string {
-    switch (source) {
-      case 'ledger': {
-        return Config._ledgerAddressesStorageKey;
-      }
-      case 'vault': {
-        return Config._vaultAddressesStorageKey;
-      }
-      case 'read-only': {
-        return Config._readOnlyAddressesStorageKey;
-      }
-      default: {
-        throw new Error('source not recognized');
-      }
-    }
-  }
 
   // Get the `import` window's message port.
   static get portImport(): MessagePort {

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -3,16 +3,22 @@
 
 import { MessageChannelMain } from 'electron';
 import { store } from '@/main';
+import type { AccountSource } from '@/types/accounts';
+import type { AnyData } from '@/types/misc';
+import type { PersistedSettings } from '@/renderer/screens/Settings/types';
 import type { PortPair, PortPairID } from '@/types/communication';
 import type { Rectangle, Tray } from 'electron';
-import type { PersistedSettings } from '@/renderer/screens/Settings/types';
-import type { AnyData } from '@/types/misc';
 
 export class Config {
   // Storage keys.
   private static _chainSubscriptionsStorageKey = 'chain_subscriptions';
   private static _settingsStorageKey = 'app_settings';
   private static _workspacesStorageKey = 'developer_console_workspaces';
+
+  // Raw account storage keys.
+  private static _ledgerAddressesStorageKey = 'ledger_addresses';
+  private static _vaultAddressesStorageKey = 'vault_addresses';
+  private static _readOnlyAddressesStorageKey = 'read_only_addresses';
 
   // Main window's docked properties.
   private static _dockedWidth = 420;
@@ -32,6 +38,24 @@ export class Config {
 
   // Flags to handle data processes.
   private static _exportingData = false;
+
+  // Return the local storage key for corresponding source addresses.
+  static getStorageKey(source: AccountSource): string {
+    switch (source) {
+      case 'ledger': {
+        return Config._ledgerAddressesStorageKey;
+      }
+      case 'vault': {
+        return Config._vaultAddressesStorageKey;
+      }
+      case 'read-only': {
+        return Config._readOnlyAddressesStorageKey;
+      }
+      default: {
+        throw new Error('source not recognized');
+      }
+    }
+  }
 
   // Instantiate message port pairs to facilitate communication between the
   // main renderer and another renderer.

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -1,0 +1,174 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Config as ConfigMain } from '@/config/processes/main';
+import { store } from '@/main';
+import type { AnyData } from '@/types/misc';
+import type { IpcTask } from '@/types/communication';
+import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
+
+export class AddressesController {
+  /**
+   * @name add
+   * @summary Set the import flag of an address to `true`.
+   */
+  static add(task: IpcTask) {
+    const { source, address } = task.data;
+    const key = ConfigMain.getStorageKey(source);
+
+    if (source === 'ledger') {
+      // Update ledger address.
+      const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
+      const serialized = JSON.stringify(
+        stored.map((a) =>
+          a.address === address ? { ...a, isImported: true } : a
+        )
+      );
+
+      this.setInStore(key, serialized);
+    } else {
+      // Update stored vault or read-only accounts.
+      const stored = this.getStoredAddresses(key) as LocalAddress[];
+      const serialized = JSON.stringify(
+        stored.map((a) =>
+          a.address === address ? { ...a, isImported: true } : a
+        )
+      );
+
+      this.setInStore(key, serialized);
+    }
+  }
+
+  /**
+   * @name delete
+   * @summary Delete a received address' data from store.
+   */
+  static delete(task: IpcTask) {
+    const { source, address } = task.data;
+    const key = ConfigMain.getStorageKey(source);
+
+    if (source === 'ledger') {
+      // Update stored ledger accounts.
+      const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
+      const serialized = JSON.stringify(
+        stored.filter((a) => a.address !== address)
+      );
+
+      this.setInStore(key, serialized);
+    } else {
+      // Update stored vault or read-only accounts.
+      const stored = this.getStoredAddresses(key) as LocalAddress[];
+      const serialized = JSON.stringify(
+        stored.filter((a) => a.address !== address)
+      );
+
+      this.setInStore(key, serialized);
+    }
+  }
+
+  /**
+   * @name get
+   * @summary Get all stored addresses for an account type.
+   */
+  static get(task: IpcTask): string {
+    const { source } = task.data;
+    const key = ConfigMain.getStorageKey(source);
+    return store.has(key) ? this.getFromStore(key) : '[]';
+  }
+
+  /**
+   * @name persist
+   * @summary Persist received address data to store.
+   */
+  static persist(task: IpcTask) {
+    const { source, serialized } = task.data;
+    const key = ConfigMain.getStorageKey(source);
+
+    if (source === 'ledger') {
+      // Update stored ledger accounts.
+      const parsed: LedgerLocalAddress = JSON.parse(serialized);
+      const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
+      this.setInStore(key, JSON.stringify([...stored, parsed]));
+    } else {
+      // Update stored vault or read-only accounts.
+      const parsed: LocalAddress = JSON.parse(serialized);
+      const stored = this.getStoredAddresses(key) as LocalAddress[];
+      this.setInStore(key, JSON.stringify([...stored, parsed]));
+    }
+  }
+
+  /**
+   * @name remove
+   * @summary Set the import flag of an address to `false`.
+   */
+  static remove(task: IpcTask) {
+    const { source, address } = task.data;
+    const key = ConfigMain.getStorageKey(source);
+
+    if (source === 'ledger') {
+      // Remove stored ledger accounts.
+      const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
+      const serialised = JSON.stringify(
+        stored.map((a) =>
+          a.address === address ? { ...a, isImported: false } : a
+        )
+      );
+
+      this.setInStore(key, serialised);
+    } else {
+      // Remove stored vault or read-only accounts.
+      const stored = this.getStoredAddresses(key) as LocalAddress[];
+      const serialized = JSON.stringify(
+        stored.map((a) =>
+          a.address === address ? { ...a, isImported: false } : a
+        )
+      );
+
+      this.setInStore(key, serialized);
+    }
+  }
+
+  /**
+   * @name rename
+   * @summary Update a stored address' name.
+   */
+  static rename(task: IpcTask) {
+    const { source, address, newName } = task.data;
+    const key = ConfigMain.getStorageKey(source);
+
+    if (source === 'ledger') {
+      // Rename ledger address data in store.
+      const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
+      const serialized = JSON.stringify(
+        stored.map((a) => (a.address === address ? { ...a, name: newName } : a))
+      );
+
+      this.setInStore(key, serialized);
+    } else {
+      // Rename vault and read-only address data in store.
+      const stored = this.getStoredAddresses(key) as LocalAddress[];
+      const serialized = JSON.stringify(
+        stored.map((a) => (a.address === address ? { ...a, name: newName } : a))
+      );
+
+      this.setInStore(key, serialized);
+    }
+  }
+
+  static getFromStore(key: string) {
+    return (store as Record<string, AnyData>).get(key) as string;
+  }
+
+  static setInStore(key: string, serialized: string) {
+    (store as Record<string, AnyData>).set(key, serialized);
+  }
+
+  static getStoredAddresses(
+    key: string,
+    ledger = false
+  ): LedgerLocalAddress[] | LocalAddress[] {
+    return ledger
+      ? (JSON.parse(this.getFromStore(key)) as LedgerLocalAddress[])
+      : (JSON.parse(this.getFromStore(key)) as LocalAddress[]);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -684,11 +684,11 @@ app.whenReady().then(async () => {
   );
 
   /**
-   * Data
+   * Backup
    */
 
   // Export a data-file.
-  ipcMain.handle('app:data:export', async (_, serialized) => {
+  ipcMain.handle('app:data:export', async () => {
     if (!ConfigMain.exportingData) {
       ConfigMain.exportingData = true;
 
@@ -713,6 +713,7 @@ app.whenReady().then(async () => {
       // Handle save or cancel.
       if (!canceled && filePath) {
         try {
+          const serialized = AddressesController.getAll();
           await fsPromises.writeFile(filePath, serialized, {
             encoding: 'utf8',
           });

--- a/src/main.ts
+++ b/src/main.ts
@@ -248,7 +248,7 @@ app.whenReady().then(async () => {
             JSON.stringify([...stored, parsed])
           );
         } else {
-          // Update stored raw vault or read-only accounts.
+          // Update stored vault or read-only accounts.
           const parsed: LocalAddress = JSON.parse(serialized);
           const stored: LocalAddress[] = store.has(key)
             ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
@@ -260,6 +260,33 @@ app.whenReady().then(async () => {
           );
         }
 
+        break;
+      }
+      case 'raw-account:delete': {
+        const { source, address } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        if (source === 'ledger') {
+          // Update stored ledger accounts.
+          const stored: LedgerLocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(stored.filter((a) => a.address !== address))
+          );
+        } else {
+          // Update stored vault or read-only accounts.
+          const stored: LocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(stored.filter((a) => a.address !== address))
+          );
+        }
         break;
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,6 +289,42 @@ app.whenReady().then(async () => {
         }
         break;
       }
+      case 'raw-account:remove': {
+        const { source, address } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        if (source === 'ledger') {
+          // Remove stored ledger accounts.
+          const stored: LedgerLocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, isImported: false } : a
+              )
+            )
+          );
+        } else {
+          // Remove stored vault or read-only accounts.
+          const stored: LocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, isImported: false } : a
+              )
+            )
+          );
+        }
+
+        break;
+      }
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,6 +287,43 @@ app.whenReady().then(async () => {
             JSON.stringify(stored.filter((a) => a.address !== address))
           );
         }
+
+        break;
+      }
+      case 'raw-account:add': {
+        const { source, address } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        // Set isImported flag to true.
+        if (source === 'ledger') {
+          const stored: LedgerLocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, isImported: true } : a
+              )
+            )
+          );
+        } else {
+          // Add stored vault or read-only accounts.
+          const stored: LocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, isImported: true } : a
+              )
+            )
+          );
+        }
+
         break;
       }
       case 'raw-account:remove': {
@@ -332,6 +369,42 @@ app.whenReady().then(async () => {
         return store.has(key)
           ? ((store as Record<string, AnyData>).get(key) as string)
           : '[]';
+      }
+      case 'raw-account:rename': {
+        const { source, address, newName } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        if (source === 'ledger') {
+          // Rename ledger address data in store.
+          const stored: LedgerLocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, name: newName } : a
+              )
+            )
+          );
+        } else {
+          // Rename vault and read-only address data in store.
+          const stored: LocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, name: newName } : a
+              )
+            )
+          );
+        }
+
+        break;
       }
     }
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -325,6 +325,14 @@ app.whenReady().then(async () => {
 
         break;
       }
+      case 'raw-account:get': {
+        const { source } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        return store.has(key)
+          ? ((store as Record<string, AnyData>).get(key) as string)
+          : '[]';
+      }
     }
   });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -119,8 +119,7 @@ export const API: PreloadAPI = {
    * File import and export
    */
 
-  exportAppData: async (serialized: string) =>
-    await ipcRenderer.invoke('app:data:export', serialized),
+  exportAppData: async () => await ipcRenderer.invoke('app:data:export'),
 
   importAppData: async () => await ipcRenderer.invoke('app:data:import'),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -11,11 +11,12 @@ import type {
   EventCallback,
   NotificationData,
 } from '@/types/reporter';
-import type { FlattenedAccountData } from './types/accounts';
-import type { SubscriptionTask } from './types/subscriptions';
 import type { AnyJson } from './types/misc';
 import type { ChainID } from './types/chains';
+import type { FlattenedAccountData } from './types/accounts';
+import type { IpcTask } from './types/communication';
 import type { SettingAction } from './renderer/screens/Settings/types';
+import type { SubscriptionTask } from './types/subscriptions';
 
 console.log(global.location.search);
 
@@ -58,6 +59,12 @@ export const API: PreloadAPI = {
     }
     return '';
   },
+
+  /**
+   * Raw Accounts
+   */
+  rawAccountTask: async (task: IpcTask) =>
+    await ipcRenderer.invoke('main:raw-account', task),
 
   /**
    * Platform

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -22,6 +22,7 @@ import { IntervalTasksManagerProvider } from './contexts/main/IntervalTasksManag
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
 import { AddressesProvider as ImportAddressesProvider } from '@app/contexts/import/Addresses';
 import { ImportHandlerProvider } from './contexts/import/ImportHandler';
+import { AddHandlerProvider } from './contexts/import/AddHandler';
 import { RemoveHandlerProvider } from './contexts/import/RemoveHandler';
 import { DeleteHandlerProvider } from './contexts/import/DeleteHandler';
 
@@ -75,6 +76,7 @@ const getProvidersForWindow = () => {
         ImportAddressesProvider,
         ImportAccountStatusesProvider,
         ImportHandlerProvider, // Requires useAccountStatuses + useAddresses
+        AddHandlerProvider, // Requires useAccountStatuses + useAddresses
         RemoveHandlerProvider, // Requires useAddresses
         DeleteHandlerProvider // Requires useAccountStatuses + useAddresses
       )(Theme);

--- a/src/renderer/contexts/import/AccountStatuses/index.tsx
+++ b/src/renderer/contexts/import/AccountStatuses/index.tsx
@@ -1,14 +1,10 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { createContext, useContext, useState } from 'react';
-import { Config as ConfigImport } from '@/config/processes/import';
 import * as defaults from './defaults';
-import type {
-  AccountSource,
-  LedgerLocalAddress,
-  LocalAddress,
-} from '@/types/accounts';
+import { createContext, useContext, useState } from 'react';
+import { useAddresses } from '../Addresses';
+import type { AccountSource } from '@/types/accounts';
 import type { AccountStatusesContextInterface } from './types';
 
 export const AccountStatusesContext =
@@ -32,33 +28,34 @@ export const AccountStatusesProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  /// Utility to fetch account statuses based on account data in local storage.
+  const { ledgerAddresses, readOnlyAddresses, vaultAddresses } = useAddresses();
+
+  /// Utility to initialize account statuses to false.
   const fetchAccountStatuses = (
     source: AccountSource
   ): Map<string, boolean> => {
     const map = new Map<string, boolean>();
-    const key: string = ConfigImport.getStorageKey(source);
-    const fetched: string | null = localStorage.getItem(key);
-
     switch (source) {
-      case 'read-only':
-      case 'vault': {
-        const parsed: LocalAddress[] = fetched ? JSON.parse(fetched) : [];
-        for (const { address } of parsed) {
+      case 'ledger': {
+        for (const { address } of ledgerAddresses) {
           map.set(address, false);
         }
         return map;
       }
-      case 'ledger': {
-        const parsed: LedgerLocalAddress[] =
-          fetched !== null ? JSON.parse(fetched) : [];
-        for (const { address } of parsed) {
+      case 'read-only': {
+        for (const { address } of readOnlyAddresses) {
+          map.set(address, false);
+        }
+        return map;
+      }
+      case 'vault': {
+        for (const { address } of vaultAddresses) {
           map.set(address, false);
         }
         return map;
       }
       default: {
-        return map;
+        throw new Error('unreachable');
       }
     }
   };

--- a/src/renderer/contexts/import/AddHandler/defaults.ts
+++ b/src/renderer/contexts/import/AddHandler/defaults.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { AddHandlerContextInterface } from './types';
+
+export const defaultAddHandlerContext: AddHandlerContextInterface = {
+  handleAddAddress: () => new Promise(() => {}),
+};

--- a/src/renderer/contexts/import/AddHandler/index.tsx
+++ b/src/renderer/contexts/import/AddHandler/index.tsx
@@ -1,0 +1,117 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { Config as ConfigImport } from '@/config/processes/import';
+import { createContext, useContext } from 'react';
+import { useAccountStatuses } from '../AccountStatuses';
+import { getAddressChainId } from '@/renderer/Utils';
+import { useAddresses } from '../Addresses';
+import type { AddHandlerContextInterface } from './types';
+import type { IpcTask } from '@/types/communication';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
+
+export const AddHandlerContext = createContext<AddHandlerContextInterface>(
+  defaults.defaultAddHandlerContext
+);
+
+export const useAddHandler = () => useContext(AddHandlerContext);
+
+export const AddHandlerProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { setStatusForAccount } = useAccountStatuses();
+  const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
+    useAddresses();
+
+  /// Exposed function to add an address.
+  const handleAddAddress = async (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    // Set processing flag for account.
+    setStatusForAccount(address, source, true);
+
+    if (source === 'vault') {
+      handleAddVaultAddress(address);
+    } else if (source === 'ledger') {
+      handleAddLedgerAddress(address);
+    } else if (source === 'read-only') {
+      handleAddReadOnlyAddress(address);
+    }
+
+    // Update address data in store in main process.
+    await updateAddressInStore(source, address);
+
+    // Process added address in main renderer.
+    postAddressToMainWindow(address, source, accountName);
+  };
+
+  /// Update import window read-only addresses state.
+  const handleAddReadOnlyAddress = (address: string) => {
+    setReadOnlyAddresses((prev: LocalAddress[]) =>
+      prev.map((a) => (a.address === address ? { ...a, isImported: true } : a))
+    );
+  };
+
+  /// Update import window vault addresses state.
+  const handleAddVaultAddress = (address: string) => {
+    setVaultAddresses((prev: LocalAddress[]) =>
+      prev.map((a) => (a.address === address ? { ...a, isImported: true } : a))
+    );
+  };
+
+  /// Update import window ledger addresses state.
+  const handleAddLedgerAddress = (address: string) => {
+    setLedgerAddresses((prev: LedgerLocalAddress[]) =>
+      prev.map((a) => (a.address === address ? { ...a, isImported: true } : a))
+    );
+  };
+
+  /// Update address in store.
+  const updateAddressInStore = async (
+    source: AccountSource,
+    address: string
+  ) => {
+    const ipcTask: IpcTask = {
+      action: 'raw-account:add',
+      data: { source, address },
+    };
+
+    await window.myAPI.rawAccountTask(ipcTask);
+  };
+
+  /// Send address data to main renderer to process.
+  const postAddressToMainWindow = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:address:import',
+      data: {
+        address,
+        chainId: getAddressChainId(address),
+        name: accountName,
+        source,
+      },
+    });
+  };
+
+  return (
+    <AddHandlerContext.Provider
+      value={{
+        handleAddAddress,
+      }}
+    >
+      {children}
+    </AddHandlerContext.Provider>
+  );
+};

--- a/src/renderer/contexts/import/AddHandler/index.tsx
+++ b/src/renderer/contexts/import/AddHandler/index.tsx
@@ -4,9 +4,10 @@
 import * as defaults from './defaults';
 import { Config as ConfigImport } from '@/config/processes/import';
 import { createContext, useContext } from 'react';
-import { useAccountStatuses } from '../AccountStatuses';
 import { getAddressChainId } from '@/renderer/Utils';
-import { useAddresses } from '../Addresses';
+import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
+import { useAddresses } from '@app/contexts/import/Addresses';
+import { useConnections } from '@app/contexts/common/Connections';
 import type { AddHandlerContextInterface } from './types';
 import type { IpcTask } from '@/types/communication';
 import type {
@@ -26,6 +27,7 @@ export const AddHandlerProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { isConnected } = useConnections();
   const { setStatusForAccount } = useAccountStatuses();
   const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
     useAddresses();
@@ -51,7 +53,9 @@ export const AddHandlerProvider = ({
     await updateAddressInStore(source, address);
 
     // Process added address in main renderer.
-    postAddressToMainWindow(address, source, accountName);
+    if (isConnected) {
+      postAddressToMainWindow(address, source, accountName);
+    }
   };
 
   /// Update import window read-only addresses state.

--- a/src/renderer/contexts/import/AddHandler/types.ts
+++ b/src/renderer/contexts/import/AddHandler/types.ts
@@ -1,0 +1,12 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AccountSource } from '@/types/accounts';
+
+export interface AddHandlerContextInterface {
+  handleAddAddress: (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => Promise<void>;
+}

--- a/src/renderer/contexts/import/Addresses/defaults.ts
+++ b/src/renderer/contexts/import/Addresses/defaults.ts
@@ -8,9 +8,9 @@ export const defaultAddressesContext: AddressesContextInterface = {
   ledgerAddresses: [],
   readOnlyAddresses: [],
   vaultAddresses: [],
-  setLedgerAddresses: (a) => {},
-  setReadOnlyAddresses: (a) => {},
-  setVaultAddresses: (a) => {},
-  importAccountJson: (a) => {},
+  handleAddressImport: () => {},
+  handleAddressDelete: () => false,
+  handleAddressRemove: () => {},
+  handleAddressAdd: () => {},
   isAlreadyImported: () => false,
 };

--- a/src/renderer/contexts/import/Addresses/types.ts
+++ b/src/renderer/contexts/import/Addresses/types.ts
@@ -1,17 +1,23 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { LedgerLocalAddress, LocalAddress } from '@/types/accounts';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
 
 export interface AddressesContextInterface {
   ledgerAddresses: LedgerLocalAddress[];
   readOnlyAddresses: LocalAddress[];
   vaultAddresses: LocalAddress[];
-  setLedgerAddresses: React.Dispatch<
-    React.SetStateAction<LedgerLocalAddress[]>
-  >;
-  setReadOnlyAddresses: React.Dispatch<React.SetStateAction<LocalAddress[]>>;
-  setVaultAddresses: React.Dispatch<React.SetStateAction<LocalAddress[]>>;
-  importAccountJson: (a: LocalAddress) => void;
+
+  handleAddressImport: (
+    source: AccountSource,
+    local: LedgerLocalAddress | LocalAddress
+  ) => void;
+  handleAddressDelete: (source: AccountSource, address: string) => boolean;
+  handleAddressRemove: (source: AccountSource, address: string) => void;
+  handleAddressAdd: (source: AccountSource, address: string) => void;
   isAlreadyImported: (address: string) => boolean;
 }

--- a/src/renderer/contexts/import/DeleteHandler/defaults.ts
+++ b/src/renderer/contexts/import/DeleteHandler/defaults.ts
@@ -5,5 +5,5 @@
 import type { DeleteHandlerContextInterface } from './types';
 
 export const defaultDeleteHandlerContext: DeleteHandlerContextInterface = {
-  handleDeleteAddress: () => false,
+  handleDeleteAddress: () => new Promise(() => {}),
 };

--- a/src/renderer/contexts/import/DeleteHandler/types.ts
+++ b/src/renderer/contexts/import/DeleteHandler/types.ts
@@ -4,5 +4,8 @@
 import type { AccountSource } from '@/types/accounts';
 
 export interface DeleteHandlerContextInterface {
-  handleDeleteAddress: (address: string, source: AccountSource) => boolean;
+  handleDeleteAddress: (
+    address: string,
+    source: AccountSource
+  ) => Promise<boolean>;
 }

--- a/src/renderer/contexts/import/ImportHandler/defaults.ts
+++ b/src/renderer/contexts/import/ImportHandler/defaults.ts
@@ -6,4 +6,5 @@ import type { ImportHandlerContextInterface } from './types';
 
 export const defaultImportHandlerContext: ImportHandlerContextInterface = {
   handleImportAddress: () => new Promise(() => {}),
+  handleImportAddressFromBackup: () => new Promise(() => {}),
 };

--- a/src/renderer/contexts/import/ImportHandler/defaults.ts
+++ b/src/renderer/contexts/import/ImportHandler/defaults.ts
@@ -5,5 +5,5 @@
 import type { ImportHandlerContextInterface } from './types';
 
 export const defaultImportHandlerContext: ImportHandlerContextInterface = {
-  handleImportAddress: () => {},
+  handleImportAddress: () => new Promise(() => {}),
 };

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -66,7 +66,9 @@ export const ImportHandlerProvider = ({
     await persistAddressToStore(source, local);
 
     // Send data to main renderer for processing.
-    postAddressToMainWindow(address, source, accountName);
+    if (isConnected) {
+      postAddressToMainWindow(address, source, accountName);
+    }
   };
 
   /// Update import window read-only addresses state.
@@ -102,7 +104,7 @@ export const ImportHandlerProvider = ({
       ? ({
           address,
           device: { ...device },
-          isImported: false,
+          isImported: isConnected ? true : false,
           name: accountName,
           pubKey: pubKey || '',
           source,

--- a/src/renderer/contexts/import/ImportHandler/types.ts
+++ b/src/renderer/contexts/import/ImportHandler/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AccountSource } from '@/types/accounts';
+import type { AccountSource, LocalAddress } from '@/types/accounts';
 import type { AnyData } from '@/types/misc';
 
 export interface ImportHandlerContextInterface {
@@ -12,4 +12,5 @@ export interface ImportHandlerContextInterface {
     pubKey?: string,
     device?: AnyData
   ) => Promise<void>;
+  handleImportAddressFromBackup: (imported: LocalAddress) => Promise<void>;
 }

--- a/src/renderer/contexts/import/ImportHandler/types.ts
+++ b/src/renderer/contexts/import/ImportHandler/types.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { AccountSource } from '@/types/accounts';
+import type { AnyData } from '@/types/misc';
 
 export interface ImportHandlerContextInterface {
   handleImportAddress: (
     address: string,
     source: AccountSource,
-    accountName: string
-  ) => void;
+    accountName: string,
+    pubKey?: string,
+    device?: AnyData
+  ) => Promise<void>;
 }

--- a/src/renderer/contexts/import/RemoveHandler/defaults.ts
+++ b/src/renderer/contexts/import/RemoveHandler/defaults.ts
@@ -5,5 +5,5 @@
 import type { RemoveHandlerContextInterface } from './types';
 
 export const defaultRemoveHandlerContext: RemoveHandlerContextInterface = {
-  handleRemoveAddress: () => {},
+  handleRemoveAddress: () => new Promise(() => {}),
 };

--- a/src/renderer/contexts/import/RemoveHandler/index.tsx
+++ b/src/renderer/contexts/import/RemoveHandler/index.tsx
@@ -6,11 +6,7 @@ import { Config as ConfigImport } from '@/config/processes/import';
 import { getAddressChainId } from '@/renderer/Utils';
 import { createContext, useContext } from 'react';
 import { useAddresses } from '@app/contexts/import/Addresses';
-import type {
-  AccountSource,
-  LedgerLocalAddress,
-  LocalAddress,
-} from '@/types/accounts';
+import type { AccountSource } from '@/types/accounts';
 import type { IpcTask } from '@/types/communication';
 import type { RemoveHandlerContextInterface } from './types';
 
@@ -26,48 +22,21 @@ export const RemoveHandlerProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
-    useAddresses();
+  const { handleAddressRemove } = useAddresses();
 
   /// Exposed function to remove an address.
   const handleRemoveAddress = async (
     address: string,
     source: AccountSource
   ) => {
-    if (source === 'vault') {
-      handleRemoveVaultAddress(address);
-    } else if (source === 'ledger') {
-      handleRemoveLedgerAddress(address);
-    } else if (source === 'read-only') {
-      handleRemoveReadOnlyAddress(address);
-    }
+    // Update addresses state and references.
+    handleAddressRemove(source, address);
 
     // Update address data in store in main process.
     await updateAddressInStore(source, address);
 
     // Process removed address in main renderer.
     postAddressToMainWindow(address);
-  };
-
-  /// Update import window read-only addresses state.
-  const handleRemoveReadOnlyAddress = (address: string) => {
-    setReadOnlyAddresses((prev: LocalAddress[]) =>
-      prev.map((a) => (a.address === address ? { ...a, isImported: false } : a))
-    );
-  };
-
-  /// Update import window vault addresses state.
-  const handleRemoveVaultAddress = (address: string) => {
-    setVaultAddresses((prev: LocalAddress[]) =>
-      prev.map((a) => (a.address === address ? { ...a, isImported: false } : a))
-    );
-  };
-
-  /// Update import window ledger addresses state.
-  const handleRemoveLedgerAddress = (address: string) => {
-    setLedgerAddresses((prev: LedgerLocalAddress[]) =>
-      prev.map((a) => (a.address === address ? { ...a, isImported: false } : a))
-    );
   };
 
   /// Update address in store.

--- a/src/renderer/contexts/import/RemoveHandler/types.ts
+++ b/src/renderer/contexts/import/RemoveHandler/types.ts
@@ -4,5 +4,8 @@
 import type { AccountSource } from '@/types/accounts';
 
 export interface RemoveHandlerContextInterface {
-  handleRemoveAddress: (address: string, source: AccountSource) => void;
+  handleRemoveAddress: (
+    address: string,
+    source: AccountSource
+  ) => Promise<void>;
 }

--- a/src/renderer/hooks/useImportMessagePorts.ts
+++ b/src/renderer/hooks/useImportMessagePorts.ts
@@ -4,13 +4,13 @@
 import { Config as ConfigImport } from '@/config/processes/import';
 
 /// Import window contexts.
-import { useAddresses as useImportAddresses } from '@app/contexts/import/Addresses';
+import { useImportHandler } from '@app/contexts/import/ImportHandler';
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useConnections } from '@/renderer/contexts/common/Connections';
 import { useEffect } from 'react';
 
 export const useImportMessagePorts = () => {
-  const { importAccountJson } = useImportAddresses();
+  const { handleImportAddressFromBackup } = useImportHandler();
   const { setIsConnected } = useConnections();
   const { setStatusForAccount } = useAccountStatuses();
 
@@ -25,11 +25,12 @@ export const useImportMessagePorts = () => {
       case 'main-import:import': {
         ConfigImport.portImport = e.ports[0];
 
-        ConfigImport.portImport.onmessage = (ev: MessageEvent) => {
+        ConfigImport.portImport.onmessage = async (ev: MessageEvent) => {
           // Message received from `main`.
           switch (ev.data.task) {
             case 'import:account:add': {
-              importAccountJson(ev.data.data.json);
+              const { json } = ev.data.data;
+              await handleImportAddressFromBackup(JSON.parse(json));
               break;
             }
             case 'import:account:processing': {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -19,6 +19,7 @@ import { isObject, u8aConcat } from '@polkadot/util';
 import { planckToUnit, rmCommas } from '@w3ux/utils';
 import { SubscriptionsController } from '@/controller/renderer/SubscriptionsController';
 import { IntervalsController } from '@/controller/renderer/IntervalsController';
+import { TaskOrchestrator } from '@/orchestrators/TaskOrchestrator';
 
 /// Main window contexts.
 import { useAddresses } from '@app/contexts/main/Addresses';
@@ -38,7 +39,6 @@ import type {
   IntervalSubscription,
   SubscriptionTask,
 } from '@/types/subscriptions';
-import { TaskOrchestrator } from '@/orchestrators/TaskOrchestrator';
 
 export const useMainMessagePorts = () => {
   /// Main renderer contexts.

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -32,7 +32,7 @@ import { useSubscriptions } from '@app/contexts/main/Subscriptions';
 import { useIntervalSubscriptions } from '../contexts/main/IntervalSubscriptions';
 
 /// Type imports.
-import type { AccountSource, LocalAddress } from '@/types/accounts';
+import type { LocalAddress } from '@/types/accounts';
 import type { ActiveReferendaInfo } from '@/types/openGov';
 import type { AnyData } from '@/types/misc';
 import type {
@@ -244,26 +244,8 @@ export const useMainMessagePorts = () => {
   const postToImport = (json: LocalAddress) => {
     ConfigRenderer.portToImport.postMessage({
       task: 'import:account:add',
-      data: { json },
+      data: { json: JSON.stringify(json) },
     });
-  };
-
-  /**
-   * @name getLocalAddresses
-   * @summary Utility to fetch local addresses from local storage.
-   */
-  const getLocalAddresses = (source: AccountSource) => {
-    const key =
-      source === 'vault'
-        ? 'vault_addresses'
-        : source === 'read-only'
-          ? 'read_only_addresses'
-          : '';
-
-    const fetched: string | null = localStorage.getItem(key);
-    return key === '' || !fetched
-      ? []
-      : (JSON.parse(fetched) as LocalAddress[]);
   };
 
   /**
@@ -271,20 +253,7 @@ export const useMainMessagePorts = () => {
    * @summary Write Polkadot Live data to a file.
    */
   const handleDataExport = async () => {
-    // Get data to export.
-    let accountsJson: LocalAddress[] = [];
-    for (const source of ['vault', 'read-only'] as AccountSource[]) {
-      accountsJson = accountsJson.concat(
-        getLocalAddresses(source).map((a) => ({
-          ...a,
-          isImported: false,
-        }))
-      );
-    }
-
-    // Serialize and export data in main process.
-    const serialized = JSON.stringify(accountsJson);
-    const { result, msg } = await window.myAPI.exportAppData(serialized);
+    const { result, msg } = await window.myAPI.exportAppData();
 
     // Render toastify message in settings window.
     switch (msg) {
@@ -320,14 +289,9 @@ export const useMainMessagePorts = () => {
     switch (response.msg) {
       case 'success': {
         try {
-          const json: LocalAddress[] = JSON.parse(response.data.serialized);
-          for (const accountJson of json) {
-            // TODO: Support importing ledger addresses.
-            if (accountJson.source === 'ledger') {
-              continue;
-            }
-            postToImport(accountJson);
-          }
+          // TODO: Support importing ledger addresses.
+          const parsed: LocalAddress[] = JSON.parse(response.data.serialized);
+          parsed.forEach((a) => a.source !== 'ledger' && postToImport(a));
           postToSettings(response.result, 'Data imported successfully.');
         } catch (err) {
           postToSettings(false, 'Error parsing JSON.');

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -73,9 +73,10 @@ export const HardwareAddress = ({
     renderToast('Account name updated.', 'success', `toast-${trimmed}`);
 
     // Otherwise rename account.
-    renameHandler(address, trimmed);
-    setEditName(trimmed);
-    setEditing(false);
+    renameHandler(address, trimmed).then(() => {
+      setEditName(trimmed);
+      setEditing(false);
+    });
   };
 
   // Input change handler.
@@ -133,7 +134,7 @@ export const HardwareAddress = ({
                       id="commit-btn"
                       type="button"
                       className="edit"
-                      onPointerDown={() => commitEdit()}
+                      onPointerDown={async () => commitEdit()}
                     >
                       <FontAwesomeIcon
                         icon={faCheck}

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -134,7 +134,7 @@ export const HardwareAddress = ({
                       id="commit-btn"
                       type="button"
                       className="edit"
-                      onPointerDown={async () => commitEdit()}
+                      onPointerDown={() => commitEdit()}
                     >
                       <FontAwesomeIcon
                         icon={faCheck}

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -26,7 +26,6 @@ import type { HardwareAddressProps } from './types';
 export const HardwareAddress = ({
   address,
   source,
-  index,
   isImported,
   orderData,
   accountName,
@@ -103,7 +102,6 @@ export const HardwareAddress = ({
         <div className="inner">
           <div className="identicon">
             <Identicon value={address} size={36} />
-            <div className="index-icon ">{index + 1}</div>
           </div>
           <div>
             <section className="row">

--- a/src/renderer/library/Hardware/HardwareAddress/types.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/types.ts
@@ -9,8 +9,6 @@ export type HardwareAddressProps = ComponentBase & {
   address: string;
   // The account's import source.
   source: AccountSource;
-  // the index of the address.
-  index: number;
   // Whether this address is imported in main window.
   isImported: boolean;
   // Index data for the current address.

--- a/src/renderer/library/Hardware/HardwareAddress/types.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/types.ts
@@ -18,7 +18,7 @@ export type HardwareAddressProps = ComponentBase & {
   // current name of the account.
   accountName: string;
   // handle rename
-  renameHandler: (address: string, newName: string) => void;
+  renameHandler: (address: string, newName: string) => Promise<void>;
   // handle remove UI.
   openRemoveHandler: () => void;
   // handle confirm import UI.

--- a/src/renderer/screens/Home/Manage/PermissionRow.tsx
+++ b/src/renderer/screens/Home/Manage/PermissionRow.tsx
@@ -76,10 +76,7 @@ export const PermissionRow = ({
               {/* Warning if nominating pending payouts */}
               {task.action ===
                 'subscribe:account:nominating:pendingPayouts' && (
-                <WarningIcon
-                  tooltip="Could Take Over 10 Seconds"
-                  iconColor="#b76438"
-                />
+                <WarningIcon tooltip="Slow Operation" iconColor="#b76438" />
               )}
             </h3>
           </div>

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -6,23 +6,15 @@ import { Identicon } from '@app/library/Identicon';
 import { ConfirmWrapper } from './Wrappers';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
-import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
+import { useAddHandler } from '@/renderer/contexts/import/AddHandler';
 import type { ConfirmProps } from './types';
 
-export const Confirm = ({
-  address,
-  name,
-  source,
-  pubKey,
-  device,
-}: ConfirmProps) => {
+export const Confirm = ({ address, name, source }: ConfirmProps) => {
   const { setStatus } = useOverlay();
-  const { handleImportAddress } = useImportHandler();
+  const { handleAddAddress } = useAddHandler();
 
   const handleClickConfirm = async () => {
-    source === 'ledger'
-      ? await handleImportAddress(address, source, name, pubKey, device)
-      : await handleImportAddress(address, source, name);
+    await handleAddAddress(address, source, name);
     setStatus(0);
   };
 

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -9,12 +9,20 @@ import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
 import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
 import type { ConfirmProps } from './types';
 
-export const Confirm = ({ address, name, source }: ConfirmProps) => {
+export const Confirm = ({
+  address,
+  name,
+  source,
+  pubKey,
+  device,
+}: ConfirmProps) => {
   const { setStatus } = useOverlay();
   const { handleImportAddress } = useImportHandler();
 
   const handleClickConfirm = async () => {
-    await handleImportAddress(address, source, name);
+    source === 'ledger'
+      ? await handleImportAddress(address, source, name, pubKey, device)
+      : await handleImportAddress(address, source, name);
     setStatus(0);
   };
 

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -13,8 +13,8 @@ export const Confirm = ({ address, name, source }: ConfirmProps) => {
   const { setStatus } = useOverlay();
   const { handleImportAddress } = useImportHandler();
 
-  const handleClickConfirm = () => {
-    handleImportAddress(address, source, name);
+  const handleClickConfirm = async () => {
+    await handleImportAddress(address, source, name);
     setStatus(0);
   };
 

--- a/src/renderer/screens/Import/Addresses/Delete.tsx
+++ b/src/renderer/screens/Import/Addresses/Delete.tsx
@@ -14,8 +14,8 @@ export const Delete = ({ address, source, setSection }: DeleteProps) => {
   const { handleDeleteAddress } = useDeleteHandler();
 
   // Click handler function.
-  const handleDeleteClick = () => {
-    const goBack = handleDeleteAddress(address, source);
+  const handleDeleteClick = async () => {
+    const goBack = await handleDeleteAddress(address, source);
     setStatus(0);
     goBack && setSection(0);
   };
@@ -31,7 +31,10 @@ export const Delete = ({ address, source, setSection }: DeleteProps) => {
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />
-        <ButtonMono text="Delete Account" onClick={() => handleDeleteClick()} />
+        <ButtonMono
+          text="Delete Account"
+          onClick={async () => await handleDeleteClick()}
+        />
       </div>
     </ConfirmWrapper>
   );

--- a/src/renderer/screens/Import/Addresses/Remove.tsx
+++ b/src/renderer/screens/Import/Addresses/Remove.tsx
@@ -13,8 +13,8 @@ export const Remove = ({ address, source }: RemoveProps) => {
   const { setStatus } = useOverlay();
   const { handleRemoveAddress } = useRemoveHandler();
 
-  const handleClickRemove = () => {
-    handleRemoveAddress(address, source);
+  const handleClickRemove = async () => {
+    await handleRemoveAddress(address, source);
     setStatus(0);
   };
 
@@ -29,7 +29,10 @@ export const Remove = ({ address, source }: RemoveProps) => {
       </p>
       <div className="footer">
         <ButtonMonoInvert text="Cancel" onClick={() => setStatus(0)} />
-        <ButtonMono text="Remove Account" onClick={() => handleClickRemove()} />
+        <ButtonMono
+          text="Remove Account"
+          onClick={async () => await handleClickRemove()}
+        />
       </div>
     </ConfirmWrapper>
   );

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { AccountSource } from '@/types/accounts';
-import type { AnyData, AnyFunction } from '@/types/misc';
+import type { AnyFunction } from '@/types/misc';
 
 export interface AddressProps {
   accountName: string;
@@ -21,8 +21,6 @@ export interface ConfirmProps {
   address: string;
   name: string;
   source: AccountSource;
-  pubKey?: string;
-  device?: AnyData;
 }
 
 export interface RemoveProps {

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -8,7 +8,6 @@ export interface AddressProps {
   accountName: string;
   source: AccountSource;
   address: string;
-  index: number;
   isImported: boolean;
   setSection: AnyFunction;
   orderData: {

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { AccountSource } from '@/types/accounts';
-import type { AnyFunction } from '@/types/misc';
+import type { AnyData, AnyFunction } from '@/types/misc';
 
 export interface AddressProps {
   accountName: string;
@@ -21,6 +21,8 @@ export interface ConfirmProps {
   address: string;
   name: string;
   source: AccountSource;
+  pubKey?: string;
+  device?: AnyData;
 }
 
 export interface RemoveProps {

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -4,8 +4,8 @@
 import { Confirm } from '../Addresses/Confirm';
 import { Delete } from '../Addresses/Delete';
 import {
-  renameLocalAccount,
   postRenameAccount,
+  renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { HardwareAddress } from '@app/library/Hardware/HardwareAddress';
 import { Remove } from '../Addresses/Remove';
@@ -21,8 +21,6 @@ export const Address = ({
   isImported,
   orderData,
   setSection,
-  device,
-  pubKey,
 }: LedgerAddressProps) => {
   const { openOverlayWith } = useOverlay();
 
@@ -30,9 +28,11 @@ export const Address = ({
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
-  const renameHandler = (who: string, newName: string) => {
+  const renameHandler = async (who: string, newName: string) => {
     setAccountNameState(newName);
-    renameLocalAccount(who, newName, 'ledger');
+
+    // Update name in store in main process.
+    await renameAccountInStore(who, 'ledger', newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);
@@ -53,13 +53,7 @@ export const Address = ({
       }
       openConfirmHandler={() =>
         openOverlayWith(
-          <Confirm
-            address={address}
-            name={accountNameState}
-            source="ledger"
-            pubKey={pubKey}
-            device={device}
-          />,
+          <Confirm address={address} name={accountNameState} source="ledger" />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -21,6 +21,8 @@ export const Address = ({
   isImported,
   orderData,
   setSection,
+  device,
+  pubKey,
 }: LedgerAddressProps) => {
   const { openOverlayWith } = useOverlay();
 
@@ -51,7 +53,13 @@ export const Address = ({
       }
       openConfirmHandler={() =>
         openOverlayWith(
-          <Confirm address={address} name={accountNameState} source="ledger" />,
+          <Confirm
+            address={address}
+            name={accountNameState}
+            source="ledger"
+            pubKey={pubKey}
+            device={device}
+          />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -43,7 +43,6 @@ export const Address = ({
       key={index}
       source={source}
       address={address}
-      index={index}
       accountName={accountNameState}
       renameHandler={renameHandler}
       isImported={isImported}

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -121,7 +121,7 @@ export const Manage = ({
                                 address={address}
                                 source={'ledger'}
                                 accountName={name}
-                                index={index}
+                                index={index || 0}
                                 isImported={isImported}
                                 orderData={{
                                   curIndex: j,

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -23,7 +23,6 @@ import {
   SortControlLabel,
 } from '@/renderer/utils/common';
 import type { ImportLedgerManageProps } from '../types';
-import type { LedgerLocalAddress } from '@/types/accounts';
 
 export const Manage = ({
   addresses,
@@ -32,7 +31,6 @@ export const Manage = ({
   toggleImport,
   cancelImport,
   setSection,
-  //section,
 }: ImportLedgerManageProps) => {
   // Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
@@ -107,15 +105,7 @@ export const Manage = ({
                       <div className="items-wrapper">
                         <div className="items round-primary-border">
                           {chainAddresses.map(
-                            (
-                              {
-                                address,
-                                index,
-                                isImported,
-                                name,
-                              }: LedgerLocalAddress,
-                              j
-                            ) => (
+                            ({ address, index, isImported, name }, j) => (
                               <Address
                                 key={`address_${name}`}
                                 address={address}

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -113,12 +113,16 @@ export const Manage = ({
                                 index,
                                 isImported,
                                 name,
+                                device,
+                                pubKey,
                               }: LedgerLocalAddress,
                               j
                             ) => (
                               <Address
                                 key={`address_${name}`}
                                 address={address}
+                                pubKey={pubKey}
+                                device={device}
                                 source={'ledger'}
                                 accountName={name}
                                 index={index || 0}

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -113,16 +113,12 @@ export const Manage = ({
                                 index,
                                 isImported,
                                 name,
-                                device,
-                                pubKey,
                               }: LedgerLocalAddress,
                               j
                             ) => (
                               <Address
                                 key={`address_${name}`}
                                 address={address}
-                                pubKey={pubKey}
-                                device={device}
                                 source={'ledger'}
                                 accountName={name}
                                 index={index || 0}

--- a/src/renderer/screens/Import/Ledger/index.tsx
+++ b/src/renderer/screens/Import/Ledger/index.tsx
@@ -5,7 +5,7 @@ import { setStateWithRef, ellipsisFn } from '@w3ux/utils';
 import { useEffect, useRef, useState } from 'react';
 import { useAccountStatuses } from '@/renderer/contexts/import/AccountStatuses';
 import { useAddresses } from '@/renderer/contexts/import/Addresses';
-import { Config as ConfigImport } from '@/config/processes/import';
+import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
 import { Manage } from './Manage';
 import { Splash } from './Splash';
 import { renderToast } from '@/renderer/utils/ImportUtils';
@@ -14,7 +14,6 @@ import type {
   LedgerResponse,
   LedgerTask,
 } from '@/types/ledger';
-import type { LedgerLocalAddress } from '@/types/accounts';
 import type { ImportLedgerProps } from '../types';
 import type { IpcRendererEvent } from 'electron';
 import type { AnyData } from '@/types/misc';
@@ -26,17 +25,16 @@ export const ImportLedger = ({
   setSection,
   curSource,
 }: ImportLedgerProps) => {
+  /// Status entry is added for a newly imported account.
+  const { insertAccountStatus } = useAccountStatuses();
+  const { ledgerAddresses: addresses, isAlreadyImported } = useAddresses();
+
+  /// Import handler.
+  const { handleImportAddress } = useImportHandler();
+
   /// Store whether import is in process
   const [isImporting, setIsImporting] = useState(false);
   const isImportingRef = useRef(isImporting);
-
-  /// Status entry is added for a newly imported account.
-  const { insertAccountStatus } = useAccountStatuses();
-  const {
-    ledgerAddresses: addresses,
-    setLedgerAddresses: setAddresses,
-    isAlreadyImported,
-  } = useAddresses();
 
   /// Used in effect for processing an import.
   const [processImport, setProcessImport] = useState(false);
@@ -56,7 +54,7 @@ export const ImportLedger = ({
 
   /// Gets the next non-imported address index.
   const getNextAddressIndex = () =>
-    !addresses.length ? 0 : addresses[addresses.length - 1].index + 1;
+    !addresses.length ? 0 : addresses[addresses.length - 1].index || 0 + 1;
 
   /// Handle an incoming new status code and persist to state.
   const handleNewStatusCode = (ack: string, statusCode: string) => {
@@ -144,47 +142,41 @@ export const ImportLedger = ({
     };
   }, [curSource]);
 
+  /// Effect to trigger a ledger account import process.
   useEffect(() => {
-    if (processImport && bodyRef.current) {
-      const { address, pubKey, device, options } = bodyRef.current;
+    const handleImportProcess = async () => {
+      if (processImport && bodyRef.current) {
+        const { address, pubKey, device /*, options*/ } = bodyRef.current;
 
-      // Check if address is already imported.
-      if (isAlreadyImported(address)) {
-        renderToast(
-          'Address is already imported.',
-          'error',
-          `toast-${address}`
-        );
-        setSection(0);
-      } else {
-        const addressFormatted: LedgerLocalAddress = {
-          address,
-          device: { ...device },
-          index: options.accountIndex,
-          isImported: false,
-          name: ellipsisFn(address),
-          pubKey,
-        };
+        // Check if address is already imported.
+        if (isAlreadyImported(address)) {
+          renderToast(
+            'Address is already imported.',
+            'error',
+            `toast-${address}`
+          );
+          setSection(0);
+        } else {
+          await handleImportAddress(
+            address,
+            'ledger',
+            ellipsisFn(address),
+            pubKey,
+            device
+          );
 
-        const newAddresses = addresses
-          .filter(
-            (a: LedgerLocalAddress) => a.address !== addressFormatted.address
-          )
-          .concat(addressFormatted);
+          // Insert account status entry.
+          insertAccountStatus(address, 'ledger');
+        }
 
-        const storageKey = ConfigImport.getStorageKey('ledger');
-        localStorage.setItem(storageKey, JSON.stringify(newAddresses));
-        setAddresses(newAddresses);
-
-        // Insert account status entry.
-        insertAccountStatus(address, 'ledger');
+        setStateWithRef(false, setIsImporting, isImportingRef);
+        setStateWithRef([], setStatusCodes, statusCodesRef);
+        setProcessImport(false);
+        bodyRef.current = null;
       }
+    };
 
-      setStateWithRef(false, setIsImporting, isImportingRef);
-      setStateWithRef([], setStatusCodes, statusCodesRef);
-      setProcessImport(false);
-      bodyRef.current = null;
-    }
+    handleImportProcess();
   }, [processImport]);
 
   return !addresses.length ? (

--- a/src/renderer/screens/Import/Ledger/index.tsx
+++ b/src/renderer/screens/Import/Ledger/index.tsx
@@ -20,11 +20,7 @@ import type { AnyData } from '@/types/misc';
 
 const TOTAL_ALLOWED_STATUS_CODES = 50;
 
-export const ImportLedger = ({
-  section,
-  setSection,
-  curSource,
-}: ImportLedgerProps) => {
+export const ImportLedger = ({ setSection, curSource }: ImportLedgerProps) => {
   /// Status entry is added for a newly imported account.
   const { insertAccountStatus } = useAccountStatuses();
   const { ledgerAddresses: addresses, isAlreadyImported } = useAddresses();
@@ -188,7 +184,6 @@ export const ImportLedger = ({
       toggleImport={toggleImport}
       statusCodes={statusCodes}
       cancelImport={cancelImport}
-      section={section}
       setSection={setSection}
     />
   );

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -16,7 +16,6 @@ import type { AddressProps } from '../Addresses/types';
 export const Address = ({
   address,
   source,
-  index,
   accountName,
   isImported,
   setSection,
@@ -40,12 +39,11 @@ export const Address = ({
 
   return (
     <HardwareAddress
-      key={index}
+      key={address}
       address={address}
       source={source}
       isImported={isImported}
       orderData={orderData}
-      index={index}
       accountName={accountNameState}
       renameHandler={renameHandler}
       openRemoveHandler={() =>

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -6,7 +6,7 @@ import { Delete } from '../Addresses/Delete';
 import { HardwareAddress } from '@/renderer/library/Hardware/HardwareAddress';
 import {
   postRenameAccount,
-  renameLocalAccount,
+  renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { Remove } from '../Addresses/Remove';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
@@ -28,9 +28,11 @@ export const Address = ({
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
-  const renameHandler = (who: string, newName: string) => {
+  const renameHandler = async (who: string, newName: string) => {
     setAccountNameState(newName);
-    renameLocalAccount(who, newName, 'read-only');
+
+    // Update name in store in main process.
+    await renameAccountInStore(who, 'read-only', newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -85,7 +85,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
 
   /// Gets the next non-imported address index.
   const getNextAddressIndex = () =>
-    !addresses.length ? 0 : addresses[addresses.length - 1].index + 1;
+    !addresses.length ? 0 : addresses[addresses.length - 1].index || 0 + 1;
 
   /// Cancel button clicked for address field.
   const onCancel = () => {
@@ -100,7 +100,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
   };
 
   /// Handle import button click.
-  const onImport = () => {
+  const onImport = async () => {
     const trimmed = editName.trim();
 
     if (isAlreadyImported(trimmed)) {
@@ -136,7 +136,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
     insertAccountStatus(trimmed, 'read-only');
 
     // Set processing flag to true if online and import via main renderer.
-    handleImportAddress(trimmed, 'read-only', accountName);
+    await handleImportAddress(trimmed, 'read-only', accountName);
   };
 
   return (
@@ -189,7 +189,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                   <div className="flex-inner-row">
                     <button
                       className="btn-mono lg"
-                      onPointerDown={() => onImport()}
+                      onPointerDown={async () => await onImport()}
                     >
                       Add
                     </button>
@@ -242,7 +242,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                                     accountName={name}
                                     source={'read-only'}
                                     address={address}
-                                    index={index}
+                                    index={index || 0}
                                     isImported={isImported || false}
                                     orderData={{
                                       curIndex: j,

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -205,12 +205,7 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                             <>
                               {chainAddresses.map(
                                 (
-                                  {
-                                    address,
-                                    index,
-                                    isImported,
-                                    name,
-                                  }: LocalAddress,
+                                  { address, isImported, name }: LocalAddress,
                                   j
                                 ) => (
                                   <Address
@@ -218,7 +213,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                                     accountName={name}
                                     source={'read-only'}
                                     address={address}
-                                    index={index || 0}
                                     isImported={isImported || false}
                                     orderData={{
                                       curIndex: j,

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -10,7 +10,6 @@ import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCare
 import { Address } from './Address';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import { checkAddress } from '@polkadot/util-crypto';
-import { Config as ConfigImport } from '@/config/processes/import';
 import { DragClose } from '@/renderer/library/DragClose';
 import { ellipsisFn, unescape } from '@w3ux/utils';
 import { faCaretLeft } from '@fortawesome/free-solid-svg-icons';
@@ -42,11 +41,7 @@ import type { LocalAddress } from '@/types/accounts';
 import type { ManageReadOnlyProps } from '../types';
 
 export const Manage = ({ setSection }: ManageReadOnlyProps) => {
-  const {
-    readOnlyAddresses: addresses,
-    setReadOnlyAddresses: setAddresses,
-    isAlreadyImported,
-  } = useAddresses();
+  const { readOnlyAddresses: addresses, isAlreadyImported } = useAddresses();
   const { insertAccountStatus } = useAccountStatuses();
   const { handleImportAddress } = useImportHandler();
 
@@ -83,10 +78,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
     return false;
   };
 
-  /// Gets the next non-imported address index.
-  const getNextAddressIndex = () =>
-    !addresses.length ? 0 : addresses[addresses.length - 1].index || 0 + 1;
-
   /// Cancel button clicked for address field.
   const onCancel = () => {
     setEditName('');
@@ -113,21 +104,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
 
     // The default account name.
     const accountName = ellipsisFn(trimmed);
-
-    // Update local storage.
-    const newAddresses = addresses
-      .filter((a: LocalAddress) => a.address !== trimmed)
-      .concat({
-        index: getNextAddressIndex(),
-        address: trimmed,
-        isImported: false,
-        name: accountName,
-        source: 'read-only',
-      });
-
-    const storageKey = ConfigImport.getStorageKey('read-only');
-    localStorage.setItem(storageKey, JSON.stringify(newAddresses));
-    setAddresses(newAddresses);
 
     // Reset read-only address input state.
     setEditName('');

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -5,7 +5,7 @@ import { Confirm } from '../Addresses/Confirm';
 import { Delete } from '../Addresses/Delete';
 import {
   postRenameAccount,
-  renameLocalAccount,
+  renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { HardwareAddress } from '@app/library/Hardware/HardwareAddress';
 import { Remove } from '../Addresses/Remove';
@@ -28,9 +28,11 @@ export const Address = ({
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
-  const renameHandler = (who: string, newName: string) => {
+  const renameHandler = async (who: string, newName: string) => {
     setAccountNameState(newName);
-    renameLocalAccount(who, newName, 'vault');
+
+    // Update name in store in main process.
+    await renameAccountInStore(address, 'vault', newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -16,7 +16,6 @@ import type { AddressProps } from '../Addresses/types';
 export const Address = ({
   address,
   source,
-  index,
   accountName,
   isImported,
   setSection,
@@ -40,12 +39,11 @@ export const Address = ({
 
   return (
     <HardwareAddress
-      key={index}
+      key={address}
       address={address}
       source={source}
       isImported={isImported}
       orderData={orderData}
-      index={index}
       accountName={accountNameState}
       renameHandler={renameHandler}
       openRemoveHandler={() =>

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -26,11 +26,7 @@ import {
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import type { ManageVaultProps } from '../types';
 
-export const Manage = ({
-  setSection,
-  addresses,
-  setAddresses,
-}: ManageVaultProps) => {
+export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
   const { openOverlayWith } = useOverlay();
 
   // Active accordion indices for account subscription tasks categories.
@@ -76,7 +72,7 @@ export const Manage = ({
             onClick={() => {
               openOverlayWith(
                 <ErrorBoundary fallback={<h2>Could not load QR Scanner</h2>}>
-                  <Reader addresses={addresses} setAddresses={setAddresses} />
+                  <Reader addresses={addresses} />
                 </ErrorBoundary>,
                 'small',
                 true
@@ -115,7 +111,7 @@ export const Manage = ({
                                   accountName={name}
                                   source={'vault'}
                                   address={address}
-                                  index={index}
+                                  index={index || 0}
                                   isImported={isImported || false}
                                   setSection={setSection}
                                   orderData={{

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -72,7 +72,7 @@ export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
             onClick={() => {
               openOverlayWith(
                 <ErrorBoundary fallback={<h2>Could not load QR Scanner</h2>}>
-                  <Reader addresses={addresses} />
+                  <Reader />
                 </ErrorBoundary>,
                 'small',
                 true
@@ -105,13 +105,12 @@ export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
                         <div className="items-wrapper">
                           <div className="items round-primary-border">
                             {chainAddresses.map(
-                              ({ address, index, isImported, name }, j) => (
+                              ({ address, isImported, name }, j) => (
                                 <Address
                                   key={`address_${name}`}
                                   accountName={name}
                                   source={'vault'}
                                   address={address}
-                                  index={index || 0}
                                   isImported={isImported || false}
                                   setSection={setSection}
                                   orderData={{

--- a/src/renderer/screens/Import/Vault/Reader.tsx
+++ b/src/renderer/screens/Import/Vault/Reader.tsx
@@ -14,9 +14,8 @@ import { ScanWrapper } from '@/renderer/library/QRCode/Wrappers';
 import { useAddresses } from '@/renderer/contexts/import/Addresses';
 import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
 import type { Html5Qrcode } from 'html5-qrcode';
-import type { ReaderVaultProps } from '../types';
 
-export const Reader = ({ addresses }: ReaderVaultProps) => {
+export const Reader = () => {
   const { setStatus: setOverlayStatus } = useOverlay();
   const { insertAccountStatus } = useAccountStatuses();
   const { handleImportAddress } = useImportHandler();
@@ -78,11 +77,6 @@ export const Reader = ({ addresses }: ReaderVaultProps) => {
     await handleImportAddress(address, 'vault', accountName);
     setImported(true);
   };
-
-  // Gets the next non-imported address index.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const getNextAddressIndex = () =>
-    !addresses.length ? 0 : addresses[addresses.length - 1].index || 0 + 1;
 
   // Close the overlay when import is successful, ignoring initial render state.
   useEffect(() => {

--- a/src/renderer/screens/Import/Vault/Splash.tsx
+++ b/src/renderer/screens/Import/Vault/Splash.tsx
@@ -1,19 +1,19 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { faAngleLeft, faQrcode } from '@fortawesome/free-solid-svg-icons';
-import type { AnyJson } from '@/types/misc';
 import { BodyInterfaceWrapper } from '@app/Wrappers';
-import { useOverlay } from '@/renderer/contexts/common/Overlay';
-import { Header } from '@app/library/Header';
-import { ErrorBoundary } from 'react-error-boundary';
-import PolkadotVaultSVG from '@w3ux/extension-assets/PolkadotVault.svg?react';
-import { SplashWrapper } from '../Wrappers';
-import { Reader } from './Reader';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { ButtonPrimary } from '@/renderer/kits/Buttons/ButtonPrimary';
+import { ErrorBoundary } from 'react-error-boundary';
+import { faAngleLeft, faQrcode } from '@fortawesome/free-solid-svg-icons';
+import { Header } from '@app/library/Header';
+import { useOverlay } from '@/renderer/contexts/common/Overlay';
+import PolkadotVaultSVG from '@w3ux/extension-assets/PolkadotVault.svg?react';
+import { Reader } from './Reader';
+import { SplashWrapper } from '../Wrappers';
+import type { VaultSplashProps } from '../types';
 
-export const Splash = ({ setSection, addresses }: AnyJson) => {
+export const Splash = ({ setSection }: VaultSplashProps) => {
   const { openOverlayWith } = useOverlay();
 
   return (
@@ -49,7 +49,7 @@ export const Splash = ({ setSection, addresses }: AnyJson) => {
                     <ErrorBoundary
                       fallback={<h2>Could not load QR Scanner</h2>}
                     >
-                      <Reader addresses={addresses} />
+                      <Reader />
                     </ErrorBoundary>,
                     'small'
                   );

--- a/src/renderer/screens/Import/Vault/Splash.tsx
+++ b/src/renderer/screens/Import/Vault/Splash.tsx
@@ -13,7 +13,7 @@ import { Reader } from './Reader';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { ButtonPrimary } from '@/renderer/kits/Buttons/ButtonPrimary';
 
-export const Splash = ({ setSection, addresses, setAddresses }: AnyJson) => {
+export const Splash = ({ setSection, addresses }: AnyJson) => {
   const { openOverlayWith } = useOverlay();
 
   return (
@@ -49,10 +49,7 @@ export const Splash = ({ setSection, addresses, setAddresses }: AnyJson) => {
                     <ErrorBoundary
                       fallback={<h2>Could not load QR Scanner</h2>}
                     >
-                      <Reader
-                        addresses={addresses}
-                        setAddresses={setAddresses}
-                      />
+                      <Reader addresses={addresses} />
                     </ErrorBoundary>,
                     'small'
                   );

--- a/src/renderer/screens/Import/Vault/index.tsx
+++ b/src/renderer/screens/Import/Vault/index.tsx
@@ -4,25 +4,18 @@
 import { Manage } from './Manage';
 import { Splash } from './Splash';
 import { useAddresses } from '@/renderer/contexts/import/Addresses';
-import type { AnyFunction } from '@/types/misc';
+import type { ImportVaultProps } from '../types';
 
-export const ImportVault = ({
-  section,
-  setSection,
-}: {
-  section: number;
-  setSection: AnyFunction;
-}) => {
-  const { vaultAddresses, setVaultAddresses } = useAddresses();
+export const ImportVault = ({ section, setSection }: ImportVaultProps) => {
+  const { vaultAddresses } = useAddresses();
 
   return !vaultAddresses.length ? (
-    <Splash addresses={vaultAddresses} setSection={setSection} />
+    <Splash setSection={setSection} />
   ) : (
     <Manage
       section={section}
       setSection={setSection}
       addresses={vaultAddresses}
-      setAddresses={setVaultAddresses}
     />
   );
 };

--- a/src/renderer/screens/Import/Vault/index.tsx
+++ b/src/renderer/screens/Import/Vault/index.tsx
@@ -16,11 +16,7 @@ export const ImportVault = ({
   const { vaultAddresses, setVaultAddresses } = useAddresses();
 
   return !vaultAddresses.length ? (
-    <Splash
-      addresses={vaultAddresses}
-      setAddresses={setVaultAddresses}
-      setSection={setSection}
-    />
+    <Splash addresses={vaultAddresses} setSection={setSection} />
   ) : (
     <Manage
       section={section}

--- a/src/renderer/screens/Import/index.tsx
+++ b/src/renderer/screens/Import/index.tsx
@@ -66,11 +66,7 @@ export const Import: React.FC = () => {
           }}
         >
           <div className={getShowClass('ledger')}>
-            <ImportLedger
-              section={section}
-              setSection={setSection}
-              curSource={source}
-            />
+            <ImportLedger setSection={setSection} curSource={source} />
           </div>
           <div className={getShowClass('vault')}>
             <ImportVault section={section} setSection={setSection} />

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyFunction, AnyJson } from '@/types/misc';
+import type { AnyData, AnyFunction, AnyJson } from '@/types/misc';
 import type { Html5Qrcode } from 'html5-qrcode';
 import type {
   AccountSource,
@@ -65,6 +65,8 @@ export interface LedgerAddressProps {
     lastIndex: number;
   };
   setSection: AnyFunction;
+  pubKey: string;
+  device: AnyData;
 }
 
 export interface ManageReadOnlyProps {

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -29,7 +29,6 @@ export interface ManageVaultProps {
 
 export interface ReaderVaultProps {
   addresses: LocalAddress[];
-  setAddresses: AnyFunction;
 }
 
 export interface Html5QrScannerProps {

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyData, AnyFunction, AnyJson } from '@/types/misc';
+import type { AnyFunction, AnyJson } from '@/types/misc';
 import type { Html5Qrcode } from 'html5-qrcode';
 import type {
   AccountSource,
@@ -65,8 +65,6 @@ export interface LedgerAddressProps {
     lastIndex: number;
   };
   setSection: AnyFunction;
-  pubKey: string;
-  device: AnyData;
 }
 
 export interface ManageReadOnlyProps {

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -20,14 +20,18 @@ export interface SplashProps {
   statusCodes?: AnyJson;
 }
 
-export interface ManageVaultProps {
-  setSection: AnyFunction;
+export interface ImportVaultProps {
   section: number;
-  addresses: LocalAddress[];
-  setAddresses: AnyFunction;
+  setSection: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export interface ReaderVaultProps {
+export interface VaultSplashProps {
+  setSection: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export interface ManageVaultProps {
+  setSection: React.Dispatch<React.SetStateAction<number>>;
+  section: number;
   addresses: LocalAddress[];
 }
 
@@ -39,7 +43,6 @@ export interface Html5QrScannerProps {
 }
 
 export interface ImportLedgerProps {
-  section: number;
   setSection: React.Dispatch<React.SetStateAction<number>>;
   curSource: AccountSource | null;
 }
@@ -48,7 +51,6 @@ export interface ImportLedgerManageProps {
   addresses: LedgerLocalAddress[];
   isImporting: boolean;
   statusCodes: LedgerResponse[];
-  section: number;
   toggleImport: AnyFunction;
   cancelImport: AnyFunction;
   setSection: AnyFunction;

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Config as ConfigImport } from '@/config/processes/import';
-import { ellipsisFn } from '@w3ux/utils';
 import { Flip, toast } from 'react-toastify';
 import type {
   AccountSource,
@@ -127,39 +126,6 @@ export const validateAccountName = (accountName: string): boolean => {
   }
 
   return true;
-};
-
-/**
- * @name getLocalAccountName
- * @summary Returns an account's name by fetching it from local storage or returning the truncated address.
- * @deprecated This function is not currently used.
- */
-export const getLocalAccountName = (
-  address: string,
-  source: AccountSource
-): string => {
-  const defaultName = ellipsisFn(address);
-  const stored = localStorage.getItem(ConfigImport.getStorageKey(source));
-
-  // Return truncated address if no storage found.
-  if (!stored) {
-    return defaultName;
-  }
-
-  // Parse fetched addresses and see if this address has a custom name.
-  if (source === 'ledger') {
-    const parsed: LedgerLocalAddress[] = JSON.parse(stored);
-    const fetched = parsed.find(
-      (a: LedgerLocalAddress) => a.address === address
-    );
-    return fetched ? fetched.name : defaultName;
-  } else if (source === 'vault') {
-    const parsed: LocalAddress[] = JSON.parse(stored);
-    const fetched = parsed.find((a: LocalAddress) => a.address === address);
-    return fetched ? fetched.name : defaultName;
-  } else {
-    return 'System Account';
-  }
 };
 
 /**

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -108,7 +108,7 @@ export interface FlattenedAccountData {
 export interface LocalAddress {
   address: string;
   isImported: boolean;
-  index: number;
+  index?: number;
   name: string;
   source: AccountSource;
 }
@@ -120,7 +120,7 @@ export interface LocalAddress {
 export interface LedgerLocalAddress {
   address: string;
   device: { id: string; productName: string };
-  index: number;
+  index?: number;
   isImported: boolean;
   name: string;
   pubKey: string;

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -108,7 +108,6 @@ export interface FlattenedAccountData {
 export interface LocalAddress {
   address: string;
   isImported: boolean;
-  index?: number;
   name: string;
   source: AccountSource;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -15,6 +15,6 @@ export interface PortPair {
 }
 
 export interface IpcTask {
-  action: 'raw-account:persist' | 'raw-account:delete';
+  action: 'raw-account:persist' | 'raw-account:delete' | 'raw-account:remove';
   data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -1,6 +1,8 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { AnyData } from './misc';
+
 export type PortPairID =
   | 'main-import'
   | 'main-action'
@@ -10,4 +12,9 @@ export type PortPairID =
 export interface PortPair {
   port1: Electron.MessagePortMain;
   port2: Electron.MessagePortMain;
+}
+
+export interface IpcTask {
+  action: 'raw-account:persist';
+  data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -18,7 +18,9 @@ export interface IpcTask {
   action:
     | 'raw-account:persist'
     | 'raw-account:delete'
+    | 'raw-account:add'
     | 'raw-account:remove'
-    | 'raw-account:get';
+    | 'raw-account:get'
+    | 'raw-account:rename';
   data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -15,6 +15,10 @@ export interface PortPair {
 }
 
 export interface IpcTask {
-  action: 'raw-account:persist' | 'raw-account:delete' | 'raw-account:remove';
+  action:
+    | 'raw-account:persist'
+    | 'raw-account:delete'
+    | 'raw-account:remove'
+    | 'raw-account:get';
   data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -15,6 +15,6 @@ export interface PortPair {
 }
 
 export interface IpcTask {
-  action: 'raw-account:persist';
+  action: 'raw-account:persist' | 'raw-account:delete';
   data: AnyData;
 }

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -1,12 +1,13 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { IpcRendererEvent } from 'electron';
-import type { ChainID } from './chains';
-import type { AnyJson } from './misc';
-import type { LedgerTask } from './ledger';
 import type { AccountSource, FlattenedAccountData } from './accounts';
+import type { AnyJson } from './misc';
+import type { ChainID } from './chains';
 import type { DismissEvent, EventCallback, NotificationData } from './reporter';
+import type { LedgerTask } from './ledger';
+import type { IpcTask } from './communication';
+import type { IpcRendererEvent } from 'electron';
 import type { SubscriptionTask } from './subscriptions';
 import type {
   PersistedSettings,
@@ -15,6 +16,7 @@ import type {
 import type { WorkspaceItem } from './developerConsole/workspaces';
 
 export interface PreloadAPI {
+  rawAccountTask: (task: IpcTask) => Promise<void>;
   getOsPlatform: () => Promise<string>;
 
   fetchPersistedWorkspaces: () => Promise<WorkspaceItem[]>;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -16,7 +16,8 @@ import type {
 import type { WorkspaceItem } from './developerConsole/workspaces';
 
 export interface PreloadAPI {
-  rawAccountTask: (task: IpcTask) => Promise<void>;
+  rawAccountTask: (task: IpcTask) => Promise<void | string>;
+
   getOsPlatform: () => Promise<string>;
 
   fetchPersistedWorkspaces: () => Promise<WorkspaceItem[]>;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -141,9 +141,7 @@ type ApiOpenBrowserWindow = (url: string) => void;
 /**
  * New types
  */
-type ApiExportAppData = (
-  serialized: string
-) => Promise<{ result: boolean; msg: string }>;
+type ApiExportAppData = () => Promise<{ result: boolean; msg: string }>;
 
 type ApiImportAppData = () => Promise<{
   result: boolean;


### PR DESCRIPTION
# Summary

Store import window address data in the electron store instead of local storage.

## Merged PRs

- [chore(accounts): rename + update in store](https://github.com/polkadot-live/polkadot-live-app/pull/635)
  Update store when renaming accounts and adding accounts to main window, and remove old local storage code.

- [chore(accounts): remove address index property](https://github.com/polkadot-live/polkadot-live-app/pull/636)
  Remove usage of `index` property on `LocalAddress` interface + import window bug fixes and cleanup.

- [chore(accounts): addresses controller](https://github.com/polkadot-live/polkadot-live-app/pull/637)
  Refactor back-end address handling logic into an `AddressesController` static class.

- [chore(accounts): backup iteration](https://github.com/polkadot-live/polkadot-live-app/pull/638)
Remove local storage code and integrate stored addresses in the export and import codebase.