### PR TITLE
chore: generic subscription task ipcs

### DIFF
--- a/src/controller/main/SubscriptionsController.ts
+++ b/src/controller/main/SubscriptionsController.ts
@@ -27,7 +27,7 @@ import type { SubscriptionTask } from '@/types/subscriptions';
 export class SubscriptionsController {
   /**
    * @name process
-   * @summary Process an address IPC task.
+   * @summary Process a subscription IPC task.
    */
   static process(task: IpcTask): string | void {
     switch (task.action) {
@@ -61,13 +61,16 @@ export class SubscriptionsController {
   }
 
   /**
-   * @name updateChainTaskInStore
-   * @summary Called when a chain subscription task is received from renderer.
+   * @name updateAccountTaskInStore
+   * @summary Update a persisted account task with the received data.
    */
-  private static updateChainTaskInStore(task: SubscriptionTask) {
-    const key = ConfigMain.getChainSubscriptionsStorageKey();
+  private static updateAccountTaskInStore(
+    task: SubscriptionTask,
+    account: FlattenedAccountData
+  ) {
+    const key = ConfigMain.getSubscriptionsStorageKeyFor(account.address);
 
-    // Deserialize all tasks from store.
+    // Deserialize the account's tasks from store.
     const tasks: SubscriptionTask[] = (store as Record<string, AnyJson>).get(
       key
     )
@@ -78,16 +81,13 @@ export class SubscriptionsController {
   }
 
   /**
-   * @name updateAccountTaskInStore
-   * @summary Called when an account subscription task is received from renderer.
+   * @name updateChainTaskInStore
+   * @summary Update a persisted chain task with the received data.
    */
-  private static updateAccountTaskInStore(
-    task: SubscriptionTask,
-    account: FlattenedAccountData
-  ) {
-    const key = ConfigMain.getSubscriptionsStorageKeyFor(account.address);
+  private static updateChainTaskInStore(task: SubscriptionTask) {
+    const key = ConfigMain.getChainSubscriptionsStorageKey();
 
-    // Deserialize the account's tasks from store.
+    // Deserialize all tasks from store.
     const tasks: SubscriptionTask[] = (store as Record<string, AnyJson>).get(
       key
     )

--- a/src/controller/main/SubscriptionsController.ts
+++ b/src/controller/main/SubscriptionsController.ts
@@ -4,8 +4,9 @@
 import { store } from '@/main';
 import { Config as ConfigMain } from '@/config/processes/main';
 import type { AnyData, AnyJson } from '@/types/misc';
-import type { SubscriptionTask } from '@/types/subscriptions';
 import type { FlattenedAccountData } from '@/types/accounts';
+import type { IpcTask } from '@/types/communication';
+import type { SubscriptionTask } from '@/types/subscriptions';
 
 /**
  * Key naming convention of subscription tasks in store:
@@ -25,10 +26,45 @@ import type { FlattenedAccountData } from '@/types/accounts';
 
 export class SubscriptionsController {
   /**
+   * @name process
+   * @summary Process an address IPC task.
+   */
+  static process(task: IpcTask): string | void {
+    switch (task.action) {
+      // Get an account's persisted tasks in serialized form.
+      case 'subscriptions:account:getAll': {
+        const { address } = task.data;
+        const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
+        const stored = (store as Record<string, AnyData>).get(key) as string;
+        return stored ? stored : '';
+      }
+      // Get persisted chain subscription tasks.
+      case 'subscriptions:chain:getAll': {
+        const key = ConfigMain.getChainSubscriptionsStorageKey();
+        const tasks = (store as Record<string, AnyData>).get(key) as string;
+        return tasks ? tasks : '';
+      }
+      // Update a persisted account subscription task.
+      case 'subscriptions:account:update': {
+        const account: FlattenedAccountData = JSON.parse(task.data.serAccount);
+        const subTask: SubscriptionTask = JSON.parse(task.data.serTask);
+        this.updateAccountTaskInStore(subTask, account);
+        return;
+      }
+      // Update a persisted chain subscription task.
+      case 'subscriptions:chain:update': {
+        const { serTask }: { serTask: string } = task.data;
+        this.updateChainTaskInStore(JSON.parse(serTask));
+        return;
+      }
+    }
+  }
+
+  /**
    * @name updateChainTaskInStore
    * @summary Called when a chain subscription task is received from renderer.
    */
-  static updateChainTaskInStore(task: SubscriptionTask) {
+  private static updateChainTaskInStore(task: SubscriptionTask) {
     const key = ConfigMain.getChainSubscriptionsStorageKey();
 
     // Deserialize all tasks from store.
@@ -45,7 +81,7 @@ export class SubscriptionsController {
    * @name updateAccountTaskInStore
    * @summary Called when an account subscription task is received from renderer.
    */
-  static updateAccountTaskInStore(
+  private static updateAccountTaskInStore(
     task: SubscriptionTask,
     account: FlattenedAccountData
   ) {

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -71,7 +71,7 @@ export class AccountsController {
       for (const account of accounts) {
         const stored =
           (await window.myAPI.sendSubscriptionTask({
-            action: 'subscriptions:tasks:getAll',
+            action: 'subscriptions:account:getAll',
             data: { address: account.address },
           })) || '';
 

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -69,9 +69,11 @@ export class AccountsController {
 
     for (const accounts of this.accounts.values()) {
       for (const account of accounts) {
-        const stored = await window.myAPI.getPersistedAccountTasks(
-          account.flatten()
-        );
+        const stored =
+          (await window.myAPI.sendSubscriptionTask({
+            action: 'subscriptions:tasks:getAll',
+            data: { address: account.address },
+          })) || '';
 
         const tasks: SubscriptionTask[] =
           stored !== '' ? JSON.parse(stored) : [];

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -148,10 +148,13 @@ export class AccountsController {
       // Remove tasks from electron store.
       // TODO: Batch removal of task data in electron store.
       for (const task of tasks) {
-        await window.myAPI.updatePersistedAccountTask(
-          JSON.stringify(task),
-          JSON.stringify(account.flatten())
-        );
+        await window.myAPI.sendSubscriptionTask({
+          action: 'subscriptions:account:update',
+          data: {
+            serAccount: JSON.stringify(account.flatten()),
+            serTask: JSON.stringify(task),
+          },
+        });
       }
     }
   }

--- a/src/controller/renderer/SubscriptionsController.ts
+++ b/src/controller/renderer/SubscriptionsController.ts
@@ -41,7 +41,11 @@ export class SubscriptionsController {
     this.chainSubscriptions = new QueryMultiWrapper();
 
     // Send IPC message to get chain tasks from store.
-    const serialized = await window.myAPI.getChainSubscriptions();
+    const serialized =
+      (await window.myAPI.sendSubscriptionTask({
+        action: 'subscriptions:chain:getAll',
+        data: null,
+      })) || '';
 
     // Deserialize fetched chain tasks.
     const tasks: SubscriptionTask[] =

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,6 +378,12 @@ app.whenReady().then(async () => {
         const tasks = (store as Record<string, AnyData>).get(key) as string;
         return tasks ? tasks : '';
       }
+      // Update a persisted account subscription task.
+      case 'subscriptions:account:update': {
+        const account: FlattenedAccountData = JSON.parse(task.data.serAccount);
+        const subTask: SubscriptionTask = JSON.parse(task.data.serTask);
+        SubscriptionsController.updateAccountTaskInStore(subTask, account);
+      }
     }
   });
 
@@ -386,16 +392,6 @@ app.whenReady().then(async () => {
     'app:subscriptions:chain:update',
     async (_, task: SubscriptionTask) => {
       SubscriptionsController.updateChainTaskInStore(task);
-    }
-  );
-
-  // Update a persisted account subscription task.
-  ipcMain.handle(
-    'app:subscriptions:account:update',
-    async (_, serializedTask: string, serializedAccount: string) => {
-      const task: SubscriptionTask = JSON.parse(serializedTask);
-      const account: FlattenedAccountData = JSON.parse(serializedAccount);
-      SubscriptionsController.updateAccountTaskInStore(task, account);
     }
   );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -366,20 +366,19 @@ app.whenReady().then(async () => {
   ipcMain.handle('main:task:subscription', async (_, task: IpcTask) => {
     switch (task.action) {
       // Get an account's persisted tasks in serialized form.
-      case 'subscriptions:tasks:getAll': {
+      case 'subscriptions:account:getAll': {
         const { address } = task.data;
         const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
         const stored = (store as Record<string, AnyData>).get(key) as string;
         return stored ? stored : '';
       }
+      // Get persisted chain subscription tasks.
+      case 'subscriptions:chain:getAll': {
+        const key = ConfigMain.getChainSubscriptionsStorageKey();
+        const tasks = (store as Record<string, AnyData>).get(key) as string;
+        return tasks ? tasks : '';
+      }
     }
-  });
-
-  // Get persisted chain subscription tasks.
-  ipcMain.handle('app:subscriptions:chain:get', async () => {
-    const key = ConfigMain.getChainSubscriptionsStorageKey();
-    const tasks = (store as Record<string, AnyData>).get(key) as string;
-    return tasks ? tasks : '';
   });
 
   // Update a persisted chain subscription task.

--- a/src/main.ts
+++ b/src/main.ts
@@ -383,19 +383,21 @@ app.whenReady().then(async () => {
         const account: FlattenedAccountData = JSON.parse(task.data.serAccount);
         const subTask: SubscriptionTask = JSON.parse(task.data.serTask);
         SubscriptionsController.updateAccountTaskInStore(subTask, account);
+        return;
+      }
+      // Update a persisted chain subscription task.
+      case 'subscriptions:chain:update': {
+        const { serTask }: { serTask: string } = task.data;
+        SubscriptionsController.updateChainTaskInStore(JSON.parse(serTask));
+        return;
       }
     }
   });
 
-  // Update a persisted chain subscription task.
-  ipcMain.handle(
-    'app:subscriptions:chain:update',
-    async (_, task: SubscriptionTask) => {
-      SubscriptionsController.updateChainTaskInStore(task);
-    }
-  );
+  /**
+   * OS Notifications
+   */
 
-  // Show native notifications.
   ipcMain.on(
     'app:notification:show',
     (_, { title, body, subtitle }: NotificationData) => {
@@ -406,6 +408,7 @@ app.whenReady().then(async () => {
   /**
    * Interval subscriptions
    */
+
   ipcMain.handle('main:task:interval', async (_, task: IpcTask) =>
     IntervalsController.process(task)
   );
@@ -413,6 +416,7 @@ app.whenReady().then(async () => {
   /**
    * Platform
    */
+
   ipcMain.handle('app:platform:get', async () => process.platform as string);
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -363,15 +363,17 @@ app.whenReady().then(async () => {
    * Subscriptions
    */
 
-  // Send stringified persisted account tasks to frontend.
-  ipcMain.handle(
-    'app:accounts:tasks:get',
-    async (_, account: FlattenedAccountData) => {
-      const key = ConfigMain.getSubscriptionsStorageKeyFor(account.address);
-      const stored = (store as Record<string, AnyData>).get(key) as string;
-      return stored ? stored : '';
+  ipcMain.handle('main:task:subscription', async (_, task: IpcTask) => {
+    switch (task.action) {
+      // Get an account's persisted tasks in serialized form.
+      case 'subscriptions:tasks:getAll': {
+        const { address } = task.data;
+        const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
+        const stored = (store as Record<string, AnyData>).get(key) as string;
+        return stored ? stored : '';
+      }
     }
-  );
+  });
 
   // Get persisted chain subscription tasks.
   ipcMain.handle('app:subscriptions:chain:get', async () => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -13,7 +13,6 @@ import type {
 } from '@/types/reporter';
 import type { AnyJson } from './types/misc';
 import type { ChainID } from './types/chains';
-import type { FlattenedAccountData } from './types/accounts';
 import type { IpcTask } from './types/communication';
 import type { SettingAction } from './renderer/screens/Settings/types';
 import type { SubscriptionTask } from './types/subscriptions';
@@ -97,6 +96,12 @@ export const API: PreloadAPI = {
     ipcRenderer.on('settings:workspace:receive', callback),
 
   /**
+   * Account subscriptions
+   */
+  sendSubscriptionTask: async (task: IpcTask) =>
+    await ipcRenderer.invoke('main:task:subscription', task),
+
+  /**
    * Interval subscriptions
    */
 
@@ -142,10 +147,6 @@ export const API: PreloadAPI = {
   // Get persisted accounts from state.
   getPersistedAccounts: async () =>
     await ipcRenderer.invoke('app:accounts:get'),
-
-  // Get persisted subscription tasks for account.
-  getPersistedAccountTasks: async (account: FlattenedAccountData) =>
-    await ipcRenderer.invoke('app:accounts:tasks:get', account),
 
   // Overwrite persisted accounts in store.
   setPersistedAccounts: (accounts: string) =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -170,9 +170,6 @@ export const API: PreloadAPI = {
   reportStaleEvent: (callback) =>
     ipcRenderer.on('renderer:event:stale', callback),
 
-  getChainSubscriptions: async () =>
-    await ipcRenderer.invoke('app:subscriptions:chain:get'),
-
   updatePersistedChainTask: async (task: SubscriptionTask) =>
     await ipcRenderer.invoke('app:subscriptions:chain:update', task),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -173,16 +173,6 @@ export const API: PreloadAPI = {
   updatePersistedChainTask: async (task: SubscriptionTask) =>
     await ipcRenderer.invoke('app:subscriptions:chain:update', task),
 
-  updatePersistedAccountTask: async (
-    serializedTask: string,
-    serializedAccount: string
-  ) =>
-    await ipcRenderer.invoke(
-      'app:subscriptions:account:update',
-      serializedTask,
-      serializedAccount
-    ),
-
   showNotification: (content: {
     title: string;
     body: string;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -15,7 +15,6 @@ import type { AnyJson } from './types/misc';
 import type { ChainID } from './types/chains';
 import type { IpcTask } from './types/communication';
 import type { SettingAction } from './renderer/screens/Settings/types';
-import type { SubscriptionTask } from './types/subscriptions';
 
 console.log(global.location.search);
 
@@ -169,9 +168,6 @@ export const API: PreloadAPI = {
 
   reportStaleEvent: (callback) =>
     ipcRenderer.on('renderer:event:stale', callback),
-
-  updatePersistedChainTask: async (task: SubscriptionTask) =>
-    await ipcRenderer.invoke('app:subscriptions:chain:update', task),
 
   showNotification: (content: {
     title: string;

--- a/src/renderer/contexts/main/Subscriptions/index.tsx
+++ b/src/renderer/contexts/main/Subscriptions/index.tsx
@@ -161,7 +161,10 @@ export const SubscriptionsProvider = ({
       case 'chain': {
         // Update persisted state and React state for tasks.
         for (const task of tasks) {
-          await window.myAPI.updatePersistedChainTask(task);
+          await window.myAPI.sendSubscriptionTask({
+            action: 'subscriptions:chain:update',
+            data: { serTask: JSON.stringify(task) },
+          });
           updateTask('chain', task);
           updateRenderedSubscriptions(task);
         }
@@ -234,7 +237,10 @@ export const SubscriptionsProvider = ({
       case 'chain': {
         // Subscribe to and persist task.
         await SubscriptionsController.subscribeChainTask(task);
-        await window.myAPI.updatePersistedChainTask(task);
+        await window.myAPI.sendSubscriptionTask({
+          action: 'subscriptions:chain:update',
+          data: { serTask: JSON.stringify(task) },
+        });
 
         // Update react state.
         updateTask('chain', task);

--- a/src/renderer/contexts/main/Subscriptions/index.tsx
+++ b/src/renderer/contexts/main/Subscriptions/index.tsx
@@ -184,10 +184,14 @@ export const SubscriptionsProvider = ({
 
         // Update persisted state and React state for tasks.
         for (const task of tasks) {
-          await window.myAPI.updatePersistedAccountTask(
-            JSON.stringify(task),
-            JSON.stringify(account.flatten())
-          );
+          await window.myAPI.sendSubscriptionTask({
+            action: 'subscriptions:account:update',
+            data: {
+              serAccount: JSON.stringify(account.flatten()),
+              serTask: JSON.stringify(task),
+            },
+          });
+
           updateTask('account', task, task.account?.address);
           updateRenderedSubscriptions(task);
         }
@@ -250,10 +254,13 @@ export const SubscriptionsProvider = ({
         // Subscribe to and persist the task.
         await SubscriptionsController.subscribeAccountTask(task, account);
 
-        await window.myAPI.updatePersistedAccountTask(
-          JSON.stringify(task),
-          JSON.stringify(account.flatten())
-        );
+        await window.myAPI.sendSubscriptionTask({
+          action: 'subscriptions:account:update',
+          data: {
+            serAccount: JSON.stringify(account.flatten()),
+            serTask: JSON.stringify(task),
+          },
+        });
 
         // Update react state.
         updateTask('account', task, task.account?.address);

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -127,10 +127,14 @@ export const useMainMessagePorts = () => {
 
       // Update persisted state and React state for tasks.
       for (const task of tasks) {
-        await window.myAPI.updatePersistedAccountTask(
-          JSON.stringify(task),
-          JSON.stringify(account.flatten())
-        );
+        await window.myAPI.sendSubscriptionTask({
+          action: 'subscriptions:account:update',
+          data: {
+            serAccount: JSON.stringify(account.flatten()),
+            serTask: JSON.stringify(task),
+          },
+        });
+
         updateTask('account', task, task.account?.address);
         updateRenderedSubscriptions(task);
       }

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -634,7 +634,10 @@ export const useMainMessagePorts = () => {
 
       // Update state.
       for (const activeTask of active) {
-        await window.myAPI.updatePersistedChainTask(activeTask);
+        await window.myAPI.sendSubscriptionTask({
+          action: 'subscriptions:chain:update',
+          data: { serTask: JSON.stringify(activeTask) },
+        });
         updateTask('chain', activeTask);
         updateRenderedSubscriptions(activeTask);
       }

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -349,10 +349,13 @@ export const Permissions = ({
       task.enableOsNotifications = checked;
 
       // Update persisted task data.
-      await window.myAPI.updatePersistedAccountTask(
-        JSON.stringify(task),
-        JSON.stringify(task.account!)
-      );
+      await window.myAPI.sendSubscriptionTask({
+        action: 'subscriptions:account:update',
+        data: {
+          serAccount: JSON.stringify(task.account!),
+          serTask: JSON.stringify(task),
+        },
+      });
 
       // Update react state for tasks.
       updateTask('account', task, task.account.address);

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -24,6 +24,7 @@ export interface IpcTask {
     | 'raw-account:rename'
     // Account subscriptions
     | 'subscriptions:account:getAll'
+    | 'subscriptions:account:update'
     | 'subscriptions:chain:getAll'
     // Interval Subscriptions
     | 'interval:task:get'

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -26,6 +26,7 @@ export interface IpcTask {
     | 'subscriptions:account:getAll'
     | 'subscriptions:account:update'
     | 'subscriptions:chain:getAll'
+    | 'subscriptions:chain:update'
     // Interval Subscriptions
     | 'interval:task:get'
     | 'interval:task:clear'

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -23,7 +23,8 @@ export interface IpcTask {
     | 'raw-account:get'
     | 'raw-account:rename'
     // Account subscriptions
-    | 'subscriptions:tasks:getAll'
+    | 'subscriptions:account:getAll'
+    | 'subscriptions:chain:getAll'
     // Interval Subscriptions
     | 'interval:task:get'
     | 'interval:task:clear'

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -22,6 +22,8 @@ export interface IpcTask {
     | 'raw-account:remove'
     | 'raw-account:get'
     | 'raw-account:rename'
+    // Account subscriptions
+    | 'subscriptions:tasks:getAll'
     // Interval Subscriptions
     | 'interval:task:get'
     | 'interval:task:clear'

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AccountSource, FlattenedAccountData } from './accounts';
+import type { AccountSource } from './accounts';
 import type { AnyJson } from './misc';
 import type { ChainID } from './chains';
 import type { DismissEvent, EventCallback, NotificationData } from './reporter';
@@ -17,8 +17,9 @@ import type { WorkspaceItem } from './developerConsole/workspaces';
 import type { ExportResult, ImportResult } from './backup';
 
 export interface PreloadAPI {
-  rawAccountTask: (task: IpcTask) => Promise<void | string>;
-  sendIntervalTask: (task: IpcTask) => Promise<void | string>;
+  rawAccountTask: (task: IpcTask) => Promise<string | void>;
+  sendIntervalTask: (task: IpcTask) => Promise<string | void>;
+  sendSubscriptionTask: (task: IpcTask) => Promise<string | void>;
 
   getOsPlatform: () => Promise<string>;
 
@@ -49,7 +50,6 @@ export interface PreloadAPI {
 
   getOnlineStatus: ApiGetOnlineStatus;
   getPersistedAccounts: ApiGetPersistedAccounts;
-  getPersistedAccountTasks: ApiGetPersistedAccountTasks;
   setPersistedAccounts: ApiSetPersistedAccounts;
 
   persistEvent: ApiPersistEvent;
@@ -157,10 +157,6 @@ type ApiInitializeAppOffline = (
 type ApiGetOnlineStatus = () => Promise<boolean>;
 
 type ApiGetPersistedAccounts = () => Promise<string>;
-
-type ApiGetPersistedAccountTasks = (
-  account: FlattenedAccountData
-) => Promise<string>;
 
 type ApiSetPersistedAccounts = (accounts: string) => Promise<void>;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -56,7 +56,6 @@ export interface PreloadAPI {
   updateAccountNameForEventsAndTasks: ApiUpdateAccountNameForEventsAndTasks;
   markEventStale: ApiMarkEventStale;
   reportStaleEvent: ApiReportStaleEvent;
-  getChainSubscriptions: ApiGetChainSubscriptions;
   updatePersistedChainTask: ApiUpdatePersistedChainTask;
   updatePersistedAccountTask: ApiUpdatePersistedAccountTask;
   showNotification: ApiShowNotification;
@@ -165,8 +164,6 @@ type ApiPersistEvent = (
   notification: NotificationData | null,
   isOneShot?: boolean
 ) => void;
-
-type ApiGetChainSubscriptions = () => Promise<string>;
 
 type ApiUpdatePersistedChainTask = (task: SubscriptionTask) => Promise<void>;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -8,7 +8,6 @@ import type { DismissEvent, EventCallback, NotificationData } from './reporter';
 import type { LedgerTask } from './ledger';
 import type { IpcTask } from './communication';
 import type { IpcRendererEvent } from 'electron';
-import type { SubscriptionTask } from './subscriptions';
 import type {
   PersistedSettings,
   SettingAction,
@@ -56,7 +55,6 @@ export interface PreloadAPI {
   updateAccountNameForEventsAndTasks: ApiUpdateAccountNameForEventsAndTasks;
   markEventStale: ApiMarkEventStale;
   reportStaleEvent: ApiReportStaleEvent;
-  updatePersistedChainTask: ApiUpdatePersistedChainTask;
   showNotification: ApiShowNotification;
 
   quitApp: ApiEmptyPromiseRequest;
@@ -163,8 +161,6 @@ type ApiPersistEvent = (
   notification: NotificationData | null,
   isOneShot?: boolean
 ) => void;
-
-type ApiUpdatePersistedChainTask = (task: SubscriptionTask) => Promise<void>;
 
 type ApiShowNotification = (content: NotificationData) => void;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -57,7 +57,6 @@ export interface PreloadAPI {
   markEventStale: ApiMarkEventStale;
   reportStaleEvent: ApiReportStaleEvent;
   updatePersistedChainTask: ApiUpdatePersistedChainTask;
-  updatePersistedAccountTask: ApiUpdatePersistedAccountTask;
   showNotification: ApiShowNotification;
 
   quitApp: ApiEmptyPromiseRequest;
@@ -166,11 +165,6 @@ type ApiPersistEvent = (
 ) => void;
 
 type ApiUpdatePersistedChainTask = (task: SubscriptionTask) => Promise<void>;
-
-type ApiUpdatePersistedAccountTask = (
-  serializedTask: string,
-  serializedAccount: string
-) => Promise<void>;
 
 type ApiShowNotification = (content: NotificationData) => void;
 


### PR DESCRIPTION
Refactor the preload API to handle subscription tasks with a generic IPC message.

Simplifies the preload API and unifies subscription task handling logic within the main process.