### PR TITLE
chore(subscriptions): fix nominating pending payouts

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -119,10 +119,10 @@ export const HelpConfig: HelpItems = [
   },
   {
     key: 'help:subscription:nominating:payouts',
-    title: 'Nominating: Pending Payouts Subscription',
+    title: 'Nominating: Era Rewards Subscription',
     definition: [
-      'Get notified when you have pending payouts from your nomiated validators.',
-      'Polkadot Live will process the last 7 eras in order to calculate any pending payouts. This calculation may take a minute, depending on your network connection speed.',
+      'Get notified of your nominating rewards from the previous era.',
+      'Polkadot Live will calculate your rewards in a decentralized way, fetching required state from the network.',
     ],
   },
   {

--- a/src/config/subscriptions/account.ts
+++ b/src/config/subscriptions/account.ts
@@ -112,7 +112,7 @@ export const accountTasks: SubscriptionTask[] = [
     chainId: 'Polkadot',
     enableOsNotifications: true,
     helpKey: 'help:subscription:nominating:payouts',
-    label: 'Pending Payouts',
+    label: 'Era Rewards',
     status: 'disable',
   },
   {
@@ -243,7 +243,7 @@ export const accountTasks: SubscriptionTask[] = [
     chainId: 'Kusama',
     enableOsNotifications: true,
     helpKey: 'help:subscription:nominating:payouts',
-    label: 'Pending Payouts',
+    label: 'Era Rewards',
     status: 'disable',
   },
   {
@@ -374,7 +374,7 @@ export const accountTasks: SubscriptionTask[] = [
     chainId: 'Westend',
     enableOsNotifications: true,
     helpKey: 'help:subscription:nominating:payouts',
-    label: 'Pending Payouts',
+    label: 'Era Rewards',
     status: 'disable',
   },
   {

--- a/src/controller/renderer/EventsController.ts
+++ b/src/controller/renderer/EventsController.ts
@@ -553,7 +553,7 @@ export class EventsController {
        */
       case 'subscribe:account:nominating:pendingPayouts': {
         // eslint-disable-next-line prettier/prettier
-        const { pendingPayout, era }: { pendingPayout: BigNumber; era: string } = miscData;
+        const { eraRewards, era }: { eraRewards: BigNumber; era: string } = miscData;
         const { chainId } = entry.task;
         const { address, name: accountName } = entry.task.account!;
 
@@ -569,11 +569,11 @@ export class EventsController {
               chainId,
             } as EventAccountData,
           },
-          title: 'Nominating Pending Payout',
-          subtitle: getBalanceText(pendingPayout, chainId),
+          title: 'Nominating Rewards',
+          subtitle: getBalanceText(eraRewards, chainId),
           data: {
             era,
-            pendingPayout: pendingPayout.toString(), // string required
+            eraRewards: eraRewards.toString(), // string required
           },
           timestamp: getUnixTime(new Date()),
           stale: false,
@@ -581,6 +581,10 @@ export class EventsController {
             {
               uri: `https://staking.polkadot.cloud/#/nominate?n=${chainId}&a=${address}`,
               text: 'Dashboard',
+            },
+            {
+              uri: `https://${chainId}.subscan.io/nominator/${address}?tab=reward`,
+              text: 'Subscan',
             },
           ],
         };

--- a/src/controller/renderer/NotificationsController.ts
+++ b/src/controller/renderer/NotificationsController.ts
@@ -144,7 +144,7 @@ export class NotificationsController {
         return {
           title: account.name,
           body: getBalanceText(pendingPayout, chainId),
-          subtitle: 'Nominating Pending Payout',
+          subtitle: 'Nominating Rewards',
         };
       }
       case 'subscribe:account:nominating:exposure': {

--- a/src/model/QueryMultiWrapper.ts
+++ b/src/model/QueryMultiWrapper.ts
@@ -203,7 +203,7 @@ export class QueryMultiWrapper {
         break;
       }
       case 'subscribe:account:nominating:pendingPayouts': {
-        await Callbacks.callback_nominating_pending_payouts(
+        await Callbacks.callback_nominating_era_rewards(
           dataArr[entry.task.dataIndex!],
           entry
         );

--- a/src/renderer/callbacks/index.ts
+++ b/src/renderer/callbacks/index.ts
@@ -661,12 +661,10 @@ export class Callbacks {
   }
 
   /*
-   * @name callback_nominating_pending_payouts
+   * @name callback_nominating_era_rewards
    * @summary Callback for 'subscribe:account:nominating:pendingPayouts'
-   *
-   * When an account's nominations receive rewards in previous era, dispatch an event and notificaiton.
    */
-  static async callback_nominating_pending_payouts(
+  static async callback_nominating_era_rewards(
     data: AnyData,
     entry: ApiCallEntry,
     isOneShot = false
@@ -705,7 +703,7 @@ export class Callbacks {
         : null;
 
       window.myAPI.persistEvent(
-        EventsController.getEvent(entry, { eraRewards, era }),
+        EventsController.getEvent(entry, { eraRewards, era: era.toString() }),
         notification,
         isOneShot
       );

--- a/src/renderer/callbacks/nominating.ts
+++ b/src/renderer/callbacks/nominating.ts
@@ -6,119 +6,7 @@ import { rmCommas } from '@w3ux/utils';
 import type { Account } from '@/model/Account';
 import type { AnyData } from '@/types/misc';
 import type { ApiPromise } from '@polkadot/api';
-import type { ChainID } from '@/types/chains';
 import type { AccountNominatingData, ValidatorData } from '@/types/accounts';
-
-const MaxSupportedPayoutEras = 6;
-
-interface LocalValidatorExposure {
-  staked: string;
-  total: string;
-  isValidator: boolean;
-  exposedPage?: number;
-}
-
-/**
- * @name getErasInterval
- * @summary Calculate eras to check for pending payouts.
- */
-const getErasInterval = (era: BigNumber) => {
-  const startEra = era.minus(1);
-  const endEra = BigNumber.max(
-    startEra.minus(MaxSupportedPayoutEras).plus(1),
-    1
-  );
-
-  return { startEra, endEra };
-};
-
-/**
- * @name getPagedErasStakers
- * @summary Get an era validator and staker data.
- */
-const getPagedErasStakers = async (api: ApiPromise, era: string) => {
-  const overview: AnyData =
-    await api.query.staking.erasStakersOverview.entries(era);
-
-  const validators = overview.reduce(
-    (prev: Record<string, AnyData>, [keys, value]: AnyData) => {
-      const validator = keys.toHuman()[1];
-      const { own, total } = value.toHuman();
-      return { ...prev, [validator]: { own, total } };
-    },
-    {}
-  );
-  const validatorKeys = Object.keys(validators);
-
-  const pagedResults = await Promise.all(
-    validatorKeys.map((v) => api.query.staking.erasStakersPaged.entries(era, v))
-  );
-
-  const result: AnyData[] = [];
-  let i = 0;
-  for (const pagedResult of pagedResults) {
-    const validator = validatorKeys[i];
-    const { own, total } = validators[validator];
-    const others = pagedResult.reduce((prev: AnyData[], [, v]: AnyData) => {
-      const o = v.toHuman()?.others || [];
-      if (!o.length) {
-        return prev;
-      }
-      return prev.concat(o);
-    }, []);
-
-    result.push({
-      keys: [rmCommas(era), validator],
-      val: {
-        total: rmCommas(total),
-        own: rmCommas(own),
-        others: others.map(({ who, value }) => ({
-          who,
-          value: rmCommas(value),
-        })),
-      },
-    });
-    i++;
-  }
-  return result;
-};
-
-/**
- * @name getLocalEraExposure
- * @summary Get exposure data for an account using the new paged API.
- */
-const getLocalEraExposure = async (
-  api: ApiPromise,
-  era: string,
-  accountAddress: string,
-  validator: string
-): Promise<LocalValidatorExposure | null> => {
-  const result: AnyData = await api.query.staking.erasStakersPaged.entries(
-    era,
-    validator
-  );
-
-  const overview: AnyData = (
-    await api.query.staking.erasStakersOverview(era, validator)
-  ).toHuman();
-
-  for (const item of result) {
-    for (const { who, value } of item[1].toHuman().others) {
-      if ((who as string) === accountAddress) {
-        const exposedPage = parseInt(rmCommas(item[0].toHuman()[2] as string));
-
-        return {
-          staked: value as string,
-          total: overview.total as string,
-          isValidator: accountAddress === validator,
-          exposedPage,
-        } as LocalValidatorExposure;
-      }
-    }
-  }
-
-  return null;
-};
 
 interface ValidatorOverviewData {
   total: string;
@@ -126,17 +14,17 @@ interface ValidatorOverviewData {
   nominatorCount: string;
   pageCount: string;
 }
+
 /**
  * @name getEraRewards
  * @summary Get an address' total nominating rewards in a given era.
  */
-export const getEraRewards = async (address: string, api: ApiPromise) => {
+export const getEraRewards = async (
+  address: string,
+  api: ApiPromise,
+  era: number
+) => {
   const showDebug = true;
-  const eraResult: AnyData = (await api.query.staking.activeEra()).toHuman();
-  const era: BigNumber = new BigNumber(
-    parseInt((eraResult.index as string).replace(/,/g, ''))
-  );
-
   const r1 = await api.query.staking.erasValidatorReward<AnyData>(era);
   const r2 = await api.query.staking.erasRewardPoints<AnyData>(era);
 
@@ -162,6 +50,7 @@ export const getEraRewards = async (address: string, api: ApiPromise) => {
 
   // Map data is <validatorId, stakedAmount[]>
   const addressStake = new Map<string, string[]>();
+  const show = false;
   for (const pagedResult of pagedResults) {
     if (pagedResult[0] === undefined) {
       continue;
@@ -171,14 +60,14 @@ export const getEraRewards = async (address: string, api: ApiPromise) => {
     const pageEra = (obj[0].toHuman() as AnyData)[0] || '0';
     const pageValidator = (obj[0].toHuman() as AnyData)[1];
     const page = (obj[0].toHuman() as AnyData)[2];
-    showDebug && console.log(pageEra, pageValidator, page);
+    showDebug && show && console.log(pageEra, pageValidator, page);
 
     const pageTotal = (obj[1].toHuman() as AnyData).pageTotal;
     const others = (obj[1].toHuman() as AnyData).others;
-    showDebug && console.log(pageTotal);
+    showDebug && show && console.log(pageTotal);
 
     for (const { who, value } of others) {
-      showDebug && console.log(who, value);
+      showDebug && show && console.log(who, value);
       if ((who as string) === address) {
         addressStake.has(pageValidator)
           ? addressStake.set(pageValidator, [
@@ -248,280 +137,6 @@ export const getEraRewards = async (address: string, api: ApiPromise) => {
   }
 
   return totalRewards;
-};
-
-/**
- * @name getUnclaimedPayouts
- * @summary Function to calculate an account's unclaimed payouts.
- */
-export const getUnclaimedPayouts = async (
-  address: string,
-  api: ApiPromise,
-  chainId: ChainID,
-  showDebug = false
-) => {
-  /**
-   * Get API instance and active era.
-   */
-  const era_res: AnyData = (await api.query.staking.activeEra()).toHuman();
-  const activeEra: BigNumber = new BigNumber(
-    parseInt((era_res.index as string).replace(/,/g, ''))
-  );
-
-  /**
-   * Accumulate eras to check, and determine all validator ledgers to
-   * fetch from exposures.
-   */
-  const erasValidators = [];
-  const { startEra, endEra } = getErasInterval(activeEra);
-  let erasToCheck: string[] = [];
-  let currentEra = startEra;
-
-  while (currentEra.isGreaterThanOrEqualTo(endEra)) {
-    const validators: string[] = [];
-    const estr: string = currentEra.toString();
-    const exposures: AnyData = await getPagedErasStakers(api, estr);
-
-    // `keys: [era, validatorId]`, `val: { total, own, others }`, `others: { who, value }`
-    for (const exposure of exposures) {
-      const vid = exposure.keys[1];
-      const { others } = exposure.val;
-      let i = 0;
-      for (const { who } of others) {
-        if (i >= 512) {
-          break;
-        }
-        if ((who as string) === address) {
-          validators.push(vid);
-          break;
-        }
-        ++i;
-      }
-    }
-
-    erasValidators.push(...validators);
-    erasToCheck.push(currentEra.toString());
-    currentEra = currentEra.minus(1);
-  }
-
-  /**
-   * Ensure no validator duplicates.
-   */
-  const uniqueValidators = [...new Set(erasValidators)];
-  erasToCheck = erasToCheck.sort((a: string, b: string) =>
-    new BigNumber(b).minus(a).toNumber()
-  );
-
-  // Sanity check.
-  if (showDebug) {
-    console.log('> getUnclaimedPayputs: erasToCheck');
-    console.log(erasToCheck);
-    console.log('> getUnclaimedPayouts: uniqueValidators');
-    console.log(uniqueValidators);
-  }
-
-  /**
-   * Fetch controllers in order to query ledgers (controllers of uniqueValidators array).
-   */
-  const bondedResults =
-    await api.query.staking.bonded.multi<AnyData>(uniqueValidators);
-
-  // Map of <ValidatorId, ValidatorControllerAccount>
-  const validatorControllers = new Map<string, string>();
-
-  for (let i = 0; i < bondedResults.length; i++) {
-    const controller = bondedResults[i].unwrapOr(null);
-    if (controller) {
-      validatorControllers.set(uniqueValidators[i], controller);
-    }
-  }
-
-  // Sanity check.
-  if (showDebug) {
-    console.log('> getUnclaimedPayouts: validatorControllers:');
-    console.log(validatorControllers);
-  }
-
-  /**
-   * Unclaimed rewards by validator. Map<validator, eras[]>
-   */
-  const unclaimedRewards = new Map<string, string[]>();
-
-  // Accumulate calls to fetch unclaimed rewards for each era for all validators.
-  const unclaimedRewardsEntries = erasToCheck
-    .map((era) => uniqueValidators.map((v) => [era, v]))
-    .flat();
-
-  const results: AnyData = await Promise.all(
-    unclaimedRewardsEntries.map(([era, v]) =>
-      api.query.staking.claimedRewards<AnyData>(era, v)
-    )
-  );
-
-  for (let i = 0; i < results.length; i++) {
-    const pages = results[i].toHuman() || [];
-    const era = unclaimedRewardsEntries[i][0];
-    const validator = unclaimedRewardsEntries[i][1];
-    const exposure: AnyData = await getLocalEraExposure(
-      api,
-      era,
-      address,
-      validator
-    );
-
-    const exposedPage =
-      exposure?.[validator]?.exposedPage !== undefined
-        ? String(exposure[validator].exposedPage)
-        : undefined;
-
-    // Add to `unclaimedRewards` if payout page has not yet been claimed.
-    if (!pages.includes(exposedPage)) {
-      const fetched = unclaimedRewards.get(validator);
-
-      if (fetched) {
-        unclaimedRewards.set(validator, [...fetched, era]);
-      } else {
-        unclaimedRewards.set(validator, [era]);
-      }
-    }
-  }
-
-  // Sanity check,
-  if (showDebug) {
-    // eslint-disable-next-line prettier/prettier
-    console.log('> getUnclaimedPayouts: unclaimedRewards: <validatorId, erasUnclaimed>');
-    console.log(unclaimedRewards);
-  }
-
-  /**
-   * Reformat `unclaimedRewards` to be <era: validators[]>
-   */
-  const unclaimedByEra = new Map<string, string[]>();
-  erasToCheck.forEach((era) => {
-    const eraValidators: string[] = [];
-    for (const [validator, eras] of unclaimedRewards.entries()) {
-      if (eras.includes(era)) {
-        eraValidators.push(validator);
-      }
-    }
-    if (eraValidators.length > 0) {
-      unclaimedByEra.set(era, eraValidators);
-    }
-  });
-
-  // Sanity check.
-  if (showDebug) {
-    console.log('> getUnclaimedPayouts: unclaimedByEra');
-    console.log(unclaimedByEra);
-  }
-
-  /**
-   * Accumulate calls needed to fetch data to accumulate rewards.
-   */
-  const calls: AnyData[] = [];
-  for (const [era, validators] of unclaimedByEra.entries()) {
-    if (validators.length > 0) {
-      // Calls for era validaotor reward and era points.
-      const subCalls: AnyData[] = [
-        api.query.staking.erasValidatorReward<AnyData>(era),
-        api.query.staking.erasRewardPoints<AnyData>(era),
-      ];
-
-      // Calls to get validator commissions.
-      //validators.map((validator) =>
-      for (const validator of validators) {
-        subCalls.push(
-          api.query.staking.erasValidatorPrefs<AnyData>(era, validator)
-        );
-      }
-
-      // Push calls to outer array.
-      calls.push(Promise.all(subCalls));
-    }
-  }
-
-  // Sanity check.
-  if (showDebug) {
-    console.log('> getUnclaimedPayouts: calls');
-    console.log(calls);
-  }
-
-  /**
-   * Iterate calls and determine unclaimed payouts.
-   * `unclaimed: Map<era, Map<validator, unclaimedPayouts>>
-   */
-  const unclaimed = new Map<string, Map<string, [number, string]>>();
-
-  let i = 0;
-  for (const [reward, points, ...prefs] of await Promise.all(calls)) {
-    const era = Array.from(unclaimedByEra.keys())[i];
-    const eraTotalPayout = new BigNumber(rmCommas(reward.toHuman()));
-    const eraRewardPoints = points.toHuman();
-    const unclaimedValidators = unclaimedByEra.get(era)!;
-
-    let j = 0;
-    for (const pref of prefs) {
-      const eraValidatorPrefs = pref.toHuman();
-      const commission = new BigNumber(
-        eraValidatorPrefs.commission.replace(/%/g, '')
-      ).multipliedBy(0.01);
-
-      // Get validator from era exposure data (`null` if not found).
-      const validator = unclaimedValidators[j] || '';
-
-      // Fetch exposure using the new paged API.
-      const localExposed: LocalValidatorExposure | null =
-        await getLocalEraExposure(api, era, address, validator);
-
-      const staked = localExposed?.staked
-        ? new BigNumber(rmCommas(localExposed.staked))
-        : new BigNumber(0);
-
-      const total = localExposed?.total
-        ? new BigNumber(rmCommas(localExposed?.total))
-        : new BigNumber(0);
-
-      const isValidator = localExposed?.isValidator || false;
-      const exposedPage = localExposed?.exposedPage || 0;
-
-      // Calculate the validator's share of total era payout.
-      const totalRewardPoints = new BigNumber(rmCommas(eraRewardPoints.total));
-      const validatorRewardPoints = new BigNumber(
-        rmCommas(eraRewardPoints.individual?.[validator] || '0')
-      );
-
-      const avail = eraTotalPayout
-        .multipliedBy(validatorRewardPoints)
-        .dividedBy(totalRewardPoints);
-
-      const valCut = commission.multipliedBy(avail);
-
-      const unclaimedPayout = total.isZero()
-        ? new BigNumber(0)
-        : avail
-            .minus(valCut)
-            .multipliedBy(staked)
-            .dividedBy(total)
-            .plus(isValidator ? valCut : 0);
-
-      if (!unclaimedPayout.isZero()) {
-        const fetched = unclaimed.get(era) || new Map();
-        fetched.set(validator, [exposedPage, unclaimedPayout.toString()]);
-        unclaimed.set(era, fetched);
-        j++;
-      }
-    }
-
-    // Increment outer loop index.
-    i++;
-  }
-
-  if (showDebug) {
-    console.log(`> getUnclaimedPayouts: unclaimed`);
-    console.log(unclaimed);
-  }
-
-  return unclaimed;
 };
 
 /**
@@ -684,4 +299,56 @@ export const areArraysEqual = (arr1: string[], arr2: string[]): boolean => {
   }
 
   return true;
+};
+
+/**
+ * @name getPagedErasStakers
+ * @summary Get an era validator and staker data.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getPagedErasStakers = async (api: ApiPromise, era: string) => {
+  const overview: AnyData =
+    await api.query.staking.erasStakersOverview.entries(era);
+
+  const validators = overview.reduce(
+    (prev: Record<string, AnyData>, [keys, value]: AnyData) => {
+      const validator = keys.toHuman()[1];
+      const { own, total } = value.toHuman();
+      return { ...prev, [validator]: { own, total } };
+    },
+    {}
+  );
+
+  const validatorKeys = Object.keys(validators);
+  const pagedResults = await Promise.all(
+    validatorKeys.map((v) => api.query.staking.erasStakersPaged.entries(era, v))
+  );
+
+  const result: AnyData[] = [];
+  let i = 0;
+  for (const pagedResult of pagedResults) {
+    const validator = validatorKeys[i];
+    const { own, total } = validators[validator];
+    const others = pagedResult.reduce((prev: AnyData[], [, v]: AnyData) => {
+      const o = v.toHuman()?.others || [];
+      if (!o.length) {
+        return prev;
+      }
+      return prev.concat(o);
+    }, []);
+
+    result.push({
+      keys: [rmCommas(era), validator],
+      val: {
+        total: rmCommas(total),
+        own: rmCommas(own),
+        others: others.map(({ who, value }) => ({
+          who,
+          value: rmCommas(value),
+        })),
+      },
+    });
+    i++;
+  }
+  return result;
 };

--- a/src/renderer/callbacks/oneshots.ts
+++ b/src/renderer/callbacks/oneshots.ts
@@ -44,7 +44,7 @@ export const executeOneShot = async (task: SubscriptionTask) => {
       return result;
     }
     case 'subscribe:account:nominating:pendingPayouts': {
-      const result = await oneShot_nominating_pending_payouts(task);
+      const result = await oneShot_nominating_era_rewards(task);
       return result;
     }
     case 'subscribe:account:nominating:exposure': {
@@ -215,7 +215,7 @@ const oneShot_nomination_pool_commission = async (task: SubscriptionTask) => {
  * @name oneShot_nominating_pending_payouts
  * @summary One-shot call to fetch an account's nominating pending paypouts.
  */
-const oneShot_nominating_pending_payouts = async (task: SubscriptionTask) => {
+const oneShot_nominating_era_rewards = async (task: SubscriptionTask) => {
   const instance = await getApiInstance(task.chainId);
   if (!instance) {
     return false;
@@ -224,7 +224,7 @@ const oneShot_nominating_pending_payouts = async (task: SubscriptionTask) => {
   const { api } = instance;
   const data = await api.query.staking.activeEra();
   const entry: ApiCallEntry = { curVal: null, task };
-  await Callbacks.callback_nominating_pending_payouts(data, entry, true);
+  await Callbacks.callback_nominating_era_rewards(data, entry, true);
   return true;
 };
 

--- a/src/renderer/screens/Home/Manage/PermissionRow.tsx
+++ b/src/renderer/screens/Home/Manage/PermissionRow.tsx
@@ -17,7 +17,6 @@ import {
   getTooltipClassForGroup,
   toolTipTextFor,
 } from '@app/utils/renderingUtils';
-import { WarningIcon } from '@/renderer/kits/Icons/IconWarning';
 import type { PermissionRowProps } from './types';
 
 export const PermissionRow = ({
@@ -72,12 +71,6 @@ export const PermissionRow = ({
                 />
               </div>
               {task.label}
-
-              {/* Warning if nominating pending payouts */}
-              {task.action ===
-                'subscribe:account:nominating:pendingPayouts' && (
-                <WarningIcon tooltip="Slow Operation" iconColor="#b76438" />
-              )}
             </h3>
           </div>
         </div>

--- a/src/renderer/screens/Home/Manage/PermissionRow.tsx
+++ b/src/renderer/screens/Home/Manage/PermissionRow.tsx
@@ -76,10 +76,7 @@ export const PermissionRow = ({
               {/* Warning if nominating pending payouts */}
               {task.action ===
                 'subscribe:account:nominating:pendingPayouts' && (
-                <WarningIcon
-                  tooltip="Potential Slow Operation"
-                  iconColor="#b76438"
-                />
+                <WarningIcon tooltip="Slow Operation" iconColor="#b76438" />
               )}
             </h3>
           </div>

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -157,7 +157,8 @@ export const Permissions = ({
       }
       case 'subscribe:account:nominating:pendingPayouts':
       case 'subscribe:account:nominating:exposure':
-      case 'subscribe:account:nominating:commission': {
+      case 'subscribe:account:nominating:commission':
+      case 'subscribe:account:nominating:nominations': {
         return task.account?.nominatingData ? false : true;
       }
       default: {

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -469,12 +469,12 @@ const filter_nominating_era_rewards = (
   event: EventCallback
 ): boolean => {
   interface Target {
-    era: string;
     eraRewards: string;
+    era: string;
   }
 
   const { address } = event.who.data as EventAccountData;
-  const { era, eraRewards }: Target = event.data;
+  const { eraRewards, era }: Target = event.data;
 
   let isUnique = true;
 

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -128,7 +128,7 @@ export const pushUniqueEvent = (
       break;
     }
     case 'subscribe:account:nominating:pendingPayouts': {
-      push = filter_nominating_pending_payouts(events, event);
+      push = filter_nominating_era_rewards(events, event);
       break;
     }
     case 'subscribe:account:nominating:exposure': {
@@ -460,33 +460,33 @@ const filter_nomination_pool_commission = (
 };
 
 /**
- * @name filter_nominating_rewards
+ * @name filter_nominating_era_rewards
  * @summary The new event is considered a duplicate if another event has
  * a matching address, pending payout and era number.
  */
-const filter_nominating_pending_payouts = (
+const filter_nominating_era_rewards = (
   events: EventCallback[],
   event: EventCallback
 ): boolean => {
   interface Target {
     era: string;
-    pendingPayout: string;
+    eraRewards: string;
   }
 
   const { address } = event.who.data as EventAccountData;
-  const { era, pendingPayout }: Target = event.data;
+  const { era, eraRewards }: Target = event.data;
 
   let isUnique = true;
 
   events.forEach((e) => {
     if (e.taskAction === event.taskAction && e.data) {
       const { address: nextAddress } = e.who.data as EventAccountData;
-      const { era: nextEra, pendingPayout: nextPendingPayout }: Target = e.data;
+      const { era: nextEra, eraRewards: nextEraRewards }: Target = e.data;
 
       if (
         address === nextAddress &&
         era === nextEra &&
-        pendingPayout === nextPendingPayout
+        eraRewards === nextEraRewards
       ) {
         isUnique = false;
       }


### PR DESCRIPTION
Replaces the pending payouts nominating subscription with a new `Era Rewards` subscription.

Get notified of your nominating rewards from the previous era (when a new era starts) with this new subscription.