### PR TITLE
feat(subscriptions): nominations changed subscription

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -105,8 +105,8 @@ export const HelpConfig: HelpItems = [
     key: 'help:subscription:nominating:commission',
     title: 'Nominating: Commission Subscription',
     definition: [
-      'Get notified when any of your nominated validators have changed their commission setting, when a new era starts.',
-      'You will be notified when you are nominating new validators in the new era, and when any validators that you nominated in the previous era have changed their commision setting.',
+      'Get notified when a commission change is detected among your nominated validators, when a new era starts.',
+      'You will be notified when your cached commissions do not match the commissions fetched in the latest era.',
     ],
   },
   {
@@ -123,6 +123,14 @@ export const HelpConfig: HelpItems = [
     definition: [
       'Get notified when you have pending payouts from your nomiated validators.',
       'Polkadot Live will process the last 7 eras in order to calculate any pending payouts. This calculation may take a minute, depending on your network connection speed.',
+    ],
+  },
+  {
+    key: 'help:subscription:nominating:nominations',
+    title: 'Nominating: Nominations Subscription',
+    definition: [
+      'Get notified when any of your nominated validators have changed.',
+      'You will be notified when your cached nominations do not match the nominations fetched in the latest era.',
     ],
   },
   {

--- a/src/config/subscriptions/account.ts
+++ b/src/config/subscriptions/account.ts
@@ -135,6 +135,16 @@ export const accountTasks: SubscriptionTask[] = [
     label: 'Commission Changed',
     status: 'disable',
   },
+  {
+    action: 'subscribe:account:nominating:nominations',
+    apiCallAsString: 'api.query.staking.activeEra',
+    category: 'Nominating',
+    chainId: 'Polkadot',
+    enableOsNotifications: true,
+    helpKey: 'help:subscription:nominating:nominations',
+    label: 'Nominations Changed',
+    status: 'disable',
+  },
   // Kusama
   {
     action: 'subscribe:account:balance:free',
@@ -256,6 +266,16 @@ export const accountTasks: SubscriptionTask[] = [
     label: 'Commission Changed',
     status: 'disable',
   },
+  {
+    action: 'subscribe:account:nominating:nominations',
+    apiCallAsString: 'api.query.staking.activeEra',
+    category: 'Nominating',
+    chainId: 'Kusama',
+    enableOsNotifications: true,
+    helpKey: 'help:subscription:nominating:nominations',
+    label: 'Nominations Changed',
+    status: 'disable',
+  },
   // Westend
   {
     action: 'subscribe:account:balance:free',
@@ -375,6 +395,16 @@ export const accountTasks: SubscriptionTask[] = [
     enableOsNotifications: true,
     helpKey: 'help:subscription:nominating:commission',
     label: 'Commission Changed',
+    status: 'disable',
+  },
+  {
+    action: 'subscribe:account:nominating:nominations',
+    apiCallAsString: 'api.query.staking.activeEra',
+    category: 'Nominating',
+    chainId: 'Westend',
+    enableOsNotifications: true,
+    helpKey: 'help:subscription:nominating:nominations',
+    label: 'Nominations Changed',
     status: 'disable',
   },
 ];

--- a/src/controller/renderer/EventsController.ts
+++ b/src/controller/renderer/EventsController.ts
@@ -617,7 +617,12 @@ export class EventsController {
           },
           timestamp: getUnixTime(new Date()),
           stale: false,
-          actions: [],
+          actions: [
+            {
+              uri: `https://staking.polkadot.cloud/#/nominate?n=${chainId}&a=${address}`,
+              text: 'Dashboard',
+            },
+          ],
         };
       }
       /**
@@ -650,7 +655,12 @@ export class EventsController {
           data: { era, hasChanged },
           timestamp: getUnixTime(new Date()),
           stale: false,
-          actions: [],
+          actions: [
+            {
+              uri: `https://staking.polkadot.cloud/#/nominate?n=${chainId}&a=${address}`,
+              text: 'Dashboard',
+            },
+          ],
         };
       }
       /**
@@ -683,7 +693,12 @@ export class EventsController {
           data: { era, hasChanged },
           timestamp: getUnixTime(new Date()),
           stale: false,
-          actions: [],
+          actions: [
+            {
+              uri: `https://staking.polkadot.cloud/#/nominate?n=${chainId}&a=${address}`,
+              text: 'Dashboard',
+            },
+          ],
         };
       }
       default: {

--- a/src/controller/renderer/EventsController.ts
+++ b/src/controller/renderer/EventsController.ts
@@ -653,6 +653,39 @@ export class EventsController {
           actions: [],
         };
       }
+      /**
+       * subscribe:account:nominating:nominations
+       */
+      case 'subscribe:account:nominating:nominations': {
+        const { chainId } = entry.task;
+        const { address, name: accountName } = entry.task.account!;
+        const { era, hasChanged }: { era: number; hasChanged: boolean } =
+          miscData;
+
+        const subtitle = hasChanged
+          ? 'A change has been detected in your nominated validator set.'
+          : 'No changes detected in your nominated validator set.';
+
+        return {
+          uid: '',
+          category: 'nominating',
+          taskAction: entry.task.action,
+          who: {
+            origin: 'account',
+            data: {
+              accountName,
+              address,
+              chainId,
+            } as EventAccountData,
+          },
+          title: 'Commission Changed',
+          subtitle,
+          data: { era, hasChanged },
+          timestamp: getUnixTime(new Date()),
+          stale: false,
+          actions: [],
+        };
+      }
       default: {
         throw new Error('getEvent: Subscription task action not recognized');
       }

--- a/src/controller/renderer/EventsController.ts
+++ b/src/controller/renderer/EventsController.ts
@@ -678,7 +678,7 @@ export class EventsController {
               chainId,
             } as EventAccountData,
           },
