### PR TITLE
chore(accounts): rename + update in store

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -333,6 +333,37 @@ app.whenReady().then(async () => {
           ? ((store as Record<string, AnyData>).get(key) as string)
           : '[]';
       }
+      case 'raw-account:rename': {
+        const { source, address, newName } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        if (source === 'ledger') {
+          // Rename ledger address data in store.
+          const stored: LedgerLocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            stored.map((a) =>
+              a.address === address ? { ...a, name: newName } : a
+            )
+          );
+        } else {
+          // Rename vault and read-only address data in store.
+          const stored: LocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            stored.map((a) =>
+              a.address === address ? { ...a, name: newName } : a
+            )
+          );
+        }
+        break;
+      }
     }
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,6 +287,43 @@ app.whenReady().then(async () => {
             JSON.stringify(stored.filter((a) => a.address !== address))
           );
         }
+
+        break;
+      }
+      case 'raw-account:add': {
+        const { source, address } = task.data;
+        const key = ConfigMain.getStorageKey(source);
+
+        // Set isImported flag to true.
+        if (source === 'ledger') {
+          const stored: LedgerLocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, isImported: true } : a
+              )
+            )
+          );
+        } else {
+          // Add stored vault or read-only accounts.
+          const stored: LocalAddress[] = store.has(key)
+            ? JSON.parse((store as Record<string, AnyData>).get(key) as string)
+            : [];
+
+          (store as Record<string, AnyData>).set(
+            key,
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, isImported: true } : a
+              )
+            )
+          );
+        }
+
         break;
       }
       case 'raw-account:remove': {
@@ -366,6 +403,7 @@ app.whenReady().then(async () => {
             )
           );
         }
