### PR TITLE
chore: generic interval task ipcs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -504,7 +504,7 @@ app.whenReady().then(async () => {
           t.action === target.action &&
           t.chainId === target.chainId &&
           t.referendumId === target.referendumId
-            ? task
+            ? target
             : t
         );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -452,7 +452,18 @@ app.whenReady().then(async () => {
         storePointer.delete(key);
         return 'done';
       }
+      // Add interval subscription to store.
       case 'interval:task:add': {
+        const { serialized }: { serialized: string } = task.data;
+        const key = 'interval_subscriptions';
+        const storePointer: Record<string, AnyJson> = store;
+
+        const stored: IntervalSubscription[] = storePointer.get(key)
+          ? JSON.parse(storePointer.get(key) as string)
+          : [];
+
+        stored.push(JSON.parse(serialized));
+        storePointer.set(key, JSON.stringify(stored));
         break;
       }
       case 'interval:task:remove': {
@@ -462,19 +473,6 @@ app.whenReady().then(async () => {
         break;
       }
     }
-  });
-
-  // Add interval subscription to store.
-  ipcMain.handle('app:interval:task:add', async (_, serialized: string) => {
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyJson> = store;
-
-    const stored: IntervalSubscription[] = storePointer.get(key)
-      ? JSON.parse(storePointer.get(key) as string)
-      : [];
-
-    stored.push(JSON.parse(serialized));
-    storePointer.set(key, JSON.stringify(stored));
   });
 
   // Add interval subscription to store.

--- a/src/main.ts
+++ b/src/main.ts
@@ -489,33 +489,29 @@ app.whenReady().then(async () => {
         storePointer.set(key, JSON.stringify(filtered));
         return;
       }
+      // Update an interval subscription in the store.
       case 'interval:task:update': {
-        break;
+        const { serialized }: { serialized: string } = task.data;
+        const key = 'interval_subscriptions';
+        const storePointer: Record<string, AnyJson> = store;
+
+        const target: IntervalSubscription = JSON.parse(serialized);
+        const stored: IntervalSubscription[] = storePointer.get(key)
+          ? JSON.parse(storePointer.get(key) as string)
+          : [];
+
+        const updated = stored.map((t) =>
+          t.action === target.action &&
+          t.chainId === target.chainId &&
+          t.referendumId === target.referendumId
+            ? task
+            : t
+        );
+
+        storePointer.set(key, JSON.stringify(updated));
+        return;
       }
     }
-  });
-
-  // Update an interval subscription in the store.
-  ipcMain.handle('app:interval:task:update', async (_, serialized: string) => {
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyJson> = store;
-
-    const task: IntervalSubscription = JSON.parse(serialized);
-    const { action, chainId, referendumId } = task;
-
-    const stored: IntervalSubscription[] = storePointer.get(key)
-      ? JSON.parse(storePointer.get(key) as string)
-      : [];
-
-    const updated = stored.map((t) =>
-      t.action === action &&
-      t.chainId === chainId &&
-      t.referendumId === referendumId
-        ? task
-        : t
-    );
-
-    storePointer.set(key, JSON.stringify(updated));
   });
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -464,38 +464,35 @@ app.whenReady().then(async () => {
 
         stored.push(JSON.parse(serialized));
         storePointer.set(key, JSON.stringify(stored));
-        break;
+        return;
       }
+      // Remove interval subscription from store.
       case 'interval:task:remove': {
-        break;
+        const { serialized }: { serialized: string } = task.data;
+        const key = 'interval_subscriptions';
+        const storePointer: Record<string, AnyJson> = store;
+
+        const stored: IntervalSubscription[] = storePointer.get(key)
+          ? JSON.parse(storePointer.get(key) as string)
+          : [];
+
+        const target: IntervalSubscription = JSON.parse(serialized);
+        const filtered = stored.filter(
+          (t) =>
+            !(
+              t.action === target.action &&
+              t.chainId === target.chainId &&
+              t.referendumId === target.referendumId
+            )
+        );
+
+        storePointer.set(key, JSON.stringify(filtered));
+        return;
       }
       case 'interval:task:update': {
         break;
       }
     }