-          title: 'Commission Changed',
+          title: 'Nominations Changed',
           subtitle,
           data: { era, hasChanged },
           timestamp: getUnixTime(new Date()),

--- a/src/controller/renderer/NotificationsController.ts
+++ b/src/controller/renderer/NotificationsController.ts
@@ -173,6 +173,19 @@ export class NotificationsController {
           subtitle: 'Commission Changed',
         };
       }
+      case 'subscribe:account:nominating:nominations': {
+        const { hasChanged }: { hasChanged: boolean } = miscData;
+
+        const body = hasChanged
+          ? 'A change has been detected in your nominated validator set.'
+          : 'No changes detected in your nominated validator set.';
+
+        return {
+          title: account.name,
+          body,
+          subtitle: 'Nominations Changed',
+        };
+      }
       default: {
         throw new Error(
           `getNotification: Not implemented for ${entry.task.action}`

--- a/src/model/QueryMultiWrapper.ts
+++ b/src/model/QueryMultiWrapper.ts
@@ -223,6 +223,13 @@ export class QueryMultiWrapper {
         );
         break;
       }
+      case 'subscribe:account:nominating:nominations': {
+        await Callbacks.callback_nominating_nominations(
+          dataArr[entry.task.dataIndex!],
+          entry
+        );
+        break;
+      }
     }
   }
 

--- a/src/orchestrators/TaskOrchestrator.ts
+++ b/src/orchestrators/TaskOrchestrator.ts
@@ -140,6 +140,10 @@ export class TaskOrchestrator {
             TaskOrchestrator.subscribe_nominating_commission(task, wrapper);
             break;
           }
+          case 'subscribe:account:nominating:nominations': {
+            TaskOrchestrator.subscribe_nominating_nominations(task, wrapper);
+            break;
+          }
           default: {
             throw new Error('Subscription action not found');
           }
