### PR TITLE
chore: account ipcs refactor 

### DIFF
--- a/src/controller/main/AccountsController.ts
+++ b/src/controller/main/AccountsController.ts
@@ -1,0 +1,89 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { store } from '@/main';
+import { AppOrchestrator } from '@/orchestrators/AppOrchestrator';
+import type { AnyData } from '@/types/misc';
+import type { AccountSource } from '@/types/accounts';
+import type { ChainID } from '@/types/chains';
+import type { IpcTask } from '@/types/communication';
+
+export class AccountsController {
+  /**
+   * @name process
+   * @summary Process an address IPC task.
+   */
+  static async process(task: IpcTask): Promise<string | void> {
+    switch (task.action) {
+      case 'account:getAll': {
+        return this.getAll();
+      }
+      case 'account:import': {
+        await this.import(task);
+        return;
+      }
+      case 'account:remove': {
+        await this.remove(task);
+        return;
+      }
+      case 'account:updateAll': {
+        this.updateAll(task);
+        return;
+      }
+    }
+  }
+
+  /**
+   * @name import
+   * @summary Import a new account from an address.
+   */
+  private static async import(task: IpcTask) {
+    const {
+      chainId,
+      source,
+      address,
+      name,
+    }: {
+      chainId: ChainID;
+      source: AccountSource;
+      address: string;
+      name: string;
+    } = task.data;
+
+    await AppOrchestrator.next({
+      task: 'app:account:import',
+      data: { chainId, source, address, name },
+    });
+  }
+
+  /**
+   * @name remove
+   * @summary Remove a managed account.
+   */
+  private static async remove(task: IpcTask) {
+    const { address }: { address: string } = task.data;
+
+    await AppOrchestrator.next({
+      task: 'app:account:remove',
+      data: { address },
+    });
+  }
+
+  /**
+   * @name getAll
+   * @summary Send persisted accounts to frontend in serialized form.
+   */
+  private static getAll(): string {
+    const stored = (store as Record<string, AnyData>).get('imported_accounts');
+    return stored ? (stored as string) : '';
+  }
+
+  /**
+   * @name updateAll
+   * @summary Set persisted accounts in store.
+   */
+  private static updateAll(task: IpcTask) {
+    const { accounts }: { accounts: string } = task.data;
+    (store as Record<string, AnyData>).set('imported_accounts', accounts);
+  }
+}

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -30,7 +30,11 @@ export class AccountsController {
    * @summary Injects accounts into class from store.
    */
   static async initialize() {
-    const stored = await window.myAPI.getPersistedAccounts();
+    const stored: string =
+      (await window.myAPI.sendAccountTask({
+        action: 'account:getAll',
+        data: null,
+      })) || '';
 
     // Instantiate empty map if no accounts found in store.
     if (stored === '') {

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -1,7 +1,6 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { MainDebug } from '@/utils/DebugUtils';
 import { Account } from '@/model/Account';
 import type { ImportedAccounts } from '@/model/Account';
 import type { ChainID } from '@/types/chains';
@@ -12,8 +11,6 @@ import type {
 } from '@/types/accounts';
 import type { SubscriptionTask } from '@/types/subscriptions';
 import { TaskOrchestrator } from '@/orchestrators/TaskOrchestrator';
-
-const debug = MainDebug.extend('Accounts');
 
 /**
  * A static class to provide an interface for managing imported accounts.
@@ -206,7 +203,10 @@ export class AccountsController {
     );
 
     // Send IPC message to update persisted accounts in store.
-    await window.myAPI.setPersistedAccounts(this.serializeAccounts());
+    await window.myAPI.sendAccountTask({
+      action: 'account:updateAll',
+      data: { accounts: this.serializeAccounts() },
+    });
   };
 
   /**
@@ -292,9 +292,14 @@ export class AccountsController {
     this.accounts = accounts;
 
     // Send IPC message to update persisted imported accounts.
-    window.myAPI.setPersistedAccounts(this.serializeAccounts());
-
-    debug('🆕 Accounts updated: %o', accounts);
+    window.myAPI
+      .sendAccountTask({
+        action: 'account:updateAll',
+        data: { accounts: this.serializeAccounts() },
+      })
+      .then(() => {
+        console.log('🆕 Accounts updated');
+      });
   };
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import * as WdioUtils from '@/utils/WdioUtils';
 import type { AnyData, AnyJson } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
 import type { NotificationData } from '@/types/reporter';
-import type { FlattenedAccounts } from '@/types/accounts';
+import type { AccountSource, FlattenedAccounts } from '@/types/accounts';
 import type { IpcTask } from './types/communication';
 import type { IpcMainInvokeEvent } from 'electron';
 import type { SettingAction } from './renderer/screens/Settings/types';
@@ -221,8 +221,24 @@ app.whenReady().then(async () => {
   ipcMain.handle('main:task:account', async (_, task: IpcTask) => {
     switch (task.action) {
       case 'account:import': {
-        // TODO
-        break;
+        const {
+          chainId,
+          source,
+          address,
+          name,
+        }: {
+          chainId: ChainID;
+          source: AccountSource;
+          address: string;
+          name: string;
+        } = task.data;
+
+        await AppOrchestrator.next({
+          task: 'app:account:import',
+          data: { chainId, source, address, name },
+        });
+
+        return;
       }
       case 'account:remove': {
         // TODO
@@ -238,17 +254,6 @@ app.whenReady().then(async () => {
       }
     }
   });
-
-  // Attempt an account import.
-  ipcMain.on(
-    'app:account:import',
-    async (_, chain: ChainID, source, address, name) => {
-      await AppOrchestrator.next({
-        task: 'app:account:import',
-        data: { chain, source, address, name },
-      });
-    }
-  );
 
   // Attempt an account removal.
   ipcMain.on('app:account:remove', async (_, address) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,27 @@ app.whenReady().then(async () => {
    * Account management
    */
 
+  ipcMain.handle('main:task:account', async (_, task: IpcTask) => {
+    switch (task.action) {
+      case 'account:import': {
+        // TODO
+        break;
+      }
+      case 'account:remove': {
+        // TODO
+        break;
+      }
+      case 'account:getAll': {
+        // TODO
+        break;
+      }
+      case 'account:updateAll': {
+        // TODO
+        break;
+      }
+    }
+  });
+
   // Attempt an account import.
   ipcMain.on(
     'app:account:import',

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,24 +252,19 @@ app.whenReady().then(async () => {
 
         return;
       }
+      // Send persisted accounts to frontend in serialized form.
       case 'account:getAll': {
-        // TODO
-        break;
+        const stored = (store as Record<string, AnyData>).get(
+          'imported_accounts'
+        ) as string;
+
+        return stored ? (stored as string) : '';
       }
       case 'account:updateAll': {
         // TODO
         break;
       }
     }
-  });
-
-  // Send stringified persisted accounts to frontend.
-  ipcMain.handle('app:accounts:get', async () => {
-    const stored = (store as Record<string, AnyData>).get(
-      'imported_accounts'
-    ) as string;
-
-    return stored ? stored : '';
   });
 
   // Set persisted accounts in store.

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import * as WdioUtils from '@/utils/WdioUtils';
 import type { AnyData, AnyJson } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
 import type { NotificationData } from '@/types/reporter';
-import type { AccountSource, FlattenedAccounts } from '@/types/accounts';
+import type { AccountSource } from '@/types/accounts';
 import type { IpcTask } from './types/communication';
 import type { IpcMainInvokeEvent } from 'electron';
 import type { SettingAction } from './renderer/screens/Settings/types';
@@ -260,16 +260,13 @@ app.whenReady().then(async () => {
 
         return stored ? (stored as string) : '';
       }
+      // Set persisted accounts in store.
       case 'account:updateAll': {
-        // TODO
-        break;
+        const { accounts }: { accounts: string } = task.data;
+        (store as Record<string, AnyData>).set('imported_accounts', accounts);
+        return;
       }
     }
-  });
-
-  // Set persisted accounts in store.
-  ipcMain.handle('app:accounts:set', async (_, accounts: FlattenedAccounts) => {
-    (store as Record<string, AnyData>).set('imported_accounts', accounts);
   });
 
   /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,6 +220,7 @@ app.whenReady().then(async () => {
 
   ipcMain.handle('main:task:account', async (_, task: IpcTask) => {
     switch (task.action) {
+      // Import a new account from an address.
       case 'account:import': {
         const {
           chainId,
@@ -240,9 +241,16 @@ app.whenReady().then(async () => {
 
         return;
       }
+      // Remove a managed account.
       case 'account:remove': {
-        // TODO
-        break;
+        const { address }: { address: string } = task.data;
+
+        await AppOrchestrator.next({
+          task: 'app:account:remove',
+          data: { address },
+        });
+
+        return;
       }
       case 'account:getAll': {
         // TODO
@@ -253,14 +261,6 @@ app.whenReady().then(async () => {
         break;
       }
     }
-  });
-
-  // Attempt an account removal.
-  ipcMain.on('app:account:remove', async (_, address) => {
-    await AppOrchestrator.next({
-      task: 'app:account:remove',
-      data: { address },
-    });
   });
 
   // Send stringified persisted accounts to frontend.

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -202,10 +202,6 @@ export const API: PreloadAPI = {
   // Requests to main process to report imported accounts to all windows.
   requestImportedAccounts: () => ipcRenderer.send('app:request:accounts'),
 
-  // Attempts to remove an imported account.
-  removeImportedAccount: (account) =>
-    ipcRenderer.send('app:account:remove', account),
-
   // Reports a new event to all open windows.
   reportNewEvent: (callback) => ipcRenderer.on('renderer:event:new', callback),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -202,11 +202,6 @@ export const API: PreloadAPI = {
   // Requests to main process to report imported accounts to all windows.
   requestImportedAccounts: () => ipcRenderer.send('app:request:accounts'),
 
-  // Attempts to import a new account.
-  newAddressImported: (chain, source, address, name) => {
-    ipcRenderer.send('app:account:import', chain, source, address, name);
-  },
-
   // Attempts to remove an imported account.
   removeImportedAccount: (account) =>
     ipcRenderer.send('app:account:remove', account),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -151,10 +151,6 @@ export const API: PreloadAPI = {
   // Get online status from main.
   getOnlineStatus: async () => await ipcRenderer.invoke('app:online:status'),
 
-  // Get persisted accounts from state.
-  getPersistedAccounts: async () =>
-    await ipcRenderer.invoke('app:accounts:get'),
-
   // Overwrite persisted accounts in store.
   setPersistedAccounts: (accounts: string) =>
     ipcRenderer.invoke('app:accounts:set', accounts),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -59,6 +59,12 @@ export const API: PreloadAPI = {
     await ipcRenderer.invoke('main:raw-account', task),
 
   /**
+   * Accounts
+   */
+  sendAccountTask: async (task: IpcTask) =>
+    await ipcRenderer.invoke('main:task:account', task),
+
+  /**
    * Events
    */
   sendEventTask: (task: IpcTask) => ipcRenderer.send('main:task:event', task),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -151,10 +151,6 @@ export const API: PreloadAPI = {
   // Get online status from main.
   getOnlineStatus: async () => await ipcRenderer.invoke('app:online:status'),
 
-  // Overwrite persisted accounts in store.
-  setPersistedAccounts: (accounts: string) =>
-    ipcRenderer.invoke('app:accounts:set', accounts),
-
   reportStaleEvent: (callback) =>
     ipcRenderer.on('renderer:event:stale', callback),
 

--- a/src/renderer/contexts/main/Addresses/defaults.ts
+++ b/src/renderer/contexts/main/Addresses/defaults.ts
@@ -9,7 +9,7 @@ export const defaultAddressesContext: AddressesContextInterface = {
   setAddresses: (a) => {},
   getAddresses: () => [],
   addressExists: (a) => false,
-  importAddress: (n, a) => {},
+  importAddress: (n, a) => new Promise(() => {}),
   removeAddress: (n, a) => {},
   getAddress: (a) => null,
 };

--- a/src/renderer/contexts/main/Addresses/defaults.ts
+++ b/src/renderer/contexts/main/Addresses/defaults.ts
@@ -10,6 +10,6 @@ export const defaultAddressesContext: AddressesContextInterface = {
   getAddresses: () => [],
   addressExists: (a) => false,
   importAddress: (n, a) => new Promise(() => {}),
-  removeAddress: (n, a) => {},
+  removeAddress: (n, a) => new Promise(() => {}),
   getAddress: (a) => null,
 };

--- a/src/renderer/contexts/main/Addresses/index.tsx
+++ b/src/renderer/contexts/main/Addresses/index.tsx
@@ -44,7 +44,7 @@ export const AddressesProvider = ({
   };
 
   // Saves received address as an imported address.
-  const importAddress = (
+  const importAddress = async (
     chain: ChainID,
     source: AccountSource,
     address: string,
@@ -54,7 +54,15 @@ export const AddressesProvider = ({
     setAddresses(AccountsController.getAllFlattenedAccountData());
 
     // Have main process send OS notification.
-    window.myAPI.newAddressImported(chain, source, address, name);
+    await window.myAPI.sendAccountTask({
+      action: 'account:import',
+      data: {
+        chainId: chain,
+        source,
+        address,
+        name,
+      },
+    });
   };
 
   // Removes an imported address.

--- a/src/renderer/contexts/main/Addresses/index.tsx
+++ b/src/renderer/contexts/main/Addresses/index.tsx
@@ -66,12 +66,15 @@ export const AddressesProvider = ({
   };
 
   // Removes an imported address.
-  const removeAddress = (chain: ChainID, address: string) => {
+  const removeAddress = async (chain: ChainID, address: string) => {
     // Set address state.
     setAddresses(AccountsController.getAllFlattenedAccountData());
 
     // Remove persisted account from store.
-    window.myAPI.removeImportedAccount(address);
+    await window.myAPI.sendAccountTask({
+      action: 'account:remove',
+      data: { address },
+    });
   };
 
   // Get current addresses

--- a/src/renderer/contexts/main/Addresses/types.ts
+++ b/src/renderer/contexts/main/Addresses/types.ts
@@ -13,7 +13,12 @@ export interface AddressesContextInterface {
   setAddresses: (a: FlattenedAccounts) => void;
   getAddresses: () => FlattenedAccountData[];
   addressExists: (a: string) => boolean;
-  importAddress: (n: ChainID, s: AccountSource, a: string, b: string) => void;
+  importAddress: (
+    n: ChainID,
+    s: AccountSource,
+    a: string,
+    b: string
+  ) => Promise<void>;
   removeAddress: (n: ChainID, a: string) => void;
   getAddress: (a: string) => FlattenedAccountData | null;
 }

--- a/src/renderer/contexts/main/Addresses/types.ts
+++ b/src/renderer/contexts/main/Addresses/types.ts
@@ -19,6 +19,6 @@ export interface AddressesContextInterface {
     a: string,
     b: string
   ) => Promise<void>;
-  removeAddress: (n: ChainID, a: string) => void;
+  removeAddress: (n: ChainID, a: string) => Promise<void>;
   getAddress: (a: string) => FlattenedAccountData | null;
 }

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -186,7 +186,7 @@ export const useMainMessagePorts = () => {
     AccountsController.remove(chainId, address);
 
     // Remove address from context.
-    removeAddress(chainId, address);
+    await removeAddress(chainId, address);
 
     // Update account subscriptions data.
     setAccountSubscriptions(

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -149,7 +149,7 @@ export const useMainMessagePorts = () => {
     }
 
     // Add account to address context state.
-    importAddress(chainId, source, address, name);
+    await importAddress(chainId, source, address, name);
 
     // Send message back to import window to reset account's processing flag.
     ConfigRenderer.portToImport.postMessage({

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -33,6 +33,11 @@ export interface IpcTask {
     | 'interval:task:add'
     | 'interval:task:remove'
     | 'interval:task:update'
+    // Accounts
+    | 'account:import'
+    | 'account:remove'
+    | 'account:getAll'
+    | 'account:updateAll'
     // Events
     | 'events:persist'
     | 'events:remove'

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -1,7 +1,6 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AccountSource } from './accounts';
 import type { AnyJson } from './misc';
 import type { ChainID } from './chains';
 import type { DismissEvent, EventCallback, NotificationData } from './reporter';
@@ -66,7 +65,6 @@ export interface PreloadAPI {
   reportLedgerStatus: ApiReportLedgerStatus;
 
   requestImportedAccounts: ApiEmptyRequest;
-  newAddressImported: ApiNewAddressImported;
   removeImportedAccount: ApiRemoveImportedAccount;
 
   reportNewEvent: ApiReportNewEvent;
@@ -96,13 +94,6 @@ type ApiDoLedgerLoop = (
 type ApiReportLedgerStatus = (
   callback: (_: IpcRendererEvent, result: string) => void
 ) => Electron.IpcRenderer;
-
-export type ApiNewAddressImported = (
-  chain: ChainID,
-  source: AccountSource,
-  address: string,
-  name: string
-) => void;
 
 type ApiRemoveImportedAccount = (account: string) => void;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -51,8 +51,6 @@ export interface PreloadAPI {
   initializeAppOffline: ApiInitializeAppOffline;
 
   getOnlineStatus: ApiGetOnlineStatus;
-  setPersistedAccounts: ApiSetPersistedAccounts;
-
   showNotification: ApiShowNotification;
 
   quitApp: ApiEmptyPromiseRequest;
@@ -131,8 +129,6 @@ type ApiInitializeAppOffline = (
 ) => void;
 
 type ApiGetOnlineStatus = () => Promise<boolean>;
-
-type ApiSetPersistedAccounts = (accounts: string) => Promise<void>;
 
 type ApiShowNotification = (content: NotificationData) => void;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -22,6 +22,7 @@ export interface PreloadAPI {
   rawAccountTask: (task: IpcTask) => Promise<string | void>;
   sendIntervalTask: (task: IpcTask) => Promise<string | void>;
   sendSubscriptionTask: (task: IpcTask) => Promise<string | void>;
+  sendAccountTask: (task: IpcTask) => Promise<string | boolean>;
 
   sendEventTaskAsync: (task: IpcTask) => Promise<string | boolean>;
   sendEventTask: (task: IpcTask) => void;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -65,7 +65,6 @@ export interface PreloadAPI {
   reportLedgerStatus: ApiReportLedgerStatus;
 
   requestImportedAccounts: ApiEmptyRequest;
-  removeImportedAccount: ApiRemoveImportedAccount;
 
   reportNewEvent: ApiReportNewEvent;
   reportDismissEvent: ApiReportDismissEvent;
@@ -94,8 +93,6 @@ type ApiDoLedgerLoop = (
 type ApiReportLedgerStatus = (
   callback: (_: IpcRendererEvent, result: string) => void
 ) => Electron.IpcRenderer;
-
-type ApiRemoveImportedAccount = (account: string) => void;
 
 type ApiReportNewEvent = (
   callback: (_: IpcRendererEvent, eventData: EventCallback) => void

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -21,7 +21,7 @@ export interface PreloadAPI {
   rawAccountTask: (task: IpcTask) => Promise<string | void>;
   sendIntervalTask: (task: IpcTask) => Promise<string | void>;
   sendSubscriptionTask: (task: IpcTask) => Promise<string | void>;
-  sendAccountTask: (task: IpcTask) => Promise<string | boolean>;
+  sendAccountTask: (task: IpcTask) => Promise<string | void>;
 
   sendEventTaskAsync: (task: IpcTask) => Promise<string | boolean>;
   sendEventTask: (task: IpcTask) => void;
@@ -51,7 +51,6 @@ export interface PreloadAPI {
   initializeAppOffline: ApiInitializeAppOffline;
 
   getOnlineStatus: ApiGetOnlineStatus;
-  getPersistedAccounts: ApiGetPersistedAccounts;
   setPersistedAccounts: ApiSetPersistedAccounts;
 
   showNotification: ApiShowNotification;
@@ -132,8 +131,6 @@ type ApiInitializeAppOffline = (
 ) => void;
 
 type ApiGetOnlineStatus = () => Promise<boolean>;
-
-type ApiGetPersistedAccounts = () => Promise<string>;
 
 type ApiSetPersistedAccounts = (accounts: string) => Promise<void>;
 


### PR DESCRIPTION
Refactor the preload API to handle account tasks with a generic IPC message.

Simplifies the preload API and unifies account task handling logic within the main process.