-  });
-
-  // Add interval subscription to store.
-  ipcMain.handle('app:interval:task:remove', async (_, serialized: string) => {
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyJson> = store;
-
-    const stored: IntervalSubscription[] = storePointer.get(key)
-      ? JSON.parse(storePointer.get(key) as string)
-      : [];
-
-    const task: IntervalSubscription = JSON.parse(serialized);
-    const { action, chainId, referendumId } = task;
-    const filtered = stored.filter(
-      (t) =>
-        !(
-          t.action === action &&
-          t.chainId === chainId &&
-          t.referendumId === referendumId
-        )
-    );
-
-    storePointer.set(key, JSON.stringify(filtered));
   });
 
   // Update an interval subscription in the store.

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,13 +435,29 @@ app.whenReady().then(async () => {
   /**
    * Interval subscriptions
    */
-
-  // Get interval subscriptions from store.
-  ipcMain.handle('app:interval:tasks:get', async () => {
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyJson> = store;
-    const stored: string = storePointer.get(key) || '[]';
-    return stored;
+  ipcMain.handle('main:task:interval', async (_, task: IpcTask) => {
+    const { action } = task;
+    switch (action) {
+      // Get serialized interval subscriptions from store.
+      case 'interval:task:get': {
+        const key = 'interval_subscriptions';
+        const storePointer: Record<string, AnyJson> = store;
+        const stored: string = storePointer.get(key) || '[]';
+        return stored;
+      }
+      case 'interval:task:clear': {
+        break;
+      }
+      case 'interval:task:add': {
+        break;
+      }
+      case 'interval:task:remove': {
+        break;
+      }
+      case 'interval:task:update': {
+        break;
+      }
+    }
   });
 
   // Clear interval subscriptions from store.

--- a/src/main.ts
+++ b/src/main.ts
@@ -445,8 +445,12 @@ app.whenReady().then(async () => {
         const stored: string = storePointer.get(key) || '[]';
         return stored;
       }
+      // Clear interval subscriptions from store.
       case 'interval:task:clear': {
-        break;
+        const key = 'interval_subscriptions';
+        const storePointer: Record<string, AnyJson> = store;
+        storePointer.delete(key);
+        return 'done';
       }
       case 'interval:task:add': {
         break;
@@ -458,14 +462,6 @@ app.whenReady().then(async () => {
         break;
       }
     }
-  });
-
-  // Clear interval subscriptions from store.
-  ipcMain.handle('app:interval:tasks:clear', async () => {
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyJson> = store;
-    storePointer.delete(key);
-    return 'done';
   });
 
   // Add interval subscription to store.

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -103,9 +103,6 @@ export const API: PreloadAPI = {
   sendIntervalTask: async (task: IpcTask) =>
     await ipcRenderer.invoke('main:task:interval', task),
 
-  updateIntervalTask: async (serialized: string) =>
-    await ipcRenderer.invoke('app:interval:task:update', serialized),
-
   /**
    * File import and export
    */

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -103,9 +103,6 @@ export const API: PreloadAPI = {
   sendIntervalTask: async (task: IpcTask) =>
     await ipcRenderer.invoke('main:task:interval', task),
 
-  clearPersistedIntervalTasks: async () =>
-    await ipcRenderer.invoke('app:interval:tasks:clear'),
-
   persistIntervalTask: async (serialized: string) =>
     await ipcRenderer.invoke('app:interval:task:add', serialized),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -103,9 +103,6 @@ export const API: PreloadAPI = {
   sendIntervalTask: async (task: IpcTask) =>
     await ipcRenderer.invoke('main:task:interval', task),
 
-  persistIntervalTask: async (serialized: string) =>
-    await ipcRenderer.invoke('app:interval:task:add', serialized),
-
   removeIntervalTask: async (serialized: string) =>
     await ipcRenderer.invoke('app:interval:task:remove', serialized),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -103,9 +103,6 @@ export const API: PreloadAPI = {
   sendIntervalTask: async (task: IpcTask) =>
     await ipcRenderer.invoke('main:task:interval', task),
 
-  removeIntervalTask: async (serialized: string) =>
-    await ipcRenderer.invoke('app:interval:task:remove', serialized),
-
   updateIntervalTask: async (serialized: string) =>
     await ipcRenderer.invoke('app:interval:task:update', serialized),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -100,8 +100,8 @@ export const API: PreloadAPI = {
    * Interval subscriptions
    */
 
-  getPersistedIntervalTasks: async () =>
-    await ipcRenderer.invoke('app:interval:tasks:get'),
+  sendIntervalTask: async (task: IpcTask) =>
+    await ipcRenderer.invoke('main:task:interval', task),
 
   clearPersistedIntervalTasks: async () =>
     await ipcRenderer.invoke('app:interval:tasks:clear'),

--- a/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -28,6 +28,7 @@ import { handleApiDisconnects } from '@/utils/ApiUtils';
 import type { BootstrappingInterface } from './types';
 import type { ChainID } from '@/types/chains';
 import type { IntervalSubscription } from '@/types/subscriptions';
+import type { IpcTask } from '@/types/communication';
 
 export const BootstrappingContext = createContext<BootstrappingInterface>(
   defaultBootstrappingContext
@@ -316,7 +317,8 @@ export const BootstrappingProvider = ({
 
   /// Utility.
   const initIntervalsController = async (isOnline: boolean) => {
-    const serialized = await window.myAPI.getPersistedIntervalTasks();
+    const ipcTask: IpcTask = { action: 'interval:task:get', data: null };
+    const serialized = (await window.myAPI.sendIntervalTask(ipcTask)) || '[]';
     const tasks: IntervalSubscription[] = JSON.parse(serialized);
 
     // Insert subscriptions and start interval if online.

--- a/src/renderer/contexts/main/IntervalTasksManager/index.tsx
+++ b/src/renderer/contexts/main/IntervalTasksManager/index.tsx
@@ -104,7 +104,10 @@ export const IntervalTasksManagerProvider = ({
     removeIntervalSubscription(task);
 
     // Remove task from store.
-    await window.myAPI.removeIntervalTask(JSON.stringify(task));
+    await window.myAPI.sendIntervalTask({
+      action: 'interval:task:remove',
+      data: { serialized: JSON.stringify(task) },
+    });
 
     // Send message to OpenGov window to update its subscription state.
     ConfigRenderer.portToOpenGov.postMessage({

--- a/src/renderer/contexts/main/IntervalTasksManager/index.tsx
+++ b/src/renderer/contexts/main/IntervalTasksManager/index.tsx
@@ -58,7 +58,10 @@ export const IntervalTasksManagerProvider = ({
     });
 
     // Update persisted task in store.
-    await window.myAPI.updateIntervalTask(JSON.stringify(task));
+    await window.myAPI.sendIntervalTask({
+      action: 'interval:task:update',
+      data: { serialized: JSON.stringify(task) },
+    });
   };
 
   /// Handle clicking os notifications toggle for interval subscriptions.
@@ -85,7 +88,10 @@ export const IntervalTasksManagerProvider = ({
     });
 
     // Update persisted task in store.
-    await window.myAPI.updateIntervalTask(JSON.stringify(task));
+    await window.myAPI.sendIntervalTask({
+      action: 'interval:task:update',
+      data: { serialized: JSON.stringify(task) },
+    });
   };
 
   /// Handle removing an interval subscription.
@@ -148,7 +154,10 @@ export const IntervalTasksManagerProvider = ({
       });
 
       // Update persisted task in store.
-      await window.myAPI.updateIntervalTask(JSON.stringify(task));
+      await window.myAPI.sendIntervalTask({
+        action: 'interval:task:update',
+        data: { serialized: JSON.stringify(task) },
+      });
     }
   };
 

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -522,7 +522,10 @@ export const useMainMessagePorts = () => {
     addIntervalSubscription({ ...task });
 
     // Persist task to store.
-    await window.myAPI.persistIntervalTask(JSON.stringify(task));
+    await window.myAPI.sendIntervalTask({
+      action: 'interval:task:add',
+      data: { serialized: JSON.stringify(task) },
+    });
   };
 
   /**
@@ -566,7 +569,10 @@ export const useMainMessagePorts = () => {
       addIntervalSubscription({ ...task });
 
       // Persist task to store.
-      await window.myAPI.persistIntervalTask(JSON.stringify(task));
+      await window.myAPI.sendIntervalTask({
+        action: 'interval:task:add',
+        data: { serialized: JSON.stringify(task) },
+      });
     }
   };
 

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -546,7 +546,10 @@ export const useMainMessagePorts = () => {
     removeIntervalSubscription({ ...task });
 
     // Remove task from store.
-    await window.myAPI.removeIntervalTask(JSON.stringify(task));
+    await window.myAPI.sendIntervalTask({
+      action: 'interval:task:remove',
+      data: { serialized: JSON.stringify(task) },
+    });
   };
 
   /**
@@ -596,7 +599,10 @@ export const useMainMessagePorts = () => {
       removeIntervalSubscription({ ...task });
 
       // Remove task from store.
-      await window.myAPI.removeIntervalTask(JSON.stringify(task));
+      await window.myAPI.sendIntervalTask({
+        action: 'interval:task:remove',
+        data: { serialized: JSON.stringify(task) },
+      });
     }
   };
 

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -294,7 +294,10 @@ export const Permissions = ({
         },
       });
 
-      await window.myAPI.updateIntervalTask(JSON.stringify(task));
+      await window.myAPI.sendIntervalTask({
+        action: 'interval:task:update',
+        data: { serialized: JSON.stringify(task) },
+      });
     }
   };
 

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -15,12 +15,18 @@ export interface PortPair {
 }
 
 export interface IpcTask {
-  action:
-    | 'raw-account:persist'
+  action: // Addresses
+  | 'raw-account:persist'
     | 'raw-account:delete'
     | 'raw-account:add'
     | 'raw-account:remove'
     | 'raw-account:get'
-    | 'raw-account:rename';
+    | 'raw-account:rename'
+    // Interval Subscriptions
+    | 'interval:task:get'
+    | 'interval:task:clear'
+    | 'interval:task:add'
+    | 'interval:task:remove'
+    | 'interval:task:update';
   data: AnyData;
 }

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -32,8 +32,6 @@ export interface PreloadAPI {
     callback: (_: IpcRendererEvent, serialised: string) => void
   ) => Electron.IpcRenderer;
 
-  clearPersistedIntervalTasks: () => Promise<string>;
-
   persistIntervalTask: ApiPersistIntervalTask;
   removeIntervalTask: ApiRemoveIntervalTask;
   updateIntervalTask: ApiUpdateIntervalTask;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -32,7 +32,6 @@ export interface PreloadAPI {
     callback: (_: IpcRendererEvent, serialised: string) => void
   ) => Electron.IpcRenderer;
 
-  removeIntervalTask: ApiRemoveIntervalTask;
   updateIntervalTask: ApiUpdateIntervalTask;
 
   getWindowId: () => string;
@@ -197,5 +196,4 @@ type ApiReportStaleEvent = (
 
 type ApiInitOnlineStatus = () => Promise<void>;
 
-type ApiRemoveIntervalTask = (serialized: string) => Promise<void>;
 type ApiUpdateIntervalTask = (serialized: string) => Promise<void>;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -32,7 +32,6 @@ export interface PreloadAPI {
     callback: (_: IpcRendererEvent, serialised: string) => void
   ) => Electron.IpcRenderer;
 
-  persistIntervalTask: ApiPersistIntervalTask;
   removeIntervalTask: ApiRemoveIntervalTask;
   updateIntervalTask: ApiUpdateIntervalTask;
 
@@ -198,6 +197,5 @@ type ApiReportStaleEvent = (
 
 type ApiInitOnlineStatus = () => Promise<void>;
 
-type ApiPersistIntervalTask = (serialized: string) => Promise<void>;
 type ApiRemoveIntervalTask = (serialized: string) => Promise<void>;
 type ApiUpdateIntervalTask = (serialized: string) => Promise<void>;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -32,8 +32,6 @@ export interface PreloadAPI {
     callback: (_: IpcRendererEvent, serialised: string) => void
   ) => Electron.IpcRenderer;
 
-  updateIntervalTask: ApiUpdateIntervalTask;
-
   getWindowId: () => string;
 
   exportAppData: () => Promise<ExportResult>;
@@ -195,5 +193,3 @@ type ApiReportStaleEvent = (
 ) => Electron.IpcRenderer;
 
 type ApiInitOnlineStatus = () => Promise<void>;
-
-type ApiUpdateIntervalTask = (serialized: string) => Promise<void>;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -18,6 +18,7 @@ import type { ExportResult, ImportResult } from './backup';
 
 export interface PreloadAPI {
   rawAccountTask: (task: IpcTask) => Promise<void | string>;
+  sendIntervalTask: (task: IpcTask) => Promise<void | string>;
 
   getOsPlatform: () => Promise<string>;
 
@@ -31,7 +32,6 @@ export interface PreloadAPI {
     callback: (_: IpcRendererEvent, serialised: string) => void
   ) => Electron.IpcRenderer;
 
-  getPersistedIntervalTasks: () => Promise<string>;
   clearPersistedIntervalTasks: () => Promise<string>;
 
   persistIntervalTask: ApiPersistIntervalTask;


### PR DESCRIPTION
# Summary

Refactor the preload API to handle interval tasks with a generic IPC message.

Simplifies the preload API and unifies interval task handling logic within the main process.