+
         break;
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -345,8 +345,10 @@ app.whenReady().then(async () => {
 
           (store as Record<string, AnyData>).set(
             key,
-            stored.map((a) =>
-              a.address === address ? { ...a, name: newName } : a
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, name: newName } : a
+              )
             )
           );
         } else {
@@ -357,8 +359,10 @@ app.whenReady().then(async () => {
 
           (store as Record<string, AnyData>).set(
             key,
-            stored.map((a) =>
-              a.address === address ? { ...a, name: newName } : a
+            JSON.stringify(
+              stored.map((a) =>
+                a.address === address ? { ...a, name: newName } : a
+              )
             )
           );
         }

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -22,6 +22,7 @@ import { IntervalTasksManagerProvider } from './contexts/main/IntervalTasksManag
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
 import { AddressesProvider as ImportAddressesProvider } from '@app/contexts/import/Addresses';
 import { ImportHandlerProvider } from './contexts/import/ImportHandler';
+import { AddHandlerProvider } from './contexts/import/AddHandler';
 import { RemoveHandlerProvider } from './contexts/import/RemoveHandler';
 import { DeleteHandlerProvider } from './contexts/import/DeleteHandler';
 
@@ -75,6 +76,7 @@ const getProvidersForWindow = () => {
         ImportAddressesProvider,
         ImportAccountStatusesProvider,
         ImportHandlerProvider, // Requires useAccountStatuses + useAddresses
+        AddHandlerProvider, // Requires useAccountStatuses + useAddresses
         RemoveHandlerProvider, // Requires useAddresses
         DeleteHandlerProvider // Requires useAccountStatuses + useAddresses
       )(Theme);

--- a/src/renderer/contexts/import/AccountStatuses/index.tsx
+++ b/src/renderer/contexts/import/AccountStatuses/index.tsx
@@ -1,14 +1,10 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { createContext, useContext, useState } from 'react';
-import { Config as ConfigImport } from '@/config/processes/import';
 import * as defaults from './defaults';
-import type {
-  AccountSource,
-  LedgerLocalAddress,
-  LocalAddress,
-} from '@/types/accounts';
+import { createContext, useContext, useState } from 'react';
+import { useAddresses } from '../Addresses';
+import type { AccountSource } from '@/types/accounts';
 import type { AccountStatusesContextInterface } from './types';
 
 export const AccountStatusesContext =
@@ -32,33 +28,34 @@ export const AccountStatusesProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  /// Utility to fetch account statuses based on account data in local storage.
+  const { ledgerAddresses, readOnlyAddresses, vaultAddresses } = useAddresses();
+
+  /// Utility to initialize account statuses to false.
   const fetchAccountStatuses = (
     source: AccountSource
   ): Map<string, boolean> => {
     const map = new Map<string, boolean>();
-    const key: string = ConfigImport.getStorageKey(source);
-    const fetched: string | null = localStorage.getItem(key);
-
     switch (source) {
-      case 'read-only':
-      case 'vault': {
-        const parsed: LocalAddress[] = fetched ? JSON.parse(fetched) : [];
-        for (const { address } of parsed) {
+      case 'ledger': {
+        for (const { address } of ledgerAddresses) {
           map.set(address, false);
         }
         return map;
       }
-      case 'ledger': {
-        const parsed: LedgerLocalAddress[] =
-          fetched !== null ? JSON.parse(fetched) : [];
-        for (const { address } of parsed) {
+      case 'read-only': {
+        for (const { address } of readOnlyAddresses) {
+          map.set(address, false);
+        }
+        return map;
+      }
+      case 'vault': {
+        for (const { address } of vaultAddresses) {
           map.set(address, false);
         }
         return map;
       }
       default: {
-        return map;
+        throw new Error('unreachable');
       }
     }
   };

--- a/src/renderer/contexts/import/AddHandler/defaults.ts
+++ b/src/renderer/contexts/import/AddHandler/defaults.ts
@@ -4,6 +4,6 @@
 
 import type { AddHandlerContextInterface } from './types';
 
-export const defaultRemoveHandlerContext: AddHandlerContextInterface = {
+export const defaultAddHandlerContext: AddHandlerContextInterface = {
   handleAddAddress: () => new Promise(() => {}),
 };

--- a/src/renderer/contexts/import/AddHandler/defaults.ts
+++ b/src/renderer/contexts/import/AddHandler/defaults.ts
@@ -1,0 +1,9 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { AddHandlerContextInterface } from './types';
+
+export const defaultRemoveHandlerContext: AddHandlerContextInterface = {
+  handleAddAddress: () => new Promise(() => {}),
+};

--- a/src/renderer/contexts/import/AddHandler/index.tsx
+++ b/src/renderer/contexts/import/AddHandler/index.tsx
@@ -16,7 +16,7 @@ import type {
 } from '@/types/accounts';
 
 export const AddHandlerContext = createContext<AddHandlerContextInterface>(
-  defaults.defaultRemoveHandlerContext
+  defaults.defaultAddHandlerContext
 );
 
 export const useAddHandler = () => useContext(AddHandlerContext);
@@ -30,7 +30,7 @@ export const AddHandlerProvider = ({
   const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
     useAddresses();
 
-  /// Exposed function to remove an address.
+  /// Exposed function to add an address.
   const handleAddAddress = async (
     address: string,
     source: AccountSource,
@@ -50,7 +50,7 @@ export const AddHandlerProvider = ({
     // Update address data in store in main process.
     await updateAddressInStore(source, address);
 
-    // Process removed address in main renderer.
+    // Process added address in main renderer.
     postAddressToMainWindow(address, source, accountName);
   };
 

--- a/src/renderer/contexts/import/AddHandler/index.tsx
+++ b/src/renderer/contexts/import/AddHandler/index.tsx
@@ -1,0 +1,117 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { Config as ConfigImport } from '@/config/processes/import';
+import { createContext, useContext } from 'react';
+import { useAccountStatuses } from '../AccountStatuses';
+import { getAddressChainId } from '@/renderer/Utils';
+import { useAddresses } from '../Addresses';
+import type { AddHandlerContextInterface } from './types';
+import type { IpcTask } from '@/types/communication';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
+
+export const AddHandlerContext = createContext<AddHandlerContextInterface>(
+  defaults.defaultRemoveHandlerContext
+);
+
+export const useAddHandler = () => useContext(AddHandlerContext);
+
+export const AddHandlerProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { setStatusForAccount } = useAccountStatuses();
+  const { setReadOnlyAddresses, setVaultAddresses, setLedgerAddresses } =
+    useAddresses();
+
+  /// Exposed function to remove an address.
+  const handleAddAddress = async (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    // Set processing flag for account.
+    setStatusForAccount(address, source, true);
+
+    if (source === 'vault') {
+      handleAddVaultAddress(address);
+    } else if (source === 'ledger') {
+      handleAddLedgerAddress(address);
+    } else if (source === 'read-only') {
+      handleAddReadOnlyAddress(address);
+    }
+
+    // Update address data in store in main process.
+    await updateAddressInStore(source, address);
+
+    // Process removed address in main renderer.
+    postAddressToMainWindow(address, source, accountName);
+  };
+
+  /// Update import window read-only addresses state.
+  const handleAddReadOnlyAddress = (address: string) => {
+    setReadOnlyAddresses((prev: LocalAddress[]) =>
+      prev.map((a) => (a.address === address ? { ...a, isImported: true } : a))
+    );
+  };
+
+  /// Update import window vault addresses state.
+  const handleAddVaultAddress = (address: string) => {
+    setVaultAddresses((prev: LocalAddress[]) =>
+      prev.map((a) => (a.address === address ? { ...a, isImported: true } : a))
+    );
+  };
+
+  /// Update import window ledger addresses state.
+  const handleAddLedgerAddress = (address: string) => {
+    setLedgerAddresses((prev: LedgerLocalAddress[]) =>
+      prev.map((a) => (a.address === address ? { ...a, isImported: true } : a))
+    );
+  };
+
+  /// Update address in store.
+  const updateAddressInStore = async (
+    source: AccountSource,
+    address: string
+  ) => {
+    const ipcTask: IpcTask = {
+      action: 'raw-account:add',
+      data: { source, address },
+    };
+
+    await window.myAPI.rawAccountTask(ipcTask);
+  };
+
+  /// Send address data to main renderer to process.
+  const postAddressToMainWindow = (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:address:import',
+      data: {
+        address,
+        chainId: getAddressChainId(address),
+        name: accountName,
+        source,
+      },
+    });
+  };
+
+  return (
+    <AddHandlerContext.Provider
+      value={{
+        handleAddAddress,
+      }}
+    >
+      {children}
+    </AddHandlerContext.Provider>
+  );
+};

--- a/src/renderer/contexts/import/AddHandler/types.ts
+++ b/src/renderer/contexts/import/AddHandler/types.ts
@@ -1,0 +1,12 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AccountSource } from '@/types/accounts';
+
+export interface AddHandlerContextInterface {
+  handleAddAddress: (
+    address: string,
+    source: AccountSource,
+    accountName: string
+  ) => Promise<void>;
+}

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -52,7 +52,7 @@ export const HardwareAddress = ({
   };
 
   // Validate input and rename account.
-  const commitEdit = () => {
+  const commitEdit = async () => {
     const trimmed = editName.trim();
 
     // Return if account name hasn't changed.
@@ -73,7 +73,7 @@ export const HardwareAddress = ({
     renderToast('Account name updated.', 'success', `toast-${trimmed}`);
 
     // Otherwise rename account.
-    renameHandler(address, trimmed);
+    await renameHandler(address, trimmed);
     setEditName(trimmed);
     setEditing(false);
   };
@@ -118,9 +118,9 @@ export const HardwareAddress = ({
                   value={editing ? editName : accountName}
                   onChange={(e) => handleChange(e)}
                   onFocus={() => setEditing(true)}
-                  onKeyUp={(e) => {
+                  onKeyUp={async (e) => {
                     if (e.key === 'Enter') {
-                      commitEdit();
+                      await commitEdit();
                       e.currentTarget.blur();
                     }
                   }}
@@ -133,7 +133,7 @@ export const HardwareAddress = ({
                       id="commit-btn"
                       type="button"
                       className="edit"
-                      onPointerDown={() => commitEdit()}
+                      onPointerDown={async () => await commitEdit()}
                     >
                       <FontAwesomeIcon
                         icon={faCheck}

--- a/src/renderer/library/Hardware/HardwareAddress/index.tsx
+++ b/src/renderer/library/Hardware/HardwareAddress/index.tsx
@@ -52,7 +52,7 @@ export const HardwareAddress = ({
   };
 
   // Validate input and rename account.
-  const commitEdit = async () => {
+  const commitEdit = () => {
     const trimmed = editName.trim();
 
     // Return if account name hasn't changed.
@@ -73,9 +73,10 @@ export const HardwareAddress = ({
     renderToast('Account name updated.', 'success', `toast-${trimmed}`);
 
     // Otherwise rename account.
-    await renameHandler(address, trimmed);
-    setEditName(trimmed);
-    setEditing(false);
+    renameHandler(address, trimmed).then(() => {
+      setEditName(trimmed);
+      setEditing(false);
+    });
   };
 
   // Input change handler.
@@ -118,9 +119,9 @@ export const HardwareAddress = ({
                   value={editing ? editName : accountName}
                   onChange={(e) => handleChange(e)}
                   onFocus={() => setEditing(true)}
-                  onKeyUp={async (e) => {
+                  onKeyUp={(e) => {
                     if (e.key === 'Enter') {
-                      await commitEdit();
+                      commitEdit();
                       e.currentTarget.blur();
                     }
                   }}
@@ -133,7 +134,7 @@ export const HardwareAddress = ({
                       id="commit-btn"
                       type="button"
                       className="edit"
-                      onPointerDown={async () => await commitEdit()}
+                      onPointerDown={async () => commitEdit()}
                     >
                       <FontAwesomeIcon
                         icon={faCheck}

--- a/src/renderer/library/Hardware/HardwareAddress/types.ts
+++ b/src/renderer/library/Hardware/HardwareAddress/types.ts
@@ -18,7 +18,7 @@ export type HardwareAddressProps = ComponentBase & {
   // current name of the account.
   accountName: string;
   // handle rename
-  renameHandler: (address: string, newName: string) => void;
+  renameHandler: (address: string, newName: string) => Promise<void>;
   // handle remove UI.
   openRemoveHandler: () => void;
   // handle confirm import UI.

--- a/src/renderer/screens/Import/Addresses/Confirm.tsx
+++ b/src/renderer/screens/Import/Addresses/Confirm.tsx
@@ -6,23 +6,15 @@ import { Identicon } from '@app/library/Identicon';
 import { ConfirmWrapper } from './Wrappers';
 import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
 import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
-import { useImportHandler } from '@/renderer/contexts/import/ImportHandler';
+import { useAddHandler } from '@/renderer/contexts/import/AddHandler';
 import type { ConfirmProps } from './types';
 
-export const Confirm = ({
-  address,
-  name,
-  source,
-  pubKey,
-  device,
-}: ConfirmProps) => {
+export const Confirm = ({ address, name, source }: ConfirmProps) => {
   const { setStatus } = useOverlay();
-  const { handleImportAddress } = useImportHandler();
+  const { handleAddAddress } = useAddHandler();
 
   const handleClickConfirm = async () => {
-    source === 'ledger'
-      ? await handleImportAddress(address, source, name, pubKey, device)
-      : await handleImportAddress(address, source, name);
+    await handleAddAddress(address, source, name);
     setStatus(0);
   };
 

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { AccountSource } from '@/types/accounts';
-import type { AnyData, AnyFunction } from '@/types/misc';
+import type { AnyFunction } from '@/types/misc';
 
 export interface AddressProps {
   accountName: string;
@@ -21,8 +21,6 @@ export interface ConfirmProps {
   address: string;
   name: string;
   source: AccountSource;
-  pubKey?: string;
-  device?: AnyData;
 }
 
 export interface RemoveProps {

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -21,8 +21,6 @@ export const Address = ({
   isImported,
   orderData,
   setSection,
-  device,
-  pubKey,
 }: LedgerAddressProps) => {
   const { openOverlayWith } = useOverlay();
 
@@ -55,13 +53,7 @@ export const Address = ({
       }
       openConfirmHandler={() =>
         openOverlayWith(
-          <Confirm
-            address={address}
-            name={accountNameState}
-            source="ledger"
-            pubKey={pubKey}
-            device={device}
-          />,
+          <Confirm address={address} name={accountNameState} source="ledger" />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/Ledger/Address.tsx
+++ b/src/renderer/screens/Import/Ledger/Address.tsx
@@ -4,8 +4,8 @@
 import { Confirm } from '../Addresses/Confirm';
 import { Delete } from '../Addresses/Delete';
 import {
-  renameLocalAccount,
   postRenameAccount,
+  renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { HardwareAddress } from '@app/library/Hardware/HardwareAddress';
 import { Remove } from '../Addresses/Remove';
@@ -30,9 +30,11 @@ export const Address = ({
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
-  const renameHandler = (who: string, newName: string) => {
+  const renameHandler = async (who: string, newName: string) => {
     setAccountNameState(newName);
-    renameLocalAccount(who, newName, 'ledger');
+
+    // Update name in store in main process.
+    await renameAccountInStore(who, 'ledger', newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -113,16 +113,12 @@ export const Manage = ({
                                 index,
                                 isImported,
                                 name,
-                                device,
-                                pubKey,
                               }: LedgerLocalAddress,
                               j
                             ) => (
                               <Address
                                 key={`address_${name}`}
                                 address={address}
-                                pubKey={pubKey}
-                                device={device}
                                 source={'ledger'}
                                 accountName={name}
                                 index={index || 0}

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -6,7 +6,7 @@ import { Delete } from '../Addresses/Delete';
 import { HardwareAddress } from '@/renderer/library/Hardware/HardwareAddress';
 import {
   postRenameAccount,
-  renameLocalAccount,
+  renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { Remove } from '../Addresses/Remove';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
@@ -28,9 +28,11 @@ export const Address = ({
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
-  const renameHandler = (who: string, newName: string) => {
+  const renameHandler = async (who: string, newName: string) => {
     setAccountNameState(newName);
-    renameLocalAccount(who, newName, 'read-only');
+
+    // Update name in store in main process.
+    await renameAccountInStore(who, 'read-only', newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -10,7 +10,6 @@ import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCare
 import { Address } from './Address';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import { checkAddress } from '@polkadot/util-crypto';
-import { Config as ConfigImport } from '@/config/processes/import';
 import { DragClose } from '@/renderer/library/DragClose';
 import { ellipsisFn, unescape } from '@w3ux/utils';
 import { faCaretLeft } from '@fortawesome/free-solid-svg-icons';
@@ -42,11 +41,7 @@ import type { LocalAddress } from '@/types/accounts';
 import type { ManageReadOnlyProps } from '../types';
 
 export const Manage = ({ setSection }: ManageReadOnlyProps) => {
-  const {
-    readOnlyAddresses: addresses,
-    setReadOnlyAddresses: setAddresses,
-    isAlreadyImported,
-  } = useAddresses();
+  const { readOnlyAddresses: addresses, isAlreadyImported } = useAddresses();
   const { insertAccountStatus } = useAccountStatuses();
   const { handleImportAddress } = useImportHandler();
 
@@ -83,10 +78,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
     return false;
   };
 
-  /// Gets the next non-imported address index.
-  const getNextAddressIndex = () =>
-    !addresses.length ? 0 : addresses[addresses.length - 1].index || 0 + 1;
-
   /// Cancel button clicked for address field.
   const onCancel = () => {
     setEditName('');
@@ -113,21 +104,6 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
 
     // The default account name.
     const accountName = ellipsisFn(trimmed);
-
-    // Update local storage.
-    const newAddresses = addresses
-      .filter((a: LocalAddress) => a.address !== trimmed)
-      .concat({
-        index: getNextAddressIndex(),
-        address: trimmed,
-        isImported: false,
-        name: accountName,
-        source: 'read-only',
-      });
-
-    const storageKey = ConfigImport.getStorageKey('read-only');
-    localStorage.setItem(storageKey, JSON.stringify(newAddresses));
-    setAddresses(newAddresses);
 
     // Reset read-only address input state.
     setEditName('');

--- a/src/renderer/screens/Import/Vault/Address.tsx
+++ b/src/renderer/screens/Import/Vault/Address.tsx
@@ -5,7 +5,7 @@ import { Confirm } from '../Addresses/Confirm';
 import { Delete } from '../Addresses/Delete';
 import {
   postRenameAccount,
-  renameLocalAccount,
+  renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { HardwareAddress } from '@app/library/Hardware/HardwareAddress';
 import { Remove } from '../Addresses/Remove';
@@ -28,9 +28,11 @@ export const Address = ({
   const [accountNameState, setAccountNameState] = useState<string>(accountName);
 
   // Handler to rename an account.
-  const renameHandler = (who: string, newName: string) => {
+  const renameHandler = async (who: string, newName: string) => {
     setAccountNameState(newName);
-    renameLocalAccount(who, newName, 'vault');
+
+    // Update name in store in main process.
+    await renameAccountInStore(address, 'vault', newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyData, AnyFunction, AnyJson } from '@/types/misc';
+import type { AnyFunction, AnyJson } from '@/types/misc';
 import type { Html5Qrcode } from 'html5-qrcode';
 import type {
   AccountSource,
@@ -65,8 +65,6 @@ export interface LedgerAddressProps {
     lastIndex: number;
   };
   setSection: AnyFunction;
-  pubKey: string;
-  device: AnyData;
 }
 
 export interface ManageReadOnlyProps {

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
 import type { ChainID } from '@/types/chains';
+import type { IpcTask } from '@/types/communication';
 
 type ToastType = 'success' | 'error';
 
@@ -56,6 +57,19 @@ export const renderToast = (
       break;
     }
   }
+};
+
+export const renameLedgerAccount = async (address: string, newName: string) => {
+  const ipcTask: IpcTask = {
+    action: 'raw-account:rename',
+    data: {
+      source: 'ledger' as AccountSource,
+      address,
+      newName,
+    },
+  };
+
+  await window.myAPI.rawAccountTask(ipcTask);
 };
 
 /**

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -59,50 +59,21 @@ export const renderToast = (
   }
 };
 
-export const renameLedgerAccount = async (address: string, newName: string) => {
+/**
+ * @name renameAccountInStore
+ * @summary Updates a stored account's name in the main process.
+ */
+export const renameAccountInStore = async (
+  address: string,
+  source: AccountSource,
+  newName: string
+) => {
   const ipcTask: IpcTask = {
     action: 'raw-account:rename',
-    data: {
-      source: 'ledger' as AccountSource,
-      address,
-      newName,
-    },
+    data: { source, address, newName },
   };
 
   await window.myAPI.rawAccountTask(ipcTask);
-};
-
-/**
- * @name renameLocalAccount
- * @summary Sets an account's name in local storage.
- */
-export const renameLocalAccount = (
-  address: string,
-  newName: string,
-  source: AccountSource
-) => {
-  // Get serialized addresses from local storage.
-  const storageKey = ConfigImport.getStorageKey(source);
-  const stored = localStorage.getItem(storageKey);
-
-  if (!stored) {
-    return;
-  }
-
-  // Update local storage account data.
-  if (source === 'ledger') {
-    const parsed: LedgerLocalAddress[] = JSON.parse(stored);
-    const updated = parsed.map((a: LedgerLocalAddress) =>
-      a.address !== address ? a : { ...a, name: newName }
-    );
-    localStorage.setItem(storageKey, JSON.stringify(updated));
-  } else {
-    const parsed: LocalAddress[] = JSON.parse(stored);
-    const updated = parsed.map((a: LocalAddress) =>
-      a.address !== address ? a : { ...a, name: newName }
-    );
-    localStorage.setItem(storageKey, JSON.stringify(updated));
-  }
 };
 
 /**

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -19,6 +19,7 @@ export interface IpcTask {
     | 'raw-account:persist'
     | 'raw-account:delete'
     | 'raw-account:remove'
-    | 'raw-account:get';
+    | 'raw-account:get'
+    | 'raw-account:rename';
   data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -18,6 +18,7 @@ export interface IpcTask {
   action:
     | 'raw-account:persist'
     | 'raw-account:delete'
+    | 'raw-account:add'
     | 'raw-account:remove'
     | 'raw-account:get'
     | 'raw-account:rename';


### PR DESCRIPTION
# Summary

Handle renaming import window account data and updating its import flag in the Electron store. Local storage code has been removed  in the implementation. 