### PR TITLE
chore: settings ipcs refactor

### DIFF
--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { MessageChannelMain } from 'electron';
-import { store } from '@/main';
 import type { AccountSource } from '@/types/accounts';
-import type { AnyData } from '@/types/misc';
-import type { PersistedSettings } from '@/renderer/screens/Settings/types';
 import type { PortPair, PortPairID } from '@/types/communication';
 import type { Rectangle, Tray } from 'electron';
 
@@ -69,31 +66,6 @@ export class Config {
 
     for (const id of ids) {
       Config.initPorts(id);
-    }
-  };
-
-  // Initialise default settings.
-  static getAppSettings = (): PersistedSettings => {
-    const key = Config._settingsStorageKey;
-
-    if (store.has(key)) {
-      // Return persisted settings.
-      return (store as Record<string, AnyData>).get(key);
-    } else {
-      const settings: PersistedSettings = {
-        appDocked: false,
-        appSilenceOsNotifications: false,
-        appShowOnAllWorkspaces: true,
-        appShowDebuggingSubscriptions: false,
-        appEnableAutomaticSubscriptions: true,
-        appEnablePolkassemblyApi: true,
-        appKeepOutdatedEvents: true,
-        appHideDockIcon: false,
-      };
-
-      // Persist default settings to store and return them.
-      (store as Record<string, AnyData>).set(key, settings);
-      return settings;
     }
   };
 

--- a/src/controller/main/EventsController.ts
+++ b/src/controller/main/EventsController.ts
@@ -1,7 +1,6 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { Config as ConfigMain } from '@/config/processes/main';
 import { getUid } from '@/utils/CryptoUtils';
 import { MainDebug } from '@/utils/DebugUtils';
 import { doRemoveOutdatedEvents, pushUniqueEvent } from '@/utils/EventUtils';
@@ -17,6 +16,7 @@ import type {
   NotificationData,
 } from '@/types/reporter';
 import type { IpcTask } from '@/types/communication';
+import { SettingsController } from './SettingsController';
 
 const debug = MainDebug.extend('EventsController');
 
@@ -76,7 +76,7 @@ export class EventsController {
         const { event, notification, isOneShot }: Target = task.data;
 
         // Remove any outdated events of the same type, if setting enabled.
-        if (!ConfigMain.getAppSettings().appKeepOutdatedEvents) {
+        if (!SettingsController.getAppSettings().appKeepOutdatedEvents) {
           this.removeOutdatedEvents(event);
         }
 

--- a/src/controller/main/SettingsController.ts
+++ b/src/controller/main/SettingsController.ts
@@ -2,16 +2,23 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Config } from '@/config/processes/main';
+import { hideDockIcon, showDockIcon } from '@/utils/SystemUtils';
 import { store } from '@/main';
+import { WindowsController } from '@/controller/main/WindowsController';
+import * as WindowUtils from '@/utils/WindowUtils';
 import type { AnyData } from '@/types/misc';
-import type { PersistedSettings } from '@/renderer/screens/Settings/types';
+import type { IpcTask } from '@/types/communication';
+import type {
+  PersistedSettings,
+  SettingAction,
+} from '@/renderer/screens/Settings/types';
 
 export class SettingsController {
   /**
    * @name getAppSettings
    * @summary Return the application settings structure, initialize if necessary.
    */
-  static getAppSettings = (): PersistedSettings => {
+  static getAppSettings(): PersistedSettings {
     const key = Config.settingsStorageKey;
 
     if (store.has(key)) {
@@ -33,5 +40,103 @@ export class SettingsController {
       (store as Record<string, AnyData>).set(key, settings);
       return settings;
     }
-  };
+  }
+
+  /**
+   * @name process
+   * @summary Process a one-way ipc task.
+   */
+  static process(task: IpcTask) {
+    switch (task.action) {
+      case 'settings:set:docked': {
+        WindowUtils.handleNewDockFlag(task.data.flag);
+        break;
+      }
+      case 'settings:toggle:allWorkspaces': {
+        this.toggleAllWorkspaces();
+        break;
+      }
+      // Toggle an app setting.
+      case 'settings:toggle': {
+        this.toggleSetting(task.data.settingAction as SettingAction);
+        break;
+      }
+    }
+  }
+
+  /**
+   * @name toggleAllWorkspaces
+   * @summary enable or disable showing the app on all workspaces (macos and linux).
+   */
+  private static toggleAllWorkspaces() {
+    if (!['darwin', 'linux'].includes(process.platform)) {
+      return;
+    }
+
+    // Get new flag.
+    const settings = this.getAppSettings();
+    const flag = !settings.appShowOnAllWorkspaces;
+
+    // Update windows.
+    settings.appShowOnAllWorkspaces = flag;
+    WindowsController.setVisibleOnAllWorkspaces(flag);
+
+    // Update storage.
+    const key = Config.settingsStorageKey;
+    (store as Record<string, AnyData>).set(key, settings);
+
+    // Re-hide dock if we're on macOS.
+    // Electron will show the dock icon after calling the workspaces API.
+    settings.appHideDockIcon && hideDockIcon();
+  }
+
+  /**
+   * @name toggleSetting
+   * @summary Toggle an application setting and persist new setting to store.
+   */
+  private static toggleSetting(settingAction: SettingAction) {
+    const settings = this.getAppSettings();
+
+    switch (settingAction) {
+      case 'settings:execute:showDebuggingSubscriptions': {
+        const flag = !settings.appShowDebuggingSubscriptions;
+        settings.appShowDebuggingSubscriptions = flag;
+        break;
+      }
+      case 'settings:execute:silenceOsNotifications': {
+        const flag = !settings.appSilenceOsNotifications;
+        settings.appSilenceOsNotifications = flag;
+        break;
+      }
+      case 'settings:execute:enableAutomaticSubscriptions': {
+        const flag = !settings.appEnableAutomaticSubscriptions;
+        settings.appEnableAutomaticSubscriptions = flag;
+        break;
+      }
+      case 'settings:execute:enablePolkassembly': {
+        const flag = !settings.appEnablePolkassemblyApi;
+        settings.appEnablePolkassemblyApi = flag;
+        break;
+      }
+      case 'settings:execute:keepOutdatedEvents': {
+        const flag = !settings.appKeepOutdatedEvents;
+        settings.appKeepOutdatedEvents = flag;
+        break;
+      }
+      case 'settings:execute:hideDockIcon': {
+        const flag = !settings.appHideDockIcon;
+        settings.appHideDockIcon = flag;
+
+        // Hide or show dock icon.
+        flag ? hideDockIcon() : showDockIcon();
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    const key = Config.settingsStorageKey;
+    (store as Record<string, AnyData>).set(key, settings);
+  }
 }

--- a/src/controller/main/SettingsController.ts
+++ b/src/controller/main/SettingsController.ts
@@ -56,7 +56,6 @@ export class SettingsController {
         this.toggleAllWorkspaces();
         break;
       }
-      // Toggle an app setting.
       case 'settings:toggle': {
         this.toggleSetting(task.data.settingAction as SettingAction);
         break;
@@ -66,7 +65,7 @@ export class SettingsController {
 
   /**
    * @name toggleAllWorkspaces
-   * @summary enable or disable showing the app on all workspaces (macos and linux).
+   * @summary Enable or disable showing the app on all workspaces (macos and linux).
    */
   private static toggleAllWorkspaces() {
     if (!['darwin', 'linux'].includes(process.platform)) {

--- a/src/controller/main/SettingsController.ts
+++ b/src/controller/main/SettingsController.ts
@@ -1,0 +1,37 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Config } from '@/config/processes/main';
+import { store } from '@/main';
+import type { AnyData } from '@/types/misc';
+import type { PersistedSettings } from '@/renderer/screens/Settings/types';
+
+export class SettingsController {
+  /**
+   * @name getAppSettings
+   * @summary Return the application settings structure, initialize if necessary.
+   */
+  static getAppSettings = (): PersistedSettings => {
+    const key = Config.settingsStorageKey;
+
+    if (store.has(key)) {
+      // Return persisted settings.
+      return (store as Record<string, AnyData>).get(key);
+    } else {
+      const settings: PersistedSettings = {
+        appDocked: false,
+        appSilenceOsNotifications: false,
+        appShowOnAllWorkspaces: true,
+        appShowDebuggingSubscriptions: false,
+        appEnableAutomaticSubscriptions: true,
+        appEnablePolkassemblyApi: true,
+        appKeepOutdatedEvents: true,
+        appHideDockIcon: false,
+      };
+
+      // Persist default settings to store and return them.
+      (store as Record<string, AnyData>).set(key, settings);
+      return settings;
+    }
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import type { IpcTask } from './types/communication';
 import type { IpcMainInvokeEvent } from 'electron';
 import type { SettingAction } from './renderer/screens/Settings/types';
 import { AccountsController } from './controller/main/AccountsController';
+import { SettingsController } from './controller/main/SettingsController';
 
 const debug = MainDebug;
 
@@ -136,7 +137,7 @@ app.whenReady().then(async () => {
   }
 
   // Hide dock icon if we're on mac OS.
-  const { appHideDockIcon } = ConfigMain.getAppSettings();
+  const { appHideDockIcon } = SettingsController.getAppSettings();
   appHideDockIcon && hideDockIcon();
 
   // ------------------------------
@@ -344,7 +345,7 @@ app.whenReady().then(async () => {
   // Get application docked flag.
   ipcMain.handle(
     'app:docked:get',
-    async () => ConfigMain.getAppSettings().appDocked
+    async () => SettingsController.getAppSettings().appDocked
   );
 
   // Set application docked flag.
@@ -353,7 +354,9 @@ app.whenReady().then(async () => {
   });
 
   // Get app settings.
-  ipcMain.handle('app:settings:get', async () => ConfigMain.getAppSettings());
+  ipcMain.handle('app:settings:get', async () =>
+    SettingsController.getAppSettings()
+  );
 
   ipcMain.on('app:set:workspaceVisibility', () => {
     if (!['darwin', 'linux'].includes(process.platform)) {
@@ -361,7 +364,7 @@ app.whenReady().then(async () => {
     }
 
     // Get new flag.
-    const settings = ConfigMain.getAppSettings();
+    const settings = SettingsController.getAppSettings();
     const flag = !settings.appShowOnAllWorkspaces;
 
     // Update windows.
@@ -379,7 +382,7 @@ app.whenReady().then(async () => {
 
   // Toggle an app setting.
   ipcMain.on('app:setting:toggle', (_, action: SettingAction) => {
-    const settings = ConfigMain.getAppSettings();
+    const settings = SettingsController.getAppSettings();
 
     switch (action) {
       case 'settings:execute:showDebuggingSubscriptions': {

--- a/src/main.ts
+++ b/src/main.ts
@@ -346,9 +346,13 @@ app.whenReady().then(async () => {
    * Settings
    */
 
-  // Set application docked flag.
-  ipcMain.on('app:docked:set', (_, flag) => {
-    WindowUtils.handleNewDockFlag(flag);
+  ipcMain.on('main:task:settings', (_, task: IpcTask) => {
+    switch (task.action) {
+      case 'settings:set:docked': {
+        WindowUtils.handleNewDockFlag(task.data.flag);
+        break;
+      }
+    }
   });
 
   // Get app settings.

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,7 +235,7 @@ app.whenReady().then(async () => {
   );
 
   /**
-   * Online status
+   * Online Status
    */
 
   ipcMain.on(
@@ -329,7 +329,7 @@ app.whenReady().then(async () => {
   });
 
   /**
-   * Window management
+   * Window Management
    */
 
   // Hides a window by its key.
@@ -342,11 +342,9 @@ app.whenReady().then(async () => {
     WindowsController.close(id);
   });
 
-  // Get application docked flag.
-  ipcMain.handle(
-    'app:docked:get',
-    async () => SettingsController.getAppSettings().appDocked
-  );
+  /**
+   * Settings
+   */
 
   // Set application docked flag.
   ipcMain.on('app:docked:set', (_, flag) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -385,9 +385,6 @@ app.whenReady().then(async () => {
       case 'settings:execute:showDebuggingSubscriptions': {
         const flag = !settings.appShowDebuggingSubscriptions;
         settings.appShowDebuggingSubscriptions = flag;
-
-        const key = ConfigMain.settingsStorageKey;
-        (store as Record<string, AnyData>).set(key, settings);
         break;
       }
       case 'settings:execute:silenceOsNotifications': {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -8,7 +8,6 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type { PreloadAPI } from '@/types/preload';
 import type { AnyJson } from './types/misc';
 import type { IpcTask } from './types/communication';
-import type { SettingAction } from './renderer/screens/Settings/types';
 
 console.log(global.location.search);
 
@@ -146,9 +145,6 @@ export const API: PreloadAPI = {
   /**
    * New handlers
    */
-
-  toggleSetting: (action: SettingAction) =>
-    ipcRenderer.send('app:setting:toggle', action),
 
   getAppSettings: async () => await ipcRenderer.invoke('app:settings:get'),
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -137,6 +137,13 @@ export const API: PreloadAPI = {
   importAppData: async () => await ipcRenderer.invoke('app:data:import'),
 
   /**
+   * Settings
+   */
+
+  sendSettingTask: (task: IpcTask) =>
+    ipcRenderer.send('main:task:settings', task),
+
+  /**
    * New handlers
    */
 
@@ -147,8 +154,6 @@ export const API: PreloadAPI = {
     ipcRenderer.send('app:set:workspaceVisibility'),
 
   getAppSettings: async () => await ipcRenderer.invoke('app:settings:get'),
-
-  setDockedFlag: (flag: boolean) => ipcRenderer.send('app:docked:set', flag),
 
   initializeApp: (callback) =>
     ipcRenderer.on('renderer:app:initialize', callback),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -148,8 +148,6 @@ export const API: PreloadAPI = {
 
   getAppSettings: async () => await ipcRenderer.invoke('app:settings:get'),
 
-  getDockedFlag: async () => await ipcRenderer.invoke('app:docked:get'),
-
   setDockedFlag: (flag: boolean) => ipcRenderer.send('app:docked:set', flag),
 
   initializeApp: (callback) =>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -150,9 +150,6 @@ export const API: PreloadAPI = {
   toggleSetting: (action: SettingAction) =>
     ipcRenderer.send('app:setting:toggle', action),
 
-  toggleWindowWorkspaceVisibility: () =>
-    ipcRenderer.send('app:set:workspaceVisibility'),
-
   getAppSettings: async () => await ipcRenderer.invoke('app:settings:get'),
 
   initializeApp: (callback) =>

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -75,7 +75,12 @@ export const AppSettingsProvider = ({
   const handleDockedToggle = () => {
     setDockToggled((prev) => {
       const docked = !prev;
-      window.myAPI.setDockedFlag(docked);
+
+      window.myAPI.sendSettingTask({
+        action: 'settings:set:docked',
+        data: { flag: docked },
+      });
+
       return docked;
     });
   };

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -5,6 +5,7 @@ import { Config as RendererConfig } from '@/config/processes/renderer';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { defaultAppSettingsContext } from './defaults';
 import type { AppSettingsContextInterface } from './types';
+import type { SettingAction } from '@/renderer/screens/Settings/types';
 
 export const AppSettingsContext = createContext<AppSettingsContextInterface>(
   defaultAppSettingsContext
@@ -39,7 +40,7 @@ export const AppSettingsProvider = ({
   /// Hide dock icon.
   const [hideDockIcon, setHideDockIcon] = useState<boolean>(false);
 
-  // Get settings from main and initialise state.
+  /// Get settings from main and initialise state.
   useEffect(() => {
     const initSettings = async () => {
       const {
@@ -71,6 +72,14 @@ export const AppSettingsProvider = ({
     initSettings();
   }, []);
 
+  /// Handle toggling a setting.
+  const handleToggleSetting = (settingAction: SettingAction) => {
+    window.myAPI.sendSettingTask({
+      action: 'settings:toggle',
+      data: { settingAction },
+    });
+  };
+
   /// Handle toggling the docked window state.
   const handleDockedToggle = () => {
     setDockToggled((prev) => {
@@ -93,7 +102,7 @@ export const AppSettingsProvider = ({
       return newFlag;
     });
 
-    window.myAPI.toggleSetting('settings:execute:silenceOsNotifications');
+    handleToggleSetting('settings:execute:silenceOsNotifications');
   };
 
   /// Handle toggling show debugging subscriptions.
@@ -104,7 +113,7 @@ export const AppSettingsProvider = ({
       return newFlag;
     });
 
-    window.myAPI.toggleSetting('settings:execute:showDebuggingSubscriptions');
+    handleToggleSetting('settings:execute:showDebuggingSubscriptions');
   };
 
   /// Handle toggling enable automatic subscriptions.
@@ -115,26 +124,26 @@ export const AppSettingsProvider = ({
       return newFlag;
     });
 
-    window.myAPI.toggleSetting('settings:execute:enableAutomaticSubscriptions');
+    handleToggleSetting('settings:execute:enableAutomaticSubscriptions');
   };
 
   /// Handle toggling enable Polkassembly API.
   const handleToggleEnablePolkassemblyApi = () => {
     setEnablePolkassemblyApi(!enablePolkassemblyApi);
-    window.myAPI.toggleSetting('settings:execute:enablePolkassembly');
+    handleToggleSetting('settings:execute:enablePolkassembly');
   };
 
   /// Handle toggling keep outdated events setting.
   const handleToggleKeepOutdatedEvents = () => {
     const newFlag = !RendererConfig.keepOutdatedEvents;
     RendererConfig.keepOutdatedEvents = newFlag;
-    window.myAPI.toggleSetting('settings:execute:keepOutdatedEvents');
+    handleToggleSetting('settings:execute:keepOutdatedEvents');
   };
 
   /// Handle toggling hide dock icon setting.
   const handleToggleHideDockIcon = () => {
     setHideDockIcon(!hideDockIcon);
-    window.myAPI.toggleSetting('settings:execute:hideDockIcon');
+    handleToggleSetting('settings:execute:hideDockIcon');
   };
 
   return (

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -741,7 +741,10 @@ export const useMainMessagePorts = () => {
               break;
             }
             case 'settings:execute:showOnAllWorkspaces': {
-              window.myAPI.toggleWindowWorkspaceVisibility();
+              window.myAPI.sendSettingTask({
+                action: 'settings:toggle:allWorkspaces',
+                data: null,
+              });
               break;
             }
             case 'settings:execute:silenceOsNotifications': {

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -48,6 +48,7 @@ export interface IpcTask {
     | 'interval:task:remove'
     | 'interval:task:update'
     // Settings
-    | 'settings:set:docked';
+    | 'settings:set:docked'
+    | 'settings:toggle:allWorkspaces';
   data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -46,6 +46,8 @@ export interface IpcTask {
     | 'interval:task:clear'
     | 'interval:task:add'
     | 'interval:task:remove'
-    | 'interval:task:update';
+    | 'interval:task:update'
+    // Settings
+    | 'settings:set:docked';
   data: AnyData;
 }

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -49,6 +49,7 @@ export interface IpcTask {
     | 'interval:task:update'
     // Settings
     | 'settings:set:docked'
+    | 'settings:toggle'
     | 'settings:toggle:allWorkspaces';
   data: AnyData;
 }

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -46,7 +46,6 @@ export interface PreloadAPI {
   sendSettingTask: (task: IpcTask) => void;
   toggleSetting: (action: SettingAction) => void;
   getAppSettings: ApiGetAppSettings;
-  toggleWindowWorkspaceVisibility: ApiToggleWorkspaceVisibility;
 
   initializeApp: ApiInitializeApp;
   initializeAppOnline: ApiInitializeAppOnline;
@@ -107,8 +106,6 @@ type ApiOpenBrowserWindow = (url: string) => void;
 /**
  * New types
  */
-type ApiToggleWorkspaceVisibility = () => void;
-
 type ApiGetAppSettings = () => Promise<PersistedSettings>;
 
 type ApiInitializeApp = (callback: (_: IpcRendererEvent) => void) => void;

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -43,9 +43,9 @@ export interface PreloadAPI {
   exportAppData: () => Promise<ExportResult>;
   importAppData: () => Promise<ImportResult>;
 
+  sendSettingTask: (task: IpcTask) => void;
   toggleSetting: (action: SettingAction) => void;
   getAppSettings: ApiGetAppSettings;
-  setDockedFlag: ApiSetDockedFlag;
   toggleWindowWorkspaceVisibility: ApiToggleWorkspaceVisibility;
 
   initializeApp: ApiInitializeApp;
@@ -110,8 +110,6 @@ type ApiOpenBrowserWindow = (url: string) => void;
 type ApiToggleWorkspaceVisibility = () => void;
 
 type ApiGetAppSettings = () => Promise<PersistedSettings>;
-
-type ApiSetDockedFlag = (flag: boolean) => void;
 
 type ApiInitializeApp = (callback: (_: IpcRendererEvent) => void) => void;
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -4,15 +4,12 @@
 import type { AnyJson } from './misc';
 import type { ChainID } from './chains';
 import type { DismissEvent, EventCallback, NotificationData } from './reporter';
+import type { ExportResult, ImportResult } from './backup';
 import type { LedgerTask } from './ledger';
 import type { IpcTask } from './communication';
 import type { IpcRendererEvent } from 'electron';
-import type {
-  PersistedSettings,
-  SettingAction,
-} from '@/renderer/screens/Settings/types';
+import type { PersistedSettings } from '@/renderer/screens/Settings/types';
 import type { WorkspaceItem } from './developerConsole/workspaces';
-import type { ExportResult, ImportResult } from './backup';
 
 export interface PreloadAPI {
   getWindowId: () => string;
@@ -25,6 +22,7 @@ export interface PreloadAPI {
 
   sendConnectionTask: (task: IpcTask) => void;
   sendConnectionTaskAsync: (task: IpcTask) => Promise<boolean | void>;
+  reportOnlineStatus: ApiReportOnlineStatus;
 
   sendEventTaskAsync: (task: IpcTask) => Promise<string | boolean>;
   sendEventTask: (task: IpcTask) => void;
@@ -44,7 +42,6 @@ export interface PreloadAPI {
   importAppData: () => Promise<ImportResult>;
 
   sendSettingTask: (task: IpcTask) => void;
-  toggleSetting: (action: SettingAction) => void;
   getAppSettings: ApiGetAppSettings;
 
   initializeApp: ApiInitializeApp;
@@ -65,9 +62,6 @@ export interface PreloadAPI {
 
   reportNewEvent: ApiReportNewEvent;
   reportDismissEvent: ApiReportDismissEvent;
-
-  reportOnlineStatus: ApiReportOnlineStatus;
-
   openBrowserURL: ApiOpenBrowserWindow;
 }
 

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -45,7 +45,6 @@ export interface PreloadAPI {
 
   toggleSetting: (action: SettingAction) => void;
   getAppSettings: ApiGetAppSettings;
-  getDockedFlag: ApiGetDockedFlag;
   setDockedFlag: ApiSetDockedFlag;
   toggleWindowWorkspaceVisibility: ApiToggleWorkspaceVisibility;
 
@@ -111,8 +110,6 @@ type ApiOpenBrowserWindow = (url: string) => void;
 type ApiToggleWorkspaceVisibility = () => void;
 
 type ApiGetAppSettings = () => Promise<PersistedSettings>;
-
-type ApiGetDockedFlag = () => Promise<boolean>;
 
 type ApiSetDockedFlag = (flag: boolean) => void;
 

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import { store } from '@/main';
 import { hideDockIcon, reportOnlineStatus } from '@/utils/SystemUtils';
 import { EventsController } from '@/controller/main/EventsController';
+import { SettingsController } from '@/controller/main/SettingsController';
 import { WindowsController } from '@/controller/main/WindowsController';
 import { Config as ConfigMain } from '@/config/processes/main';
 import { MainDebug } from './DebugUtils';
@@ -155,8 +156,7 @@ export const createMainWindow = (isTest: boolean) => {
     sendMainWindowPorts(mainWindow);
 
     // Freeze window if in docked mode.
-    const { appDocked } = ConfigMain.getAppSettings();
-    if (appDocked) {
+    if (SettingsController.getAppSettings().appDocked) {
       mainWindow.setMovable(false);
       mainWindow.setResizable(false);
     }
@@ -313,7 +313,7 @@ export const handleWindowOnIPC = (
     setAllWorkspaceVisibilityForWindow(name);
 
     // Hide dock icon.
-    const { appHideDockIcon } = ConfigMain.getAppSettings();
+    const { appHideDockIcon } = SettingsController.getAppSettings();
     appHideDockIcon && hideDockIcon();
   });
 };
@@ -429,7 +429,7 @@ export const handleNewDockFlag = (isDocked: boolean) => {
   }
 
   // Update storage.
-  const settings = ConfigMain.getAppSettings();
+  const settings = SettingsController.getAppSettings();
   settings.appDocked = isDocked;
 
   const key = ConfigMain.settingsStorageKey;
@@ -462,7 +462,7 @@ export const handleNewDockFlag = (isDocked: boolean) => {
  */
 export const setAllWorkspaceVisibilityForWindow = (windowId: string) => {
   const window = WindowsController.get(windowId);
-  const { appShowOnAllWorkspaces } = ConfigMain.getAppSettings();
+  const { appShowOnAllWorkspaces } = SettingsController.getAppSettings();
   window?.setVisibleOnAllWorkspaces(appShowOnAllWorkspaces);
 };
 


### PR DESCRIPTION
Refactor the preload API to handle settings tasks with a generic IPC message.

Simplifies the preload API and unifies settings task handling logic within the main process.