@@ -211,6 +215,8 @@ export class TaskOrchestrator {
       case 'subscribe:account:nominating:exposure':
         return instance.api.query.staking.activeEra;
       case 'subscribe:account:nominating:commission':
+        return instance.api.query.staking.activeEra;
+      case 'subscribe:account:nominating:nominations':
         return instance.api.query.staking.activeEra;
       default:
         throw new Error('Subscription action not found');
@@ -418,6 +424,24 @@ export class TaskOrchestrator {
    * @summary Handle a task that subscribes to the API function api.query.activeEra and handles nominated validator commission changes.
    */
   private static subscribe_nominating_commission(
+    task: SubscriptionTask,
+    wrapper: QueryMultiWrapper
+  ) {
+    // Exit early if the account in question is not nominating.
+    if (!task.account?.nominatingData) {
+      console.log('🟠 Account is not nominating.');
+      return;
+    }
+
+    // Otherwise rebuild query.
+    TaskOrchestrator.handleTask(task, wrapper);
+  }
+
+  /**
+   * @name subscribe_nominating_nominations
+   * @summary Handle a task that subscribes to the API function api.query.activeEra and handles changes in nominated validators.
+   */
+  private static subscribe_nominating_nominations(
     task: SubscriptionTask,
     wrapper: QueryMultiWrapper
   ) {

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -976,7 +976,7 @@ export class Callbacks {
       await AccountsController.set(account.chain, account);
       entry.task.account = account.flatten();
 
-      // Return if commissions haven't changed.
+      // Return if nominations haven't changed.
       if (maybeNominatingData) {
         const cur = maybeNominatingData.validators.map((v) => v.validatorId);
         const areEqual = areArraysEqual(prev, cur);
@@ -998,7 +998,7 @@ export class Callbacks {
           })
         : null;
 
-      //// Handle notification and events in main process.
+      // Handle notification and events in main process.
       window.myAPI.persistEvent(
         EventsController.getEvent(entry, { era, hasChanged }),
         notification,

--- a/src/renderer/callbacks/oneshots.ts
+++ b/src/renderer/callbacks/oneshots.ts
@@ -55,6 +55,10 @@ export const executeOneShot = async (task: SubscriptionTask) => {
       const result = await oneShot_nominating_commission(task);
       return result;
     }
+    case 'subscribe:account:nominating:nominations': {
+      const result = await oneShot_nominating_nominations(task);
+      return result;
+    }
     default: {
       return false;
     }
@@ -255,5 +259,22 @@ const oneShot_nominating_commission = async (task: SubscriptionTask) => {
   const data = await api.query.staking.activeEra();
   const entry: ApiCallEntry = { curVal: null, task };
   await Callbacks.callback_nominating_commission(data, entry, true);
+  return true;
+};
+
+/**
+ * @name oneShot_nominating_nominations
+ * @summary One-shot call to see a change in nominations.
+ */
+const oneShot_nominating_nominations = async (task: SubscriptionTask) => {
+  const instance = await getApiInstance(task.chainId);
+  if (!instance) {
+    return false;
+  }
+
+  const { api } = instance;
+  const data = await api.query.staking.activeEra();
+  const entry: ApiCallEntry = { curVal: null, task };
+  await Callbacks.callback_nominating_nominations(data, entry, true);
   return true;
 };

--- a/src/renderer/contexts/common/Help/types.ts
+++ b/src/renderer/contexts/common/Help/types.ts
@@ -56,6 +56,7 @@ export type HelpItemKey =
   | 'help:subscription:nominating:commission'
   | 'help:subscription:nominating:exposure'
   | 'help:subscription:nominating:payouts'
+  | 'help:subscription:nominating:nominations'
   | 'help:subscription:chain:timestamp'
   | 'help:subscription:chain:currentSlot'
   | 'help:settings:dockedWindow'

--- a/src/types/subscriptions.ts
+++ b/src/types/subscriptions.ts
@@ -83,7 +83,8 @@ export type TaskAction =
   | 'subscribe:account:nominationPools:commission'
   | 'subscribe:account:nominating:pendingPayouts'
   | 'subscribe:account:nominating:exposure'
-  | 'subscribe:account:nominating:commission';
+  | 'subscribe:account:nominating:commission'
+  | 'subscribe:account:nominating:nominations';
 
 /// String literals to define task categories.
 export type TaskCategory =

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -139,6 +139,10 @@ export const pushUniqueEvent = (
       push = filter_nominating_commission(events, event);
       break;
     }
+    case 'subscribe:account:nominating:nominations': {
+      push = filter_nominating_nominations(events, event);
+      break;
+    }
     /**
      * Interval Subscriptions
      */
@@ -527,9 +531,44 @@ const filter_nominating_exposure = (
 /**
  * @name filter_nominating_commission
  * @summary The new event is considered a duplicate if another event has
- * a matching address and changed validator data.
+ * a matching address and commission data.
  */
 const filter_nominating_commission = (
+  events: EventCallback[],
+  event: EventCallback
+): boolean => {
+  const { address } = event.who.data as EventAccountData;
+  const { era, hasChanged }: { era: number; hasChanged: boolean } = event.data;
+
+  let isUnique = true;
+
+  events.forEach((e) => {
+    if (e.taskAction === event.taskAction && e.data) {
+      const { address: nextAddress } = e.who.data as EventAccountData;
+      const {
+        era: nextEra,
+        hasChanged: nextHasChanged,
+      }: { era: number; hasChanged: boolean } = e.data;
+
+      if (
+        address === nextAddress &&
+        era === nextEra &&
+        hasChanged === nextHasChanged
+      ) {
+        isUnique = false;
+      }
+    }
+  });
+
+  return isUnique;
+};
+
+/**
+ * @name filter_nominating_nominations
+ * @summary The new event is considered a duplicate if another event has
+ * a matching address and validator data.
+ */
+const filter_nominating_nominations = (
   events: EventCallback[],
   event: EventCallback
 ): boolean => {


### PR DESCRIPTION
# Summary

Initial implementation of the `nominating:nominations` subscription.

A notification is received when a user's nominated validator set changes on the start of a new era.