### PR TITLE
feat: backup iteration

### DIFF
--- a/src/config/help.ts
+++ b/src/config/help.ts
@@ -217,16 +217,16 @@ export const HelpConfig: HelpItems = [
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [
-      'Import a data file that was exported from another Polkadot Live installation to restore your accounts.',
-      'Accounts in the data file that do not currently exist in Polkadot Live will be added to the Accounts window. From there, you can import the account and turn on subscriptions in the normal manner.',
+      'Import a text file that was exported from another Polkadot Live installation to restore your state. Polkadot Live will import accounts, events and subscriptions that are read from the backup file.',
+      "Data read from the backup file will take precedence over the application's current state. This means that accounts will be added or removed from the main window to reflect the imported data. Account names will also update to reflect what is specified in the backup file.",
     ],
   },
   {
     key: 'help:settings:exportData',
     title: 'Export Data',
     definition: [
-      'Export account data to a text file, allowing you to backup your accounts managed by Polkadot Live.',
-      'Use the corresponding "Import" button in the settings window to read the exported data file and restore your accounts in Polkadot Live.',
+      'Export your Polkadot Live state to a backup file. Your imported addresses, event items, and enabled subscriptions will be written to the backup file.',
+      'Use the corresponding "Import" button in the settings window to read the exported backup file and restore your state in Polkadot Live.',
     ],
   },
   {

--- a/src/config/processes/main.ts
+++ b/src/config/processes/main.ts
@@ -35,6 +35,7 @@ export class Config {
 
   // Flags to handle data processes.
   private static _exportingData = false;
+  private static _importingData = false;
 
   // Return the local storage key for corresponding source addresses.
   static getStorageKey(source: AccountSource): string {
@@ -153,6 +154,14 @@ export class Config {
 
   static set exportingData(flag: boolean) {
     Config._exportingData = flag;
+  }
+
+  static get importingData(): boolean {
+    return Config._importingData;
+  }
+
+  static set importingData(flag: boolean) {
+    Config._importingData = flag;
   }
 
   // Setter for app's tray object.

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -85,7 +85,7 @@ export const SettingsList: SettingItem[] = [
     enabled: true,
     helpKey: 'help:settings:importData',
     settingType: 'button',
-    title: 'Import Accounts',
+    title: 'Import Data',
     platforms: ['darwin', 'win32'],
   },
   {
@@ -96,7 +96,7 @@ export const SettingsList: SettingItem[] = [
     enabled: true,
     helpKey: 'help:settings:exportData',
     settingType: 'button',
-    title: 'Export Accounts',
+    title: 'Export Data',
     platforms: ['darwin', 'win32'],
   },
 ];

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -129,6 +129,17 @@ export class AddressesController {
   }
 
   /**
+   * @name getBySourceAndChain
+   * @summary Get all addresses from a particular source.
+   */
+  static getAllBySource(
+    source: AccountSource
+  ): LedgerLocalAddress[] | LocalAddress[] {
+    const key = ConfigMain.getStorageKey(source);
+    return this.getStoredAddresses(key, source === 'ledger');
+  }
+
+  /**
    * @name get
    * @summary Get all stored addresses for an account type.
    */

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -115,7 +115,14 @@ export class AddressesController {
         source === 'ledger'
           ? (this.getStoredAddresses(key) as LedgerLocalAddress[])
           : (this.getStoredAddresses(key) as LocalAddress[]);
-      map.set(source, JSON.stringify(fetched));
+
+      if (fetched.length === 0) {
+        continue;
+      }
+
+      // Set imported flag to false.
+      const updated = fetched.map((a) => ({ ...a, isImported: false }));
+      map.set(source, JSON.stringify(updated));
     }
 
     return JSON.stringify(Array.from(map.entries()));

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -53,7 +53,7 @@ export class AddressesController {
    * @summary Set the import flag of an address to `true`.
    */
   private static add(task: IpcTask) {
-    const { source, address } = task.data;
+    const { address, source, name } = task.data;
     const key = ConfigMain.getStorageKey(source);
 
     if (source === 'ledger') {
@@ -61,7 +61,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
       const serialized = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: true } : a
+          a.address === address ? { ...a, name, isImported: true } : a
         )
       );
 
@@ -71,7 +71,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key) as LocalAddress[];
       const serialized = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: true } : a
+          a.address === address ? { ...a, name, isImported: true } : a
         )
       );
 
@@ -153,22 +153,22 @@ export class AddressesController {
 
   /**
    * @name doImport
-   * @summary Persist an address to store being imported from a backup file.
+   * @summary Persist an address to store that's being imported from a backup file.
    */
   private static doImport(task: IpcTask) {
     const { source, serialized } = task.data;
     const parsed: LocalAddress | LedgerLocalAddress = JSON.parse(serialized);
-    const { address, isImported } = parsed;
+    const { address, isImported, name } = parsed;
 
     if (this.isAlreadyPersisted(address)) {
       isImported
         ? this.add({
             action: 'raw-account:add',
-            data: { source, address },
+            data: { source, address, name },
           })
         : this.remove({
             action: 'raw-account:remove',
-            data: { source, address },
+            data: { source, address, name },
           });
     } else {
       this.persist({
@@ -215,7 +215,7 @@ export class AddressesController {
    * @summary Set the import flag of an address to `false`.
    */
   private static remove(task: IpcTask) {
-    const { source, address } = task.data;
+    const { address, source, name } = task.data;
     const key = ConfigMain.getStorageKey(source);
 
     if (source === 'ledger') {
@@ -223,7 +223,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
       const serialised = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: false } : a
+          a.address === address ? { ...a, name, isImported: false } : a
         )
       );
 
@@ -233,7 +233,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key) as LocalAddress[];
       const serialized = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: false } : a
+          a.address === address ? { ...a, name, isImported: false } : a
         )
       );
 

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -33,6 +33,10 @@ export class AddressesController {
         this.persist(task);
         break;
       }
+      case 'raw-account:import': {
+        this.doImport(task);
+        break;
+      }
       case 'raw-account:remove': {
         this.remove(task);
         break;
@@ -120,9 +124,7 @@ export class AddressesController {
         continue;
       }
 
-      // Set imported flag to false.
-      const updated = fetched.map((a) => ({ ...a, isImported: false }));
-      map.set(source, JSON.stringify(updated));
+      map.set(source, JSON.stringify(fetched));
     }
 
     return JSON.stringify(Array.from(map.entries()));
@@ -147,6 +149,33 @@ export class AddressesController {
     const { source } = task.data;
     const key = ConfigMain.getStorageKey(source);
     return store.has(key) ? this.getFromStore(key) : '[]';
+  }
+
+  /**
+   * @name doImport
+   * @summary Persist an address to store being imported from a backup file.
+   */
+  private static doImport(task: IpcTask) {
+    const { source, serialized } = task.data;
+    const parsed: LocalAddress | LedgerLocalAddress = JSON.parse(serialized);
+    const { address, isImported } = parsed;
+
+    if (this.isAlreadyPersisted(address)) {
+      isImported
+        ? this.add({
+            action: 'raw-account:add',
+            data: { source, address },
+          })
+        : this.remove({
+            action: 'raw-account:remove',
+            data: { source, address },
+          });
+    } else {
+      this.persist({
+        action: 'raw-account:persist',
+        data: { source, serialized },
+      });
+    }
   }
 
   /**

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -129,7 +129,7 @@ export class AddressesController {
   }
 
   /**
-   * @name getBySourceAndChain
+   * @name getAllBySource
    * @summary Get all addresses from a particular source.
    */
   static getAllBySource(

--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -103,10 +103,10 @@ export class AddressesController {
   }
 
   /**
-   * @name getAll
+   * @name getBackupData
    * @summary Get all stored addresses in serialized form.
    */
-  static getAll(): string {
+  static getBackupData(): string {
     const map = new Map<AccountSource, string>();
 
     for (const source of ['ledger', 'read-only', 'vault'] as AccountSource[]) {

--- a/src/controller/main/AnalyticsController.ts
+++ b/src/controller/main/AnalyticsController.ts
@@ -21,7 +21,7 @@ export class AnalyticsController {
 
     this.umami = new Umami(ipAddress(), agent, language);
     this.enabled = true;
-    this.umami.view(`/${windowId}`, { data: {} });
+    windowId !== 'tabs' && this.umami.view(`/${windowId}`, { data: {} });
   }
 
   /**

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -5,6 +5,7 @@ import { Config as ConfigMain } from '@/config/processes/main';
 import { dialog } from 'electron';
 import { promises as fsPromises } from 'fs';
 import { AddressesController } from '@/controller/main/AddressesController';
+import { EventsController } from '@/controller/main/EventsController';
 import type { ExportResult, ImportResult } from '@/types/backup';
 
 export class BackupController {
@@ -36,7 +37,7 @@ export class BackupController {
     // Handle save or cancel.
     if (!canceled && filePath) {
       try {
-        const serialized = AddressesController.getBackupData();
+        const serialized = this.getExportData();
         await fsPromises.writeFile(filePath, serialized, {
           encoding: 'utf8',
         });
@@ -82,5 +83,20 @@ export class BackupController {
     } else {
       return { result: false, msg: 'canceled' };
     }
+  }
+
+  /**
+   * @name getExportData
+   * @summary Return serialized backup data which should be written to a text file.
+   */
+  private static getExportData(): string {
+    const map = new Map<string, string>();
+    const addresses = AddressesController.getBackupData();
+    const events = EventsController.getBackupData();
+
+    map.set('addresses', addresses);
+    map.set('events', events);
+
+    return JSON.stringify(Array.from(map));
   }
 }

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -36,7 +36,7 @@ export class BackupController {
     // Handle save or cancel.
     if (!canceled && filePath) {
       try {
-        const serialized = AddressesController.getAll();
+        const serialized = AddressesController.getBackupData();
         await fsPromises.writeFile(filePath, serialized, {
           encoding: 'utf8',
         });

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -7,6 +7,7 @@ import { promises as fsPromises } from 'fs';
 import { AddressesController } from '@/controller/main/AddressesController';
 import { EventsController } from '@/controller/main/EventsController';
 import { IntervalsController } from '@/controller/main/IntervalsController';
+import { SubscriptionsController } from './SubscriptionsController';
 import type { ExportResult, ImportResult } from '@/types/backup';
 
 export class BackupController {
@@ -95,10 +96,12 @@ export class BackupController {
     const addresses = AddressesController.getBackupData();
     const events = EventsController.getBackupData();
     const intervals = IntervalsController.getBackupData();
+    const accountTasks = SubscriptionsController.getBackupData();
 
     map.set('addresses', addresses);
     map.set('events', events);
     map.set('intervals', intervals);
+    map.set('accountTasks', accountTasks);
 
     return JSON.stringify(Array.from(map));
   }

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -6,6 +6,7 @@ import { dialog } from 'electron';
 import { promises as fsPromises } from 'fs';
 import { AddressesController } from '@/controller/main/AddressesController';
 import { EventsController } from '@/controller/main/EventsController';
+import { IntervalsController } from '@/controller/main/IntervalsController';
 import type { ExportResult, ImportResult } from '@/types/backup';
 
 export class BackupController {
@@ -93,9 +94,11 @@ export class BackupController {
     const map = new Map<string, string>();
     const addresses = AddressesController.getBackupData();
     const events = EventsController.getBackupData();
+    const intervals = IntervalsController.getBackupData();
 
     map.set('addresses', addresses);
     map.set('events', events);
+    map.set('intervals', intervals);
 
     return JSON.stringify(Array.from(map));
   }

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -18,6 +18,11 @@ export class BackupController {
    * @summary Export Polkadot Live data to a text file.
    */
   static async export(): Promise<ExportResult> {
+    // Exit early if overlay is created.
+    if (WindowsController.overlayExists()) {
+      return { result: false, msg: 'alreadyOpen' };
+    }
+
     // Return early if export dialog is already open.
     if (ConfigMain.exportingData) {
       return { result: false, msg: 'executing' };
@@ -68,6 +73,11 @@ export class BackupController {
    * @summary Import a Polkadot Live data file.
    */
   static async import(): Promise<ImportResult> {
+    // Exit early if overlay is created.
+    if (WindowsController.overlayExists()) {
+      return { result: false, msg: 'alreadyOpen' };
+    }
+
     // Render transparent browser window over base window.
     const overlay = WindowsController.getOverlay();
     if (!overlay) {

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -5,9 +5,11 @@ import { Config as ConfigMain } from '@/config/processes/main';
 import { dialog } from 'electron';
 import { promises as fsPromises } from 'fs';
 import { AddressesController } from '@/controller/main/AddressesController';
+import { WindowsController } from './WindowsController';
 import { EventsController } from '@/controller/main/EventsController';
 import { IntervalsController } from '@/controller/main/IntervalsController';
 import { SubscriptionsController } from './SubscriptionsController';
+import { version } from '../../../package.json';
 import type { ExportResult, ImportResult } from '@/types/backup';
 
 export class BackupController {
@@ -21,10 +23,14 @@ export class BackupController {
       return { result: false, msg: 'executing' };
     }
 
+    // Render transparent browser window over base window.
     ConfigMain.exportingData = true;
+    const overlay = WindowsController.getOverlay();
+    if (!overlay) {
+      return { result: false, msg: 'error' };
+    }
 
-    // TODO: Pass BaseWindow when supported.
-    const { canceled, filePath } = await dialog.showSaveDialog({
+    const { canceled, filePath } = await dialog.showSaveDialog(overlay, {
       title: 'Export Data',
       defaultPath: 'polkadot-live-data.txt',
       filters: [
@@ -37,6 +43,7 @@ export class BackupController {
     });
 
     // Handle save or cancel.
+    WindowsController.destroyOverlay();
     if (!canceled && filePath) {
       try {
         const serialized = this.getExportData();
@@ -61,8 +68,13 @@ export class BackupController {
    * @summary Import a Polkadot Live data file.
    */
   static async import(): Promise<ImportResult> {
-    // TODO: Pass BaseWindow when supported.
-    const { canceled, filePaths } = await dialog.showOpenDialog({
+    // Render transparent browser window over base window.
+    const overlay = WindowsController.getOverlay();
+    if (!overlay) {
+      return { result: false, msg: 'error' };
+    }
+
+    const { canceled, filePaths } = await dialog.showOpenDialog(overlay, {
       title: 'Import Data',
       filters: [
         {
@@ -73,6 +85,7 @@ export class BackupController {
       properties: ['openFile'],
     });
 
+    WindowsController.destroyOverlay();
     if (!canceled && filePaths.length) {
       try {
         const serialized = await fsPromises.readFile(filePaths[0], {
@@ -98,6 +111,7 @@ export class BackupController {
     const intervals = IntervalsController.getBackupData();
     const accountTasks = SubscriptionsController.getBackupData();
 
+    map.set('version', version);
     map.set('addresses', addresses);
     map.set('events', events);
     map.set('intervals', intervals);

--- a/src/controller/main/EventsController.ts
+++ b/src/controller/main/EventsController.ts
@@ -235,6 +235,14 @@ export class EventsController {
   }
 
   /**
+   * @name getBackupData
+   * @summary Get all stored events in serialized form.
+   */
+  static getBackupData(): string {
+    return (store as Record<string, AnyJson>).get(this.storeKey) as string;
+  }
+
+  /**
    * @name removeOutdatedEvents
    * @summary Remove outdated events from the store.
    *

--- a/src/controller/main/EventsController.ts
+++ b/src/controller/main/EventsController.ts
@@ -128,6 +128,7 @@ export class EventsController {
         // Update events in storage.
         const updated = this.updateEventAccountName(address, newName);
 
+        // TODO: Decouple from this function.
         // Update account's subscription tasks in storage.
         SubscriptionsController.updateCachedAccountNameForTasks(
           address,

--- a/src/controller/main/IntervalsController.ts
+++ b/src/controller/main/IntervalsController.ts
@@ -7,6 +7,8 @@ import type { IntervalSubscription } from '@/types/subscriptions';
 import type { IpcTask } from '@/types/communication';
 
 export class IntervalsController {
+  private static key = 'interval_subscriptions';
+
   /**
    * @name process
    * @summary Process an interval subscription IPC task.
@@ -35,20 +37,43 @@ export class IntervalsController {
   }
 
   /**
+   * @name compare
+   * @summary Compare data of two tasks to determine if they're the same task.
+   */
+  private static compare(
+    left: IntervalSubscription,
+    right: IntervalSubscription
+  ): boolean {
+    return left.action === right.action &&
+      left.chainId === right.chainId &&
+      left.referendumId === right.referendumId
+      ? true
+      : false;
+  }
+
+  /**
+   * @name exists
+   * @summary Check if a given interval subscription task exists in the store.
+   */
+  static exists(task: IntervalSubscription): boolean {
+    const stored: IntervalSubscription[] = JSON.parse(this.get());
+    for (const item of stored) {
+      if (this.compare(task, item)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * @name add
    * @summary Add interval subscription to store.
    */
   private static add(task: IpcTask) {
     const { serialized }: { serialized: string } = task.data;
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyData> = store;
-
-    const stored: IntervalSubscription[] = storePointer.get(key)
-      ? JSON.parse(storePointer.get(key) as string)
-      : [];
-
+    const stored: IntervalSubscription[] = JSON.parse(this.get());
     stored.push(JSON.parse(serialized));
-    storePointer.set(key, JSON.stringify(stored));
+    this.set(stored);
   }
 
   /**
@@ -56,9 +81,8 @@ export class IntervalsController {
    * @summary Clear interval subscriptions from store.
    */
   private static clear(): string {
-    const key = 'interval_subscriptions';
     const storePointer: Record<string, AnyData> = store;
-    storePointer.delete(key);
+    storePointer.delete(this.key);
     return 'done';
   }
 
@@ -67,10 +91,17 @@ export class IntervalsController {
    * @summary Get serialized interval subscriptions from store.
    */
   private static get(): string {
-    const key = 'interval_subscriptions';
     const storePointer: Record<string, AnyData> = store;
-    const stored: string = storePointer.get(key) || '[]';
+    const stored: string = storePointer.get(this.key) || '[]';
     return stored;
+  }
+
+  /**
+   * @name getBackupData
+   * @summary Get stored serialized tasks for writing to a backup text file.
+   */
+  static getBackupData(): string {
+    return this.get();
   }
 
   /**
@@ -79,14 +110,8 @@ export class IntervalsController {
    */
   private static remove(task: IpcTask) {
     const { serialized }: { serialized: string } = task.data;
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyData> = store;
-
-    const stored: IntervalSubscription[] = storePointer.get(key)
-      ? JSON.parse(storePointer.get(key) as string)
-      : [];
-
     const target: IntervalSubscription = JSON.parse(serialized);
+    const stored: IntervalSubscription[] = JSON.parse(this.get());
     const filtered = stored.filter(
       (t) =>
         !(
@@ -95,8 +120,16 @@ export class IntervalsController {
           t.referendumId === target.referendumId
         )
     );
+    this.set(filtered);
+  }
 
-    storePointer.set(key, JSON.stringify(filtered));
+  /**
+   * @name set
+   * @summary Updates stored interval subscriptions.
+   */
+  private static set(tasks: IntervalSubscription[]) {
+    const storePointer: Record<string, AnyData> = store;
+    storePointer.set(this.key, JSON.stringify(tasks));
   }
 
   /**
@@ -105,14 +138,8 @@ export class IntervalsController {
    */
   private static update(task: IpcTask) {
     const { serialized }: { serialized: string } = task.data;
-    const key = 'interval_subscriptions';
-    const storePointer: Record<string, AnyData> = store;
-
     const target: IntervalSubscription = JSON.parse(serialized);
-    const stored: IntervalSubscription[] = storePointer.get(key)
-      ? JSON.parse(storePointer.get(key) as string)
-      : [];
-
+    const stored: IntervalSubscription[] = JSON.parse(this.get());
     const updated = stored.map((t) =>
       t.action === target.action &&
       t.chainId === target.chainId &&
@@ -120,7 +147,6 @@ export class IntervalsController {
         ? target
         : t
     );
-
-    storePointer.set(key, JSON.stringify(updated));
+    this.set(updated);
   }
 }

--- a/src/controller/main/WindowsController.ts
+++ b/src/controller/main/WindowsController.ts
@@ -48,6 +48,8 @@ export class WindowsController {
   /* Overlay Window                           */
   /* ---------------------------------------- */
 
+  static overlayExists = (): boolean => this.overlay !== null;
+
   static getOverlay = (): BrowserWindow | null => {
     const window = this.base?.window;
     if (!window) {

--- a/src/controller/main/WindowsController.ts
+++ b/src/controller/main/WindowsController.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { store } from '@/main';
+import { BrowserWindow } from 'electron';
 import type { AnyJson } from '@/types/misc';
-import type { BaseWindow, BrowserWindow, WebContentsView } from 'electron';
+import type { BaseWindow, WebContentsView } from 'electron';
 
 // A window helper to manage which windows are open and their current state.
 interface StoredWindow {
@@ -30,6 +31,7 @@ export class WindowsController {
   static base: StoredBase | null = null;
   static views: StoredView[] = [];
   static tabsView: WebContentsView | null = null;
+  private static overlay: BrowserWindow | null = null;
 
   // Height of tabs view in pixels (tabs height + header height)
   static Y_OFFSET = 49 + 35.0938;
@@ -41,6 +43,49 @@ export class WindowsController {
   // Get a managed web contents view.
   static getView = (viewId: string) =>
     this.views.find(({ id }) => viewId === id)?.view ?? undefined;
+
+  /* ---------------------------------------- */
+  /* Overlay Window                           */
+  /* ---------------------------------------- */
+
+  static getOverlay = (): BrowserWindow | null => {
+    const window = this.base?.window;
+    if (!window) {
+      return null;
+    }
+
+    const { x, y, width, height } = window.getBounds();
+    const overlay = new BrowserWindow({
+      alwaysOnTop: true,
+      frame: false,
+      show: true,
+      x,
+      y,
+      width,
+      height,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      closable: true,
+      fullscreenable: false,
+      skipTaskbar: true,
+      backgroundColor: '#2b2b2b',
+      opacity: 0.25,
+    });
+
+    overlay.on('move', () => {
+      const [xPos, yPos] = WindowsController.overlay!.getPosition();
+      WindowsController.base?.window.setPosition(xPos, yPos, false);
+    });
+
+    this.overlay = overlay;
+    return this.overlay;
+  };
+
+  static destroyOverlay = () => {
+    this.overlay?.close();
+    this.overlay = null;
+  };
 
   /* ---------------------------------------- */
   /* Base Window                              */

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -27,36 +27,29 @@ export class AccountsController {
    * @summary Injects accounts into class from store.
    */
   static async initialize() {
-    const stored: string =
+    const serialized: string =
       (await window.myAPI.sendAccountTask({
         action: 'account:getAll',
         data: null,
       })) || '';
 
-    // Instantiate empty map if no accounts found in store.
-    if (stored === '') {
+    // Instantiate empty map if no accounts exist.
+    if (serialized === '') {
       this.accounts = new Map();
       return;
     }
 
-    // Parse serialized data into a map of StoredAccounts.
-    const parsed = new Map<ChainID, StoredAccount[]>(JSON.parse(stored));
-    const importedAccounts: ImportedAccounts = new Map();
-
-    for (const [chain, accounts] of parsed) {
-      const imported: Account[] = [];
-
-      for (const a of accounts) {
-        // Instantiate account.
-        const account = new Account(chain, a._source, a._address, a._name);
-        imported.push(account);
-      }
-
-      importedAccounts.set(chain, imported);
+    // Instantiate accounts.
+    const parsed = new Map<ChainID, StoredAccount[]>(JSON.parse(serialized));
+    for (const [chain, stored] of parsed) {
+      this.accounts.set(
+        chain,
+        stored.map(
+          ({ _source, _address, _name }) =>
+            new Account(chain, _source, _address, _name)
+        )
+      );
     }
-
-    // Inject imported accounts into controller.
-    this.accounts = importedAccounts;
   }
 
   /**

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -184,8 +184,6 @@ export class AccountsController {
   /**
    * @name set
    * @summary Updates an Account in the `accounts` property.
-   * @param {ChainID} chain - the chain the account belongs to.
-   * @param {Account} account - the account to set.
    */
   static set = async (chain: ChainID, account: Account) => {
     this.accounts.set(
@@ -200,6 +198,19 @@ export class AccountsController {
       action: 'account:updateAll',
       data: { accounts: this.serializeAccounts() },
     });
+  };
+
+  /**
+   * @name update
+   * @summary Update an existing account.
+   */
+  static update = (chain: ChainID, account: Account) => {
+    this.accounts.set(
+      chain,
+      this.accounts
+        .get(chain)
+        ?.map((a) => (a.address === account.address ? account : a)) || []
+    );
   };
 
   /**

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -201,19 +201,6 @@ export class AccountsController {
   };
 
   /**
-   * @name update
-   * @summary Update an existing account.
-   */
-  static update = (chain: ChainID, account: Account) => {
-    this.accounts.set(
-      chain,
-      this.accounts
-        .get(chain)
-        ?.map((a) => (a.address === account.address ? account : a)) || []
-    );
-  };
-
-  /**
    * @name add
    * @summary Adds an account to the list of imported accounts. Fails if the account already
    * exists.

--- a/src/controller/renderer/EventsController.ts
+++ b/src/controller/renderer/EventsController.ts
@@ -192,6 +192,7 @@ export class EventsController {
 
         const { chainId } = entry.task;
         const address = account.address;
+        const source = account.source;
         const accountName = entry.task.account!.name;
 
         return {
@@ -204,6 +205,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Free Balance',
@@ -224,6 +226,7 @@ export class EventsController {
 
         const { chainId } = entry.task;
         const address = account.address;
+        const source = account.source;
         const accountName = entry.task.account!.name;
 
         return {
@@ -236,6 +239,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Frozen Balance',
@@ -256,6 +260,7 @@ export class EventsController {
 
         const { chainId } = entry.task;
         const address = account.address;
+        const source = account.source;
         const accountName = entry.task.account!.name;
 
         return {
@@ -268,6 +273,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Reserved Balance',
@@ -288,6 +294,7 @@ export class EventsController {
 
         const { chainId } = entry.task;
         const address = account.address;
+        const source = account.source;
         const accountName = entry.task.account!.name;
 
         return {
@@ -300,6 +307,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Spendable Balance',
@@ -399,7 +407,7 @@ export class EventsController {
         ]);
 
         const { chainId } = entry.task;
-        const { address, name: accountName } = flattenedAccount;
+        const { address, name: accountName, source } = flattenedAccount;
         const { poolState, poolId } = flattenedAccount.nominationPoolData!;
         const { prevState } = miscData;
 
@@ -413,6 +421,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Nomination Pool State',
@@ -439,7 +448,7 @@ export class EventsController {
         ]);
 
         const { chainId } = entry.task;
-        const { address, name: accountName } = flattenedAccount;
+        const { address, name: accountName, source } = flattenedAccount;
         const { poolName, poolId } = flattenedAccount.nominationPoolData!;
         const { prevName } = miscData;
 
@@ -453,6 +462,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Nomination Pool Name',
@@ -479,7 +489,7 @@ export class EventsController {
         ]);
 
         const { chainId } = entry.task;
-        const { address, name: accountName } = flattenedAccount;
+        const { address, name: accountName, source } = flattenedAccount;
         const { poolRoles, poolId } = flattenedAccount.nominationPoolData!;
         const { poolRoles: prevRoles } = miscData;
 
@@ -493,6 +503,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Nomination Pool Roles',
@@ -519,7 +530,7 @@ export class EventsController {
         ]);
 
         const { chainId } = entry.task;
-        const { address, name: accountName } = flattenedAccount;
+        const { address, name: accountName, source } = flattenedAccount;
         const { poolCommission } = flattenedAccount.nominationPoolData!;
         const { poolCommission: prevCommission } = miscData;
 
@@ -533,6 +544,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Nomination Pool Commission',
@@ -555,7 +567,7 @@ export class EventsController {
         // eslint-disable-next-line prettier/prettier
         const { eraRewards, era }: { eraRewards: BigNumber; era: string } = miscData;
         const { chainId } = entry.task;
-        const { address, name: accountName } = entry.task.account!;
+        const { address, name: accountName, source } = entry.task.account!;
 
         return {
           uid: '',
@@ -567,6 +579,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Nominating Rewards',
@@ -594,7 +607,7 @@ export class EventsController {
        */
       case 'subscribe:account:nominating:exposure': {
         const { chainId } = entry.task;
-        const { address, name: accountName } = entry.task.account!;
+        const { address, name: accountName, source } = entry.task.account!;
         const { era, exposed }: { era: number; exposed: boolean } = miscData;
 
         const subtitle = exposed
@@ -611,6 +624,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Era Exposure',
@@ -634,7 +648,7 @@ export class EventsController {
        */
       case 'subscribe:account:nominating:commission': {
         const { chainId } = entry.task;
-        const { address, name: accountName } = entry.task.account!;
+        const { address, name: accountName, source } = entry.task.account!;
         const { era, hasChanged }: { era: number; hasChanged: boolean } =
           miscData;
 
@@ -652,6 +666,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Commission Changed',
@@ -672,7 +687,7 @@ export class EventsController {
        */
       case 'subscribe:account:nominating:nominations': {
         const { chainId } = entry.task;
-        const { address, name: accountName } = entry.task.account!;
+        const { address, name: accountName, source } = entry.task.account!;
         const { era, hasChanged }: { era: number; hasChanged: boolean } =
           miscData;
 
@@ -690,6 +705,7 @@ export class EventsController {
               accountName,
               address,
               chainId,
+              source,
             } as EventAccountData,
           },
           title: 'Nominations Changed',

--- a/src/controller/renderer/IntervalsController.ts
+++ b/src/controller/renderer/IntervalsController.ts
@@ -65,7 +65,7 @@ export class IntervalsController {
   }
 
   /**
-   * @name insertInterval
+   * @name insertSubscription
    * @summary Insert an interval subscription into this controller's map.
    */
   static insertSubscription(
@@ -160,9 +160,13 @@ export class IntervalsController {
 
   /**
    * @name updateSubscription
-   * @summary Updae data of a managed interval subscription task.
+   * @summary Update data of a managed interval subscription task.
    */
   static updateSubscription(task: IntervalSubscription) {
+    if (task.status === 'disable') {
+      return;
+    }
+
     console.log('UPDATE SUBSCRIPTION:');
     console.log(task);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { executeLedgerLoop } from './ledger';
 import Store from 'electron-store';
 import AutoLaunch from 'auto-launch';
 import unhandled from 'electron-unhandled';
+import { Config as ConfigMain } from '@/config/processes/main';
 import { AccountsController } from '@/controller/main/AccountsController';
 import { AddressesController } from '@/controller/main/AddressesController';
 import { AnalyticsController } from './controller/main/AnalyticsController';
@@ -351,6 +352,43 @@ app.whenReady().then(async () => {
   ipcMain.handle('app:settings:get', async () =>
     SettingsController.getAppSettings()
   );
+
+  ipcMain.on('app:modeFlag:relay', (_, modeId: string, flag: boolean) => {
+    switch (modeId) {
+      case 'isImporting': {
+        ConfigMain.importingData = flag;
+
+        // Send to main window.
+        WindowsController.getWindow('menu')?.webContents?.send(
+          'renderer:modeFlag:set',
+          modeId,
+          flag
+        );
+
+        // Send to open views.
+        for (const viewId of ['import', 'settings']) {
+          const view = WindowsController.getView(viewId);
+          view && view.webContents.send(`renderer:modeFlag:set`, modeId, flag);
+        }
+
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+  });
+
+  ipcMain.handle('app:modeFlag:get', async (_, modeId: string) => {
+    switch (modeId) {
+      case 'isImporting': {
+        return ConfigMain.importingData;
+      }
+      default: {
+        return false;
+      }
+    }
+  });
 
   /**
    * Ledger

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -190,6 +190,16 @@ export const API: PreloadAPI = {
     ipcRenderer.send('app:view:close', destroyViewId, showViewId),
   isViewOpen: (viewId) => ipcRenderer.invoke('app:view:isOpen', viewId),
 
+  // Returns a mode flag cached in the main process to the requesting renderer.
+  getModeFlag: async (modeId: string): Promise<boolean> =>
+    await ipcRenderer.invoke('app:modeFlag:get', modeId),
+  // Called when a mode flag changes in any renderer to broadcast it to every renderer.
+  relayModeFlag: (modeId: string, flag: boolean) =>
+    ipcRenderer.send('app:modeFlag:relay', modeId, flag),
+  // Callback provided in useModeFlagsSyncing hook to sync state between renderers.
+  syncModeFlags: (callback) =>
+    ipcRenderer.on('renderer:modeFlag:set', callback),
+
   /**
    * Chain management
    */

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -61,6 +61,7 @@ const getProvidersForWindow = () => {
         HelpProvider,
         OverlayProvider,
         TooltipProvider,
+        ConnectionsProvider,
         AddressesProvider,
         AppSettingsProvider,
         ChainsProvider,
@@ -92,6 +93,7 @@ const getProvidersForWindow = () => {
         HelpProvider,
         OverlayProvider,
         TooltipProvider,
+        ConnectionsProvider,
         SettingFlagsProvider,
         WebsocketServerProvider,
         WorkspacesProvider

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -2,48 +2,49 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 // General contexts.
-import { HelpProvider } from '@/renderer/contexts/common/Help';
-import { OverlayProvider } from '@/renderer/contexts/common/Overlay';
-import { TooltipProvider } from '@/renderer/contexts/common/Tooltip';
-import { ConnectionsProvider } from '@/renderer/contexts/common/Connections';
+import { HelpProvider } from '@app/contexts/common/Help';
+import { OverlayProvider } from '@app/contexts/common/Overlay';
+import { TooltipProvider } from '@app/contexts/common/Tooltip';
+import { ConnectionsProvider } from '@app/contexts/common/Connections';
 
 // Tabs contexts.
 import { TabsProvider } from '@/renderer/contexts/tabs/Tabs';
 
 // Main window contexts.
-import { AddressesProvider } from '@/renderer/contexts/main/Addresses';
-import { AppSettingsProvider } from '@/renderer/contexts/main/AppSettings';
+import { AddressesProvider } from '@app/contexts/main/Addresses';
+import { AppSettingsProvider } from '@app/contexts/main/AppSettings';
 import { BootstrappingProvider } from '@app/contexts/main/Bootstrapping';
-import { ChainsProvider } from '@/renderer/contexts/main/Chains';
-import { EventsProvider } from '@/renderer/contexts/main/Events';
-import { ManageProvider } from '@/renderer/contexts/main/Manage';
+import { ChainsProvider } from '@app/contexts/main/Chains';
+import { EventsProvider } from '@app/contexts/main/Events';
+import { ManageProvider } from '@app/contexts/main/Manage';
 import { SubscriptionsProvider } from '@app/contexts/main/Subscriptions';
-import { IntervalSubscriptionsProvider } from './contexts/main/IntervalSubscriptions';
-import { IntervalTasksManagerProvider } from './contexts/main/IntervalTasksManager';
+import { IntervalSubscriptionsProvider } from '@app/contexts/main/IntervalSubscriptions';
+import { IntervalTasksManagerProvider } from '@app/contexts/main/IntervalTasksManager';
+import { DataBackupProvider } from '@app/contexts/main/DataBackup';
 
 // Import window contexts.
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
 import { AddressesProvider as ImportAddressesProvider } from '@app/contexts/import/Addresses';
-import { ImportHandlerProvider } from './contexts/import/ImportHandler';
-import { AddHandlerProvider } from './contexts/import/AddHandler';
-import { RemoveHandlerProvider } from './contexts/import/RemoveHandler';
-import { DeleteHandlerProvider } from './contexts/import/DeleteHandler';
+import { ImportHandlerProvider } from '@app/contexts/import/ImportHandler';
+import { AddHandlerProvider } from '@app/contexts/import/AddHandler';
+import { RemoveHandlerProvider } from '@app/contexts/import/RemoveHandler';
+import { DeleteHandlerProvider } from '@app/contexts/import/DeleteHandler';
 
 // Settings window contexts.
-import { SettingFlagsProvider } from './contexts/settings/SettingFlags';
-import { WebsocketServerProvider } from './contexts/settings/WebsocketServer';
-import { WorkspacesProvider } from './contexts/settings/Workspaces';
+import { SettingFlagsProvider } from '@app/contexts/settings/SettingFlags';
+import { WebsocketServerProvider } from '@app/contexts/settings/WebsocketServer';
+import { WorkspacesProvider } from '@app/contexts/settings/Workspaces';
 
 // Actions window contexts.
-import { TxMetaProvider } from '@/renderer/contexts/action/TxMeta';
+import { TxMetaProvider } from '@app/contexts/action/TxMeta';
 
 // OpenGov window contexts.
-import { TracksProvider } from './contexts/openGov/Tracks';
-import { TreasuryProvider } from './contexts/openGov/Treasury';
-import { ReferendaProvider } from './contexts/openGov/Referenda';
-import { ReferendaSubscriptionsProvider } from './contexts/openGov/ReferendaSubscriptions';
-import { TaskHandlerProvider } from './contexts/openGov/TaskHandler';
-import { PolkassemblyProvider } from './contexts/openGov/Polkassembly';
+import { TracksProvider } from '@app/contexts/openGov/Tracks';
+import { TreasuryProvider } from '@app/contexts/openGov/Treasury';
+import { ReferendaProvider } from '@app/contexts/openGov/Referenda';
+import { ReferendaSubscriptionsProvider } from '@app/contexts/openGov/ReferendaSubscriptions';
+import { TaskHandlerProvider } from '@app/contexts/openGov/TaskHandler';
+import { PolkassemblyProvider } from '@app/contexts/openGov/Polkassembly';
 
 // Other imports.
 import { Theme } from './Theme';
@@ -71,7 +72,9 @@ const getProvidersForWindow = () => {
         IntervalTasksManagerProvider,
         EventsProvider,
         // Online status relies on other contexts being initialized.
-        BootstrappingProvider
+        BootstrappingProvider,
+        // Requires setting state from other contexts.
+        DataBackupProvider
       )(Theme);
     }
     case 'import': {

--- a/src/renderer/contexts/common/Connections/defaults.ts
+++ b/src/renderer/contexts/common/Connections/defaults.ts
@@ -6,5 +6,7 @@ import type { ConnectionsContextInterface } from './types';
 
 export const defaultConnectionsContext: ConnectionsContextInterface = {
   isConnected: false,
+  isImporting: false,
   setIsConnected: (b) => {},
+  setIsImporting: (b) => {},
 };

--- a/src/renderer/contexts/common/Connections/index.tsx
+++ b/src/renderer/contexts/common/Connections/index.tsx
@@ -16,11 +16,16 @@ export const ConnectionsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  // Connection flag set to `true` when app is in online mode.
+  // Flag set to `true` when app is in online mode.
   const [isConnected, setIsConnected] = useState(false);
 
+  // Flag set to `true` when app is importing data from backup file.
+  const [isImporting, setIsImporting] = useState(false);
+
   return (
-    <ConnectionsContext.Provider value={{ isConnected, setIsConnected }}>
+    <ConnectionsContext.Provider
+      value={{ isConnected, setIsConnected, isImporting, setIsImporting }}
+    >
       {children}
     </ConnectionsContext.Provider>
   );

--- a/src/renderer/contexts/common/Connections/types.ts
+++ b/src/renderer/contexts/common/Connections/types.ts
@@ -3,5 +3,7 @@
 
 export interface ConnectionsContextInterface {
   isConnected: boolean;
-  setIsConnected: (flag: boolean) => void;
+  isImporting: boolean;
+  setIsConnected: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsImporting: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/src/renderer/contexts/import/AddHandler/index.tsx
+++ b/src/renderer/contexts/import/AddHandler/index.tsx
@@ -40,7 +40,7 @@ export const AddHandlerProvider = ({
     handleAddressAdd(source, address);
 
     // Update address data in store in main process.
-    await updateAddressInStore(source, address);
+    await updateAddressInStore(source, address, accountName);
 
     // Process added address in main renderer.
     if (isConnected) {
@@ -51,11 +51,12 @@ export const AddHandlerProvider = ({
   /// Update address in store.
   const updateAddressInStore = async (
     source: AccountSource,
-    address: string
+    address: string,
+    accountName: string
   ) => {
     const ipcTask: IpcTask = {
       action: 'raw-account:add',
-      data: { source, address },
+      data: { source, address, name: accountName },
     };
 
     await window.myAPI.rawAccountTask(ipcTask);

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -31,7 +31,7 @@ export const ImportHandlerProvider = ({
 }) => {
   const { isConnected } = useConnections();
   const { setStatusForAccount, insertAccountStatus } = useAccountStatuses();
-  const { handleAddressImport, isAlreadyImported } = useAddresses();
+  const { handleAddressImport } = useAddresses();
 
   /// Exposed function to import an address.
   const handleImportAddress = async (
@@ -70,11 +70,6 @@ export const ImportHandlerProvider = ({
     source: AccountSource
   ) => {
     const { address, isImported } = imported;
-
-    // Return if address is already imported.
-    if (isAlreadyImported(address)) {
-      return;
-    }
 
     // Set processing flag for account if it needs importing.
     isImported

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -69,15 +69,19 @@ export const ImportHandlerProvider = ({
     imported: LocalAddress | LedgerLocalAddress,
     source: AccountSource
   ) => {
-    const { address } = imported;
+    const { address, isImported } = imported;
 
     // Return if address is already imported.
     if (isAlreadyImported(address)) {
       return;
     }
 
+    // Set processing flag for account if it needs importing.
+    isImported
+      ? setStatusForAccount(address, source, true)
+      : insertAccountStatus(address, source);
+
     // Update addresses state and references.
-    insertAccountStatus(address, source);
     handleAddressImport(source, imported);
   };
 

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -76,10 +76,8 @@ export const ImportHandlerProvider = ({
       return;
     }
 
-    insertAccountStatus(address, source);
-    imported.isImported = false;
-
     // Update addresses state and references.
+    insertAccountStatus(address, source);
     handleAddressImport(source, imported);
   };
 

--- a/src/renderer/contexts/import/RemoveHandler/index.tsx
+++ b/src/renderer/contexts/import/RemoveHandler/index.tsx
@@ -27,13 +27,14 @@ export const RemoveHandlerProvider = ({
   /// Exposed function to remove an address.
   const handleRemoveAddress = async (
     address: string,
-    source: AccountSource
+    source: AccountSource,
+    accountName: string
   ) => {
     // Update addresses state and references.
     handleAddressRemove(source, address);
 
     // Update address data in store in main process.
-    await updateAddressInStore(source, address);
+    await updateAddressInStore(source, address, accountName);
 
     // Process removed address in main renderer.
     postAddressToMainWindow(address);
@@ -42,11 +43,12 @@ export const RemoveHandlerProvider = ({
   /// Update address in store.
   const updateAddressInStore = async (
     source: AccountSource,
-    address: string
+    address: string,
+    accountName: string
   ) => {
     const ipcTask: IpcTask = {
       action: 'raw-account:remove',
-      data: { source, address },
+      data: { source, address, name: accountName },
     };
 
     await window.myAPI.rawAccountTask(ipcTask);

--- a/src/renderer/contexts/import/RemoveHandler/types.ts
+++ b/src/renderer/contexts/import/RemoveHandler/types.ts
@@ -6,6 +6,7 @@ import type { AccountSource } from '@/types/accounts';
 export interface RemoveHandlerContextInterface {
   handleRemoveAddress: (
     address: string,
-    source: AccountSource
+    source: AccountSource,
+    accountName: string
   ) => Promise<void>;
 }

--- a/src/renderer/contexts/main/Addresses/index.tsx
+++ b/src/renderer/contexts/main/Addresses/index.tsx
@@ -48,21 +48,24 @@ export const AddressesProvider = ({
     chain: ChainID,
     source: AccountSource,
     address: string,
-    name: string
+    name: string,
+    fromBackup = false
   ) => {
     // Update accounts state.
     setAddresses(AccountsController.getAllFlattenedAccountData());
 
-    // Have main process send OS notification.
-    await window.myAPI.sendAccountTask({
-      action: 'account:import',
-      data: {
-        chainId: chain,
-        source,
-        address,
-        name,
-      },
-    });
+    // Show OS notification for new address imports.
+    if (!fromBackup) {
+      await window.myAPI.sendAccountTask({
+        action: 'account:import',
+        data: {
+          chainId: chain,
+          source,
+          address,
+          name,
+        },
+      });
+    }
   };
 
   // Removes an imported address.

--- a/src/renderer/contexts/main/Addresses/types.ts
+++ b/src/renderer/contexts/main/Addresses/types.ts
@@ -17,7 +17,8 @@ export interface AddressesContextInterface {
     n: ChainID,
     s: AccountSource,
     a: string,
-    b: string
+    b: string,
+    fromBackup: boolean
   ) => Promise<void>;
   removeAddress: (n: ChainID, a: string) => Promise<void>;
   getAddress: (a: string) => FlattenedAccountData | null;

--- a/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -132,11 +132,8 @@ export const BootstrappingProvider = ({
         );
 
         await Promise.all([
-          // Fetch account nonce and balance.
           fetchAccountBalances(),
-          // Use API instance to initialize account nomination pool data.
           fetchAccountNominationPoolData(),
-          // Initialize account nominating data.
           fetchAccountNominatingData(),
         ]);
       }
@@ -259,11 +256,8 @@ export const BootstrappingProvider = ({
     // Fetch up-to-date account data.
     if (!aborted) {
       await Promise.all([
-        // Fetch account nonce and balance.
         fetchAccountBalances(),
-        // Use API instance to initialize account nomination pool data.
         fetchAccountNominationPoolData(),
-        // Initialize account nominating data.
         fetchAccountNominatingData(),
       ]);
     }

--- a/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -21,9 +21,9 @@ import React, {
   useState,
 } from 'react';
 import { useAddresses } from '@app/contexts/main/Addresses';
-import { useChains } from '../Chains';
-import { useSubscriptions } from '../Subscriptions';
-import { useIntervalSubscriptions } from '../IntervalSubscriptions';
+import { useChains } from '@app/contexts/main/Chains';
+import { useSubscriptions } from '@app/contexts/main/Subscriptions';
+import { useIntervalSubscriptions } from '@app/contexts/main/IntervalSubscriptions';
 import { handleApiDisconnects } from '@/utils/ApiUtils';
 import type { BootstrappingInterface } from './types';
 import type { ChainID } from '@/types/chains';

--- a/src/renderer/contexts/main/DataBackup/default.ts
+++ b/src/renderer/contexts/main/DataBackup/default.ts
@@ -1,0 +1,10 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { DataBackupContextInterface } from './types';
+
+export const defaultDataBackupContext: DataBackupContextInterface = {
+  exportDataToBackup: () => new Promise(() => {}),
+  importDataFromBackup: () => new Promise(() => {}),
+};

--- a/src/renderer/contexts/main/DataBackup/index.tsx
+++ b/src/renderer/contexts/main/DataBackup/index.tsx
@@ -1,0 +1,371 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+/// Dependencies.
+import { createContext, useContext } from 'react';
+import { defaultDataBackupContext } from './default';
+import { AccountsController } from '@/controller/renderer/AccountsController';
+import { IntervalsController } from '@/controller/renderer/IntervalsController';
+import { SubscriptionsController } from '@/controller/renderer/SubscriptionsController';
+import { getAddressChainId } from '@/renderer/Utils';
+import {
+  getFromBackupFile,
+  postToImport,
+  postToOpenGov,
+  postToSettings,
+} from '@/renderer/utils/ImportUtils';
+
+/// Main window contexts.
+import { useAddresses } from '@app/contexts/main/Addresses';
+import { useEvents } from '@app/contexts/main/Events';
+import { useManage } from '../Manage';
+import { useIntervalSubscriptions } from '../IntervalSubscriptions';
+import { useSubscriptions } from '../Subscriptions';
+
+/// Types.
+import type {
+  DataBackupContextInterface,
+  ImportFunc,
+  RemoveFunc,
+} from './types';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@/types/accounts';
+import type { EventCallback } from '@/types/reporter';
+import type {
+  IntervalSubscription,
+  SubscriptionTask,
+} from '@/types/subscriptions';
+import type { ExportResult, ImportResult } from '@/types/backup';
+
+export const DataBackupContext = createContext<DataBackupContextInterface>(
+  defaultDataBackupContext
+);
+
+export const useDataBackup = () => useContext(DataBackupContext);
+
+export const DataBackupProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { setAddresses } = useAddresses();
+  const { setEvents } = useEvents();
+  const {
+    updateRenderedSubscriptions,
+    tryAddIntervalSubscription,
+    tryUpdateDynamicIntervalTask,
+  } = useManage();
+
+  const { setAccountSubscriptions } = useSubscriptions();
+  const { addIntervalSubscription, updateIntervalSubscription } =
+    useIntervalSubscriptions();
+
+  /// Write Polkadot Live data to a file.
+  const exportDataToBackup = async () => {
+    const { result, msg }: ExportResult = await window.myAPI.exportAppData();
+
+    // Render toastify message in settings window.
+    switch (msg) {
+      case 'success': {
+        postToSettings('settings:render:toast', {
+          success: result,
+          text: 'Data exported successfully.',
+        });
+        break;
+      }
+      case 'error': {
+        postToSettings('settings:render:toast', {
+          success: result,
+          text: 'Data export error.',
+        });
+        break;
+      }
+      case 'canceled': {
+        // Don't do anything on cancel.
+        break;
+      }
+      case 'executing': {
+        postToSettings('settings:render:toast', {
+          success: result,
+          text: 'Export dialog is already open.',
+        });
+        break;
+      }
+      default: {
+        throw new Error('Message not recognized');
+      }
+    }
+  };
+
+  /// Exported function for importing data from a backup file.
+  const importDataFromBackup = async (
+    handleImportAddress: ImportFunc,
+    handleRemoveAddress: RemoveFunc
+  ) => {
+    const response: ImportResult = await window.myAPI.importAppData();
+
+    switch (response.msg) {
+      case 'success': {
+        // Broadcast importing flag.
+        window.myAPI.relayModeFlag('isImporting', true);
+
+        try {
+          if (!response.data) {
+            throw new Error('No import data.');
+          }
+
+          // Import serialized data.
+          const { serialized: s } = response.data;
+          await importAddressData(s, handleImportAddress, handleRemoveAddress);
+          await importEventData(s);
+          await importIntervalData(s);
+          await importAccountTaskData(s);
+
+          postToSettings('settings:render:toast', {
+            success: response.result,
+            text: 'Data imported successfully.',
+          });
+        } catch (err) {
+          postToSettings('settings:render:toast', {
+            success: false,
+            text: 'Error parsing JSON.',
+          });
+        }
+
+        // Broadcast importing flag.
+        window.myAPI.relayModeFlag('isImporting', false);
+        break;
+      }
+      case 'canceled': {
+        // Don't do anything on cancel.
+        break;
+      }
+      case 'error': {
+        postToSettings('settings:render:toast', {
+          success: response.result,
+          text: 'Data import error.',
+        });
+        break;
+      }
+      default: {
+        throw new Error('Message not recognized');
+      }
+    }
+  };
+
+  /// Extract address data from an imported text file and send to application.
+  const importAddressData = async (
+    serialized: string,
+    handleImportAddress: ImportFunc,
+    handleRemoveAddress: RemoveFunc
+  ) => {
+    const s_addresses = getFromBackupFile('addresses', serialized);
+    if (!s_addresses) {
+      return;
+    }
+
+    const p_array: [AccountSource, string][] = JSON.parse(s_addresses);
+    const p_map = new Map<AccountSource, string>(p_array);
+    const importWindowOpen = await window.myAPI.isViewOpen('import');
+
+    for (const [source, ser] of p_map.entries()) {
+      const parsed =
+        source === 'ledger'
+          ? (JSON.parse(ser) as LedgerLocalAddress[])
+          : (JSON.parse(ser) as LocalAddress[]);
+
+      // Check connection status and set isImported to `false` if app is offline.
+      const isOnline: boolean =
+        (await window.myAPI.sendConnectionTaskAsync({
+          action: 'connection:getStatus',
+          data: null,
+        })) || false;
+
+      // Process parsed addresses.
+      for (const a of parsed) {
+        a.isImported && !isOnline && (a.isImported = false);
+
+        // Persist or update address in Electron store.
+        await window.myAPI.rawAccountTask({
+          action: 'raw-account:import',
+          data: { source, serialized: JSON.stringify(a) },
+        });
+
+        // Add address and its status to import window's state.
+        importWindowOpen &&
+          postToImport('import:account:add', {
+            json: JSON.stringify(a),
+            source,
+          });
+
+        // Handle importing or removing account from main window and setting `isImported` flag state.
+        const { address, name } = a;
+        const chainId = getAddressChainId(address);
+
+        if (a.isImported) {
+          const data = { data: { data: { address, chainId, name, source } } };
+          await handleImportAddress(new MessageEvent('message', data), true);
+          postToImport('import:address:update', { address: a, source });
+        } else {
+          const data = { data: { data: { address, chainId } } };
+          await handleRemoveAddress(new MessageEvent('message', data));
+          postToImport('import:address:update', { address: a, source });
+        }
+
+        // Update managed account names.
+        const account = AccountsController.get(chainId, address);
+        if (account) {
+          account.name = name;
+          AccountsController.update(chainId, account);
+        }
+      }
+
+      // Update account list state.
+      setAddresses(AccountsController.getAllFlattenedAccountData());
+    }
+  };
+
+  /// Extract event data from an imported text file and send to application.
+  const importEventData = async (serialized: string): Promise<void> => {
+    const s_events = getFromBackupFile('events', serialized);
+    if (!s_events) {
+      return;
+    }
+
+    // Send serialized events to main for processing.
+    const updated = (await window.myAPI.sendEventTaskAsync({
+      action: 'events:import',
+      data: { events: s_events },
+    })) as string;
+
+    const parsed: EventCallback[] = JSON.parse(updated);
+    setEvents(parsed);
+  };
+
+  /// Extract interval task data from an imported text file and send to application.
+  const importIntervalData = async (serialized: string): Promise<void> => {
+    const s_tasks = getFromBackupFile('intervals', serialized);
+    if (!s_tasks) {
+      return;
+    }
+
+    // Receive new tasks after persisting them to store.
+    const s_data =
+      (await window.myAPI.sendIntervalTask({
+        action: 'interval:tasks:import',
+        data: { serialized: s_tasks },
+      })) || '[]';
+
+    // Parse received tasks to insert and update.
+    const s_array: [string, string][] = JSON.parse(s_data);
+    const map = new Map<string, string>(s_array);
+
+    const inserts: IntervalSubscription[] = JSON.parse(
+      map.get('insert') || '[]'
+    );
+    const updates: IntervalSubscription[] = JSON.parse(
+      map.get('update') || '[]'
+    );
+
+    // Update manage subscriptions in controller and update React state.
+    if (inserts.length > 0) {
+      IntervalsController.insertSubscriptions(inserts);
+      inserts.forEach((t) => {
+        tryAddIntervalSubscription(t);
+        addIntervalSubscription(t);
+      });
+    }
+
+    if (updates.length > 0) {
+      IntervalsController.removeSubscriptions(updates);
+      updates.forEach((t) => {
+        t.status === 'enable' && IntervalsController.insertSubscription(t);
+        tryUpdateDynamicIntervalTask(t);
+        updateIntervalSubscription(t);
+      });
+    }
+
+    // Update state in OpenGov window.
+    if (await window.myAPI.isViewOpen('openGov')) {
+      inserts.forEach((t) => {
+        postToOpenGov('openGov:task:add', { serialized: JSON.stringify(t) });
+      });
+      updates.forEach((t) => {
+        postToOpenGov('openGov:task:update', { serialized: JSON.stringify(t) });
+      });
+    }
+  };
+
+  /// Extract account subscription data from an imported text file and send to application.
+  const importAccountTaskData = async (serialized: string) => {
+    const s_tasks = getFromBackupFile('accountTasks', serialized);
+    if (!s_tasks) {
+      return;
+    }
+
+    const s_array: [string, string][] = JSON.parse(s_tasks);
+    const s_map = new Map<string, string>(s_array);
+
+    // Store tasks to persist to store.
+    const s_persistMap = new Map<string, string>();
+
+    // Iterate map of serialized tasks keyed by an account address.
+    for (const [address, serTasks] of s_map.entries()) {
+      const parsed: SubscriptionTask[] = JSON.parse(serTasks);
+      if (parsed.length === 0) {
+        continue;
+      }
+
+      const account = AccountsController.get(parsed[0].chainId, address);
+      const valid: SubscriptionTask[] = [];
+
+      if (account) {
+        for (const t of parsed) {
+          if (
+            (t.category === 'Nomination Pools' &&
+              !account.nominationPoolData) ||
+            (t.category === 'Nominating' && !account.nominatingData)
+          ) {
+            // Throw away task if necessary.
+            continue;
+          }
+
+          // Otherwise subscribe to task.
+          await account?.subscribeToTask(t);
+          updateRenderedSubscriptions(t);
+          valid.push(t);
+        }
+      }
+
+      // Serialize the account's subscribed tasks.
+      valid.length > 0 && s_persistMap.set(address, JSON.stringify(valid));
+    }
+
+    // Set subscriptions React state.
+    setAccountSubscriptions(
+      SubscriptionsController.getAccountSubscriptions(
+        AccountsController.accounts
+      )
+    );
+
+    // Send successfully imported tasks to main process.
+    await window.myAPI.sendSubscriptionTask({
+      action: 'subscriptions:account:import',
+      data: { serialized: JSON.stringify(Array.from(s_persistMap.entries())) },
+    });
+  };
+
+  return (
+    <DataBackupContext.Provider
+      value={{
+        exportDataToBackup,
+        importDataFromBackup,
+      }}
+    >
+      {children}
+    </DataBackupContext.Provider>
+  );
+};

--- a/src/renderer/contexts/main/DataBackup/index.tsx
+++ b/src/renderer/contexts/main/DataBackup/index.tsx
@@ -76,15 +76,19 @@ export const DataBackupProvider = ({
         });
         break;
       }
+      case 'alreadyOpen': {
+        // Don't do anything.
+        break;
+      }
+      case 'canceled': {
+        // Don't do anything on cancel.
+        break;
+      }
       case 'error': {
         postToSettings('settings:render:toast', {
           success: result,
           text: 'Data export error.',
         });
-        break;
-      }
-      case 'canceled': {
-        // Don't do anything on cancel.
         break;
       }
       case 'executing': {
@@ -137,6 +141,10 @@ export const DataBackupProvider = ({
 
         // Broadcast importing flag.
         window.myAPI.relayModeFlag('isImporting', false);
+        break;
+      }
+      case 'alreadyOpen': {
+        // Don't do anything.
         break;
       }
       case 'canceled': {
@@ -219,7 +227,7 @@ export const DataBackupProvider = ({
         const account = AccountsController.get(chainId, address);
         if (account) {
           account.name = name;
-          AccountsController.update(chainId, account);
+          await AccountsController.set(chainId, account);
         }
       }
 

--- a/src/renderer/contexts/main/DataBackup/types.ts
+++ b/src/renderer/contexts/main/DataBackup/types.ts
@@ -1,0 +1,21 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { IntervalSubscription } from '@/types/subscriptions';
+
+export type ImportFunc = (
+  ev: MessageEvent,
+  fromBackup: boolean
+) => Promise<void>;
+
+export type RemoveFunc = (ev: MessageEvent) => Promise<void>;
+
+export type IntervalFunc = (t: IntervalSubscription) => void;
+
+export interface DataBackupContextInterface {
+  exportDataToBackup: () => Promise<void>;
+  importDataFromBackup: (
+    handleImportAddress: ImportFunc,
+    handleRemoveAddress: RemoveFunc
+  ) => Promise<void>;
+}

--- a/src/renderer/contexts/main/Events/defaults.ts
+++ b/src/renderer/contexts/main/Events/defaults.ts
@@ -6,6 +6,7 @@ import type { EventsContextInterface } from './types';
 
 export const defaultEventsContext: EventsContextInterface = {
   events: new Map(),
+  setEvents: () => {},
   addEvent: (e) => {},
   dismissEvent: (e) => {},
   sortAllGroupedEvents: (newestFirst) => new Map(),

--- a/src/renderer/contexts/main/Events/index.tsx
+++ b/src/renderer/contexts/main/Events/index.tsx
@@ -26,6 +26,20 @@ export const EventsProvider = ({ children }: { children: React.ReactNode }) => {
   /// Store the currently imported events
   const [events, setEventsState] = useState<EventsState>(new Map());
 
+  /// Set events (on event import).
+  const setEvents = (newEvents: EventCallback[]) => {
+    const map: EventsState = new Map();
+
+    for (const event of newEvents) {
+      const chainId = getEventChainId(event);
+      map.has(chainId)
+        ? map.set(chainId, [...map.get(chainId)!, event])
+        : map.set(chainId, [event]);
+    }
+
+    setEventsState(map);
+  };
+
   /// Removes an event item on a specified chain; compares event uid.
   const dismissEvent = ({ who: { data }, uid }: DismissEvent) => {
     setEventsState((prev) => {
@@ -214,6 +228,7 @@ export const EventsProvider = ({ children }: { children: React.ReactNode }) => {
       value={{
         events,
         addEvent,
+        setEvents,
         dismissEvent,
         sortAllEvents,
         sortAllGroupedEvents,

--- a/src/renderer/contexts/main/Events/types.ts
+++ b/src/renderer/contexts/main/Events/types.ts
@@ -6,6 +6,7 @@ import type { DismissEvent, EventCallback } from '@/types/reporter';
 
 export interface EventsContextInterface {
   events: EventsState;
+  setEvents: (events: EventCallback[]) => void;
   addEvent: (e: EventCallback) => void;
   dismissEvent: (e: DismissEvent) => void;
   sortAllEvents: (newestFirst: boolean) => EventCallback[];

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -42,7 +42,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
   const updateRenderedSubscriptions = (task: SubscriptionTask) => {
     setRenderedSubscriptionsState((prev) => ({
       ...prev,
-      tasks: prev.tasks.map((t) => (t.action === task.action ? task : t)),
+      tasks: prev.tasks.map((t) => (compareTasks(task, t) ? task : t)),
     }));
   };
 
@@ -137,6 +137,30 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     }
 
     return map;
+  };
+
+  /// Determine if two tasks are the same task.
+  const compareTasks = (a: SubscriptionTask, b: SubscriptionTask): boolean => {
+    // Different task types.
+    if (!a.account && b.account) {
+      return false;
+    }
+
+    // Compare chain tasks.
+    if (!a.account && !b.account) {
+      return a.chainId === b.chainId && a.action === b.action;
+    }
+
+    // Account account tasks.
+    if (a.account && b.account) {
+      return (
+        a.account.address === b.account.address &&
+        a.action === b.action &&
+        a.chainId === b.chainId
+      );
+    }
+
+    return false;
   };
 
   return (

--- a/src/renderer/hooks/useAppModesSyncing.ts
+++ b/src/renderer/hooks/useAppModesSyncing.ts
@@ -1,0 +1,38 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useConnections } from '@app/contexts/common/Connections';
+import { useEffect } from 'react';
+
+/**
+ * Hook automatically listens for and sets mode flag state when they are
+ * updated in other processes.
+ *
+ * Hook also immediately sets this renderer's mode flag state which is
+ * consistent with the app.
+ */
+
+export const useAppModesSyncing = () => {
+  const { setIsImporting } = useConnections();
+
+  useEffect(() => {
+    const syncModeFlags = async () => {
+      setIsImporting(await window.myAPI.getModeFlag('isImporting'));
+    };
+
+    // Listen for setting events.
+    window.myAPI.syncModeFlags((_, modeId, flag) => {
+      switch (modeId) {
+        case 'isImporting': {
+          setIsImporting(flag);
+          break;
+        }
+        default: {
+          break;
+        }
+      }
+    });
+
+    syncModeFlags();
+  }, []);
+};

--- a/src/renderer/hooks/useImportMessagePorts.ts
+++ b/src/renderer/hooks/useImportMessagePorts.ts
@@ -4,6 +4,7 @@
 import { Config as ConfigImport } from '@/config/processes/import';
 
 /// Import window contexts.
+import { useAddresses } from '@app/contexts/import/Addresses';
 import { useImportHandler } from '@app/contexts/import/ImportHandler';
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useConnections } from '@/renderer/contexts/common/Connections';
@@ -18,6 +19,7 @@ export const useImportMessagePorts = () => {
   const { handleImportAddressFromBackup } = useImportHandler();
   const { setIsConnected } = useConnections();
   const { setStatusForAccount } = useAccountStatuses();
+  const { handleAddressImport } = useAddresses();
 
   /**
    * @name handleReceivedPort
@@ -34,6 +36,7 @@ export const useImportMessagePorts = () => {
           // Message received from `main`.
           switch (ev.data.task) {
             case 'import:account:add': {
+              // Import an address from a backup file.
               const { json, source }: { json: string; source: AccountSource } =
                 ev.data.data;
 
@@ -53,6 +56,12 @@ export const useImportMessagePorts = () => {
             case 'import:connection:status': {
               const { status } = ev.data.data;
               setIsConnected(status);
+              break;
+            }
+            case 'import:address:update': {
+              // Update state for an address.
+              const { address, source } = ev.data.data;
+              handleAddressImport(source, address);
               break;
             }
             default: {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -348,7 +348,8 @@ export const useMainMessagePorts = () => {
           await importAddresses(
             serialized,
             handleImportAddress,
-            handleRemoveAddress
+            handleRemoveAddress,
+            setAddresses
           );
 
           // Events.

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -195,7 +195,7 @@ export const useMainMessagePorts = () => {
 
   /**
    * @name handleRemoveAddress
-   * @summary Removes an account a message is received from `import` window.
+   * @summary Removes an account when a message is received from `import` window.
    *
    * Also called when deleting an account.
    */
@@ -250,21 +250,17 @@ export const useMainMessagePorts = () => {
     const { address, chainId, newName } = ev.data.data;
     const account = AccountsController.get(chainId, address);
 
-    if (!account) {
-      // Account not found in controller.
-      console.log('account not imported');
-      return;
+    if (account) {
+      // Set new account name and persist new account data to storage.
+      account.name = newName;
+      await AccountsController.set(chainId, account);
+
+      // Update account react state.
+      setAddresses(AccountsController.getAllFlattenedAccountData());
+
+      // Update subscription task react state.
+      updateAccountNameInTasks(address, newName);
     }
-
-    // Set new account name and persist new account data to storage.
-    account.name = newName;
-    await AccountsController.set(chainId, account);
-
-    // Update account react state.
-    setAddresses(AccountsController.getAllFlattenedAccountData());
-
-    // Update subscription task react state.
-    updateAccountNameInTasks(address, newName);
 
     // The updated events will be sent back to the renderer for updating React state.
     const serialized = (await window.myAPI.sendEventTaskAsync({

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -14,7 +14,11 @@ import {
   fetchNominatingDataForAccount,
   fetchNominationPoolDataForAccount,
 } from '@/utils/AccountUtils';
-import { importAddresses, importEvents } from '@app/utils/ImportUtils';
+import {
+  importAddresses,
+  importEvents,
+  importIntervalTasks,
+} from '@app/utils/ImportUtils';
 import { getApiInstanceOrThrow, handleApiDisconnects } from '@/utils/ApiUtils';
 import { isObject, u8aConcat } from '@polkadot/util';
 import { planckToUnit, rmCommas } from '@w3ux/utils';
@@ -56,6 +60,7 @@ export const useMainMessagePorts = () => {
     setRenderedSubscriptions,
     tryAddIntervalSubscription,
     tryRemoveIntervalSubscription,
+    tryUpdateDynamicIntervalTask,
   } = useManage();
 
   const {
@@ -71,8 +76,11 @@ export const useMainMessagePorts = () => {
   const { setAccountSubscriptions, updateAccountNameInTasks, updateTask } =
     useSubscriptions();
 
-  const { addIntervalSubscription, removeIntervalSubscription } =
-    useIntervalSubscriptions();
+  const {
+    addIntervalSubscription,
+    removeIntervalSubscription,
+    updateIntervalSubscription,
+  } = useIntervalSubscriptions();
 
   /**
    * @name setSubscriptionsAndChainConnections
@@ -308,6 +316,13 @@ export const useMainMessagePorts = () => {
           const { serialized } = response.data;
           await importAddresses(serialized);
           await importEvents(serialized, setEvents);
+          await importIntervalTasks(
+            serialized,
+            tryAddIntervalSubscription,
+            tryUpdateDynamicIntervalTask,
+            addIntervalSubscription,
+            updateIntervalSubscription
+          );
 
           postToSettings(response.result, 'Data imported successfully.');
         } catch (err) {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -53,7 +53,6 @@ export const useMainMessagePorts = () => {
   const { importAddress, removeAddress, setAddresses } = useAddresses();
   const { addChain } = useChains();
   const { setEvents, updateEventsOnAccountRename } = useEvents();
-
   const { syncImportWindow, syncOpenGovWindow } = useBootstrapping();
 
   const {
@@ -335,6 +334,9 @@ export const useMainMessagePorts = () => {
 
     switch (response.msg) {
       case 'success': {
+        // Broadcast importing flag.
+        window.myAPI.relayModeFlag('isImporting', true);
+
         try {
           if (!response.data) {
             throw new Error('No import data.');
@@ -373,6 +375,8 @@ export const useMainMessagePorts = () => {
           postToSettings(false, 'Error parsing JSON.');
         }
 
+        // Broadcast importing flag.
+        window.myAPI.relayModeFlag('isImporting', false);
         break;
       }
       case 'canceled': {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -14,7 +14,7 @@ import {
   fetchNominatingDataForAccount,
   fetchNominationPoolDataForAccount,
 } from '@/utils/AccountUtils';
-import { importAddresses } from '@app/utils/ImportUtils';
+import { importAddresses, importEvents } from '@app/utils/ImportUtils';
 import { getApiInstanceOrThrow, handleApiDisconnects } from '@/utils/ApiUtils';
 import { isObject, u8aConcat } from '@polkadot/util';
 import { planckToUnit, rmCommas } from '@w3ux/utils';
@@ -47,7 +47,7 @@ export const useMainMessagePorts = () => {
   /// Main renderer contexts.
   const { importAddress, removeAddress, setAddresses } = useAddresses();
   const { addChain } = useChains();
-  const { updateEventsOnAccountRename } = useEvents();
+  const { setEvents, updateEventsOnAccountRename } = useEvents();
 
   const { syncImportWindow, syncOpenGovWindow } = useBootstrapping();
 
@@ -307,6 +307,7 @@ export const useMainMessagePorts = () => {
 
           const { serialized } = response.data;
           await importAddresses(serialized);
+          await importEvents(serialized, setEvents);
 
           postToSettings(response.result, 'Data imported successfully.');
         } catch (err) {

--- a/src/renderer/hooks/useSettingsMessagePorts.ts
+++ b/src/renderer/hooks/useSettingsMessagePorts.ts
@@ -4,8 +4,8 @@
 import { Config as ConfigSettings } from '@/config/processes/settings';
 
 /// Settings window contexts.
-import { useSettingFlags } from '@app/contexts/settings/SettingFlags';
 import { useEffect } from 'react';
+import { useSettingFlags } from '@app/contexts/settings/SettingFlags';
 
 export const useSettingsMessagePorts = () => {
   const { setWindowDocked, setSilenceOsNotifications, renderToastify } =

--- a/src/renderer/screens/Home/Manage/IntervalRow.tsx
+++ b/src/renderer/screens/Home/Manage/IntervalRow.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useBootstrapping } from '@/renderer/contexts/main/Bootstrapping';
+import { useConnections } from '@/renderer/contexts/common/Connections';
 import { useHelp } from '@/renderer/contexts/common/Help';
 import { useIntervalTasksManager } from '@/renderer/contexts/main/IntervalTasksManager';
 import { useTooltip } from '@/renderer/contexts/common/Tooltip';
@@ -23,10 +24,12 @@ import { getShortIntervalLabel } from '@/renderer/utils/renderingUtils';
 import type { AnyData } from '@/types/misc';
 import type { IntervalRowProps } from './types';
 
-export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
+export const IntervalRow = ({ task }: IntervalRowProps) => {
   const { openHelp } = useHelp();
   const { setTooltipTextAndOpen } = useTooltip();
-  const { online: isConnected } = useBootstrapping();
+  const { online: isConnected, isConnecting } = useBootstrapping();
+  const { isImporting } = useConnections();
+
   const {
     handleIntervalToggle,
     handleIntervalNativeCheckbox,
@@ -48,6 +51,14 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
   const [intervalSetting, setIntervalSetting] = useState(
     task.intervalSetting.ticksToWait
   );
+
+  const [isDisabled, setIsDisabled] = useState<boolean>(
+    isConnecting || !isConnected || isImporting
+  );
+
+  useEffect(() => {
+    setIsDisabled(isConnecting || !isConnected || isImporting);
+  }, [isConnecting, isConnected, isImporting]);
 
   useEffect(() => {
     const newStatusToBoolean = task.status === 'enable';
@@ -74,7 +85,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
   };
 
   const handleNativeCheckbox = async () => {
-    if (!isTaskDisabled() && task.status === 'enable') {
+    if (!isDisabled && task.status === 'enable') {
       const flag = !nativeChecked;
       await handleIntervalNativeCheckbox(task, flag);
       setNativeChecked(flag);
@@ -149,7 +160,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
             onMouseMove={() => setTooltipTextAndOpen('Get Notification')}
           >
             {/* One-shot is enabled and not processing. */}
-            {!isTaskDisabled() && !oneShotProcessing && (
+            {!isDisabled && !oneShotProcessing && (
               <FontAwesomeIcon
                 className="enabled"
                 icon={faAnglesDown}
@@ -161,7 +172,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
             )}
 
             {/* One-shot is enabled and processing */}
-            {!isTaskDisabled() && oneShotProcessing && (
+            {!isDisabled && oneShotProcessing && (
               <FontAwesomeIcon
                 className="processing"
                 fade
@@ -171,7 +182,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
             )}
 
             {/* One-shot disabled */}
-            {isTaskDisabled() && (
+            {isDisabled && (
               <FontAwesomeIcon
                 className="disabled"
                 icon={faAnglesDown}
@@ -186,13 +197,11 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
             data-tooltip-text={'Set Interval'}
             onMouseMove={() => setTooltipTextAndOpen('Set Interval')}
           >
-            {!intervalClicked || isTaskDisabled() ? (
+            {!intervalClicked || isDisabled ? (
               <div
                 className="badge-container"
                 onClick={() =>
-                  setIntervalClicked((prev) =>
-                    isTaskDisabled() ? prev : !prev
-                  )
+                  setIntervalClicked((prev) => (isDisabled ? prev : !prev))
                 }
               >
                 <div className="interval-badge">
@@ -202,7 +211,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
                   style={{
                     position: 'absolute',
                     top: '-4px',
-                    opacity: isTaskDisabled() ? '0.3' : '1',
+                    opacity: isDisabled ? '0.3' : '1',
                   }}
                   className="enabled"
                   icon={faClock}
@@ -212,7 +221,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
             ) : (
               <div className="select-wrapper">
                 <select
-                  disabled={isTaskDisabled()}
+                  disabled={isDisabled}
                   className="select-interval"
                   id="select-interval"
                   value={intervalSetting}
@@ -251,7 +260,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
               {/* Main icon */}
               <FontAwesomeIcon
                 className={
-                  !isTaskDisabled() && task.status === 'enable'
+                  !isDisabled && task.status === 'enable'
                     ? nativeChecked
                       ? 'checked'
                       : 'unchecked'
@@ -276,7 +285,7 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
 
           {/* Toggle Switch */}
           <Switch
-            disabled={isTaskDisabled()}
+            disabled={isDisabled}
             size="sm"
             type="primary"
             isOn={isToggled}

--- a/src/renderer/screens/Home/Manage/IntervalRow.tsx
+++ b/src/renderer/screens/Home/Manage/IntervalRow.tsx
@@ -55,6 +55,14 @@ export const IntervalRow = ({ task, isTaskDisabled }: IntervalRowProps) => {
   }, [task.status]);
 
   useEffect(() => {
+    setIntervalSetting(task.intervalSetting.ticksToWait);
+  }, [task.intervalSetting]);
+
+  useEffect(() => {
+    setNativeChecked(task.enableOsNotifications);
+  }, [task.enableOsNotifications]);
+
+  useEffect(() => {
     if (!isConnected) {
       setIntervalClicked(false);
     }

--- a/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -43,6 +43,7 @@ import type {
   SubscriptionTask,
   TaskCategory,
 } from '@/types/subscriptions';
+import { useConnections } from '@/renderer/contexts/common/Connections';
 
 export const Permissions = ({
   breadcrumb,
@@ -52,6 +53,7 @@ export const Permissions = ({
 }: PermissionsProps) => {
   const { setTooltipTextAndOpen } = useTooltip();
   const { showDebuggingSubscriptions } = useAppSettings();
+  const { isImporting } = useConnections();
   const { online: isOnline, isConnecting } = useBootstrapping();
 
   const { updateTask, handleQueuedToggle, toggleCategoryTasks, getTaskType } =
@@ -143,7 +145,7 @@ export const Permissions = ({
   /// Determine whether the toggle should be disabled based on the
   /// task and account data.
   const getDisabled = (task: SubscriptionTask) => {
-    if (!isOnline || isConnecting) {
+    if (!isOnline || isConnecting || isImporting) {
       return true;
     }
 
@@ -168,7 +170,7 @@ export const Permissions = ({
   };
 
   /// Determines if interval task should be disabled.
-  const isIntervalTaskDisabled = () => !isOnline || isConnecting;
+  const isIntervalTaskDisabled = () => !isOnline || isConnecting || isImporting;
 
   /// Get unique key for the task row component.
   const getKey = (
@@ -483,7 +485,6 @@ export const Permissions = ({
                 {intervalTasks.map((task: IntervalSubscription, j: number) => (
                   <IntervalRow
                     key={`${j}_${task.referendumId}_${task.action}`}
-                    isTaskDisabled={isIntervalTaskDisabled}
                     task={task}
                   />
                 ))}

--- a/src/renderer/screens/Home/Manage/index.tsx
+++ b/src/renderer/screens/Home/Manage/index.tsx
@@ -10,7 +10,7 @@ import type { ManageProps } from './types';
 import type { SubscriptionTaskType } from '@/types/subscriptions';
 
 export const Manage = ({ addresses }: ManageProps) => {
-  // Store the currently active maange tab.
+  // Store the currently active manage tab.
   const [section, setSection] = useState<number>(0);
 
   // Outermost breadcrumb title.

--- a/src/renderer/screens/Home/Manage/types.tsx
+++ b/src/renderer/screens/Home/Manage/types.tsx
@@ -46,5 +46,4 @@ export interface PermissionRowProps {
 
 export interface IntervalRowProps {
   task: IntervalSubscription;
-  isTaskDisabled: () => boolean;
 }

--- a/src/renderer/screens/Home/index.tsx
+++ b/src/renderer/screens/Home/index.tsx
@@ -14,20 +14,22 @@ import { Manage } from './Manage';
 import { CarouselWrapper, IconWrapper, TabsWrapper } from './Wrappers';
 import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { useInitIpcHandlers } from '@app/hooks/useInitIpcHandlers';
+import { useMainMessagePorts } from '@/renderer/hooks/useMainMessagePorts';
+import { useAppModesSyncing } from '@/renderer/hooks/useAppModesSyncing';
 import type { ChainID } from '@/types/chains';
 import type { EventCallback } from '@/types/reporter';
 import type { IpcRendererEvent } from 'electron';
-import { useMainMessagePorts } from '@/renderer/hooks/useMainMessagePorts';
 
 export const Home = () => {
   // Set up port communication for the `main` renderer.
   useMainMessagePorts();
-
-  const { getAddresses } = useAddresses();
-  const { addEvent, markStaleEvent, removeOutdatedEvents } = useEvents();
+  useAppModesSyncing();
 
   // Set up app initialization and online/offline switching handlers.
   useInitIpcHandlers();
+
+  const { getAddresses } = useAddresses();
+  const { addEvent, markStaleEvent, removeOutdatedEvents } = useEvents();
 
   // Get app loading flag.
   const { appLoading } = useBootstrapping();

--- a/src/renderer/screens/Import/Addresses/Remove.tsx
+++ b/src/renderer/screens/Import/Addresses/Remove.tsx
@@ -9,12 +9,12 @@ import { ButtonMono } from '@/renderer/kits/Buttons/ButtonMono';
 import { useRemoveHandler } from '@/renderer/contexts/import/RemoveHandler';
 import type { RemoveProps } from './types';
 
-export const Remove = ({ address, source }: RemoveProps) => {
+export const Remove = ({ address, source, accountName }: RemoveProps) => {
   const { setStatus } = useOverlay();
   const { handleRemoveAddress } = useRemoveHandler();
 
   const handleClickRemove = async () => {
-    await handleRemoveAddress(address, source);
+    await handleRemoveAddress(address, source, accountName);
     setStatus(0);
   };
 

--- a/src/renderer/screens/Import/Addresses/types.ts
+++ b/src/renderer/screens/Import/Addresses/types.ts
@@ -1,14 +1,11 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AccountSource } from '@/types/accounts';
+import type { AccountSource, LocalAddress } from '@/types/accounts';
 import type { AnyFunction } from '@/types/misc';
 
 export interface AddressProps {
-  accountName: string;
-  source: AccountSource;
-  address: string;
-  isImported: boolean;
+  localAddress: LocalAddress;
   setSection: AnyFunction;
   orderData: {
     curIndex: number;
@@ -23,6 +20,7 @@ export interface ConfirmProps {
 }
 
 export interface RemoveProps {
+  accountName: string;
   address: string;
   source: AccountSource;
 }

--- a/src/renderer/screens/Import/Ledger/Manage.tsx
+++ b/src/renderer/screens/Import/Ledger/Manage.tsx
@@ -12,6 +12,7 @@ import { determineStatusFromCodes } from './Utils';
 import { ButtonText } from '@/renderer/kits/Buttons/ButtonText';
 import { ContentWrapper } from '../../Wrappers';
 import { getSortedLocalLedgerAddresses } from '@/renderer/utils/ImportUtils';
+import { useAddresses } from '@/renderer/contexts/import/Addresses';
 import { useState } from 'react';
 import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCaretHeaders';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
@@ -24,13 +25,14 @@ import {
 import type { ImportLedgerManageProps } from '../types';
 
 export const Manage = ({
-  addresses,
   isImporting,
   statusCodes,
   toggleImport,
   cancelImport,
   setSection,
 }: ImportLedgerManageProps) => {
+  const { ledgerAddresses: addresses } = useAddresses();
+
   // Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
     number[]
@@ -95,23 +97,17 @@ export const Manage = ({
                     <AccordionPanel>
                       <div className="items-wrapper">
                         <div className="items round-primary-border">
-                          {chainAddresses.map(
-                            ({ address, index, isImported, name }, j) => (
-                              <Address
-                                key={`address_${name}`}
-                                address={address}
-                                source={'ledger'}
-                                accountName={name}
-                                index={index || 0}
-                                isImported={isImported}
-                                orderData={{
-                                  curIndex: j,
-                                  lastIndex: chainAddresses.length - 1,
-                                }}
-                                setSection={setSection}
-                              />
-                            )
-                          )}
+                          {chainAddresses.map((localAddress, j) => (
+                            <Address
+                              key={`address_${localAddress.name}`}
+                              localAddress={localAddress}
+                              orderData={{
+                                curIndex: j,
+                                lastIndex: chainAddresses.length - 1,
+                              }}
+                              setSection={setSection}
+                            />
+                          ))}
                         </div>
                       </div>
                     </AccordionPanel>

--- a/src/renderer/screens/Import/Ledger/index.tsx
+++ b/src/renderer/screens/Import/Ledger/index.tsx
@@ -179,7 +179,6 @@ export const ImportLedger = ({ setSection, curSource }: ImportLedgerProps) => {
     <Splash setSection={setSection} statusCodes={statusCodesRef.current} />
   ) : (
     <Manage
-      addresses={addresses}
       isImporting={isImporting}
       toggleImport={toggleImport}
       statusCodes={statusCodes}

--- a/src/renderer/screens/Import/ReadOnly/Address.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Address.tsx
@@ -9,32 +9,29 @@ import {
   renameAccountInStore,
 } from '@/renderer/utils/ImportUtils';
 import { Remove } from '../Addresses/Remove';
+import { useAddresses } from '@/renderer/contexts/import/Addresses';
 import { useOverlay } from '@/renderer/contexts/common/Overlay';
-import { useState } from 'react';
 import type { AddressProps } from '../Addresses/types';
 
 export const Address = ({
-  address,
-  source,
-  accountName,
-  isImported,
+  localAddress,
   setSection,
   orderData,
 }: AddressProps) => {
+  const { address, isImported, name, source } = localAddress;
   const { openOverlayWith } = useOverlay();
-
-  // State for account name.
-  const [accountNameState, setAccountNameState] = useState<string>(accountName);
+  const { handleAddressImport } = useAddresses();
 
   // Handler to rename an account.
   const renameHandler = async (who: string, newName: string) => {
-    setAccountNameState(newName);
-
     // Update name in store in main process.
-    await renameAccountInStore(who, 'read-only', newName);
+    await renameAccountInStore(address, source, newName);
 
     // Post message to main renderer to process the account rename.
     postRenameAccount(who, newName);
+
+    // Update import window address state
+    handleAddressImport(source, { ...localAddress, name: newName });
   };
 
   return (
@@ -44,21 +41,17 @@ export const Address = ({
       source={source}
       isImported={isImported}
       orderData={orderData}
-      accountName={accountNameState}
+      accountName={name}
       renameHandler={renameHandler}
       openRemoveHandler={() =>
         openOverlayWith(
-          <Remove address={address} source="read-only" />,
+          <Remove address={address} source="read-only" accountName={name} />,
           'small'
         )
       }
       openConfirmHandler={() =>
         openOverlayWith(
-          <Confirm
-            address={address}
-            name={accountNameState}
-            source="read-only"
-          />,
+          <Confirm address={address} name={name} source="read-only" />,
           'small'
         )
       }

--- a/src/renderer/screens/Import/ReadOnly/Manage.tsx
+++ b/src/renderer/screens/Import/ReadOnly/Manage.tsx
@@ -36,7 +36,6 @@ import {
 
 /// Type imports.
 import type { FormEvent } from 'react';
-import type { LocalAddress } from '@/types/accounts';
 import type { ManageReadOnlyProps } from '../types';
 
 export const Manage = ({ setSection }: ManageReadOnlyProps) => {
@@ -194,25 +193,17 @@ export const Manage = ({ setSection }: ManageReadOnlyProps) => {
                         <div className="items round-primary-border">
                           {addresses.length ? (
                             <>
-                              {chainAddresses.map(
-                                (
-                                  { address, isImported, name }: LocalAddress,
-                                  j
-                                ) => (
-                                  <Address
-                                    key={`address_${name}`}
-                                    accountName={name}
-                                    source={'read-only'}
-                                    address={address}
-                                    isImported={isImported || false}
-                                    orderData={{
-                                      curIndex: j,
-                                      lastIndex: chainAddresses.length - 1,
-                                    }}
-                                    setSection={setSection}
-                                  />
-                                )
-                              )}
+                              {chainAddresses.map((localAddress, j) => (
+                                <Address
+                                  key={`address_${localAddress.name}`}
+                                  localAddress={localAddress}
+                                  orderData={{
+                                    curIndex: j,
+                                    lastIndex: chainAddresses.length - 1,
+                                  }}
+                                  setSection={setSection}
+                                />
+                              ))}
                             </>
                           ) : (
                             <p>No read only addresses imported.</p>

--- a/src/renderer/screens/Import/Vault/Manage.tsx
+++ b/src/renderer/screens/Import/Vault/Manage.tsx
@@ -24,9 +24,11 @@ import {
 } from '@/renderer/utils/common';
 import { ButtonPrimaryInvert } from '@/renderer/kits/Buttons/ButtonPrimaryInvert';
 import type { ManageVaultProps } from '../types';
+import { useAddresses } from '@/renderer/contexts/import/Addresses';
 
-export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
+export const Manage = ({ setSection }: ManageVaultProps) => {
   const { openOverlayWith } = useOverlay();
+  const { vaultAddresses: addresses } = useAddresses();
 
   // Active accordion indices for account subscription tasks categories.
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
@@ -74,7 +76,7 @@ export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
 
         {/* Address List */}
         <ContentWrapper style={{ padding: '1rem 2rem 0' }}>
-          {addresses.length ? (
+          {addresses.length && (
             <Accordion
               multiple
               defaultIndex={accordionActiveIndices}
@@ -95,22 +97,17 @@ export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
                       <AccordionPanel>
                         <div className="items-wrapper">
                           <div className="items round-primary-border">
-                            {chainAddresses.map(
-                              ({ address, isImported, name }, j) => (
-                                <Address
-                                  key={`address_${name}`}
-                                  accountName={name}
-                                  source={'vault'}
-                                  address={address}
-                                  isImported={isImported || false}
-                                  setSection={setSection}
-                                  orderData={{
-                                    curIndex: j,
-                                    lastIndex: chainAddresses.length - 1,
-                                  }}
-                                />
-                              )
-                            )}
+                            {chainAddresses.map((localAddress, j) => (
+                              <Address
+                                key={`address_${localAddress.name}`}
+                                localAddress={localAddress}
+                                setSection={setSection}
+                                orderData={{
+                                  curIndex: j,
+                                  lastIndex: chainAddresses.length - 1,
+                                }}
+                              />
+                            ))}
                           </div>
                         </div>
                       </AccordionPanel>
@@ -119,7 +116,7 @@ export const Manage = ({ setSection, addresses }: ManageVaultProps) => {
                 )
               )}
             </Accordion>
-          ) : null}
+          )}
         </ContentWrapper>
       </Scrollable>
 

--- a/src/renderer/screens/Import/Vault/index.tsx
+++ b/src/renderer/screens/Import/Vault/index.tsx
@@ -12,10 +12,6 @@ export const ImportVault = ({ section, setSection }: ImportVaultProps) => {
   return !vaultAddresses.length ? (
     <Splash setSection={setSection} />
   ) : (
-    <Manage
-      section={section}
-      setSection={setSection}
-      addresses={vaultAddresses}
-    />
+    <Manage section={section} setSection={setSection} />
   );
 };

--- a/src/renderer/screens/Import/index.tsx
+++ b/src/renderer/screens/Import/index.tsx
@@ -9,18 +9,19 @@ import { ModalSection } from '@/renderer/kits/Overlay/structure/ModalSection';
 import { ModalMotionTwoSection } from '@/renderer/kits/Overlay/structure/ModalMotionTwoSection';
 import { ImportReadOnly } from './ReadOnly';
 import { useImportMessagePorts } from '@/renderer/hooks/useImportMessagePorts';
-import type { AccountSource } from '@/types/accounts';
 import { useDebug } from '@/renderer/hooks/useDebug';
+import { useAppModesSyncing } from '@/renderer/hooks/useAppModesSyncing';
+import type { AccountSource } from '@/types/accounts';
 
 export const Import: React.FC = () => {
   // Set up port communication for `import` window.
   useImportMessagePorts();
+  useAppModesSyncing();
   useDebug(window.myAPI.getWindowId());
-
-  const [source, setSource] = useState<AccountSource | null>(null);
 
   // Active section
   const [section, setSection] = useState<number>(0);
+  const [source, setSource] = useState<AccountSource | null>(null);
 
   useEffect(() => {
     if (section === 0) {

--- a/src/renderer/screens/Import/types.ts
+++ b/src/renderer/screens/Import/types.ts
@@ -3,11 +3,7 @@
 
 import type { AnyFunction, AnyJson } from '@/types/misc';
 import type { Html5Qrcode } from 'html5-qrcode';
-import type {
-  AccountSource,
-  LedgerLocalAddress,
-  LocalAddress,
-} from '@/types/accounts';
+import type { AccountSource, LedgerLocalAddress } from '@/types/accounts';
 import type { LedgerResponse } from '@/types/ledger';
 
 export interface HomeProps {
@@ -32,7 +28,6 @@ export interface VaultSplashProps {
 export interface ManageVaultProps {
   setSection: React.Dispatch<React.SetStateAction<number>>;
   section: number;
-  addresses: LocalAddress[];
 }
 
 export interface Html5QrScannerProps {
@@ -48,7 +43,6 @@ export interface ImportLedgerProps {
 }
 
 export interface ImportLedgerManageProps {
-  addresses: LedgerLocalAddress[];
   isImporting: boolean;
   statusCodes: LedgerResponse[];
   toggleImport: AnyFunction;
@@ -57,11 +51,7 @@ export interface ImportLedgerManageProps {
 }
 
 export interface LedgerAddressProps {
-  accountName: string;
-  address: string;
-  source: AccountSource;
-  index: number;
-  isImported: boolean;
+  localAddress: LedgerLocalAddress;
   orderData: {
     curIndex: number;
     lastIndex: number;

--- a/src/renderer/screens/Settings/Setting.tsx
+++ b/src/renderer/screens/Settings/Setting.tsx
@@ -3,18 +3,20 @@
 
 import { faInfo } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { SettingWrapper } from './Wrappers';
+import { SettingWrapper, SpinnerWrapper } from './Wrappers';
 import { Switch } from '@/renderer/library/Switch';
 import { useHelp } from '@/renderer/contexts/common/Help';
-import { ButtonMonoInvert } from '@/renderer/kits/Buttons/ButtonMonoInvert';
-import { useSettingFlags } from '@/renderer/contexts/settings/SettingFlags';
-import type { SettingProps } from './types';
+import { ButtonMonoInvert } from '@app/kits/Buttons/ButtonMonoInvert';
+import { useConnections } from '@app/contexts/common/Connections';
+import { useSettingFlags } from '@app/contexts/settings/SettingFlags';
+import type { SettingAction, SettingProps } from './types';
 
 export const Setting = ({ setting, handleSetting }: SettingProps) => {
   const { title, settingType, helpKey } = setting;
 
   const { openHelp } = useHelp();
   const { getSwitchState, handleSwitchToggle } = useSettingFlags();
+  const { isImporting } = useConnections();
 
   /// Handle a setting switch toggle.
   const handleSwitchToggleOuter = () => {
@@ -39,6 +41,10 @@ export const Setting = ({ setting, handleSetting }: SettingProps) => {
     }
   };
 
+  /// Determine if switch should be disabled.
+  const getDisabled = (action: SettingAction): boolean =>
+    action === 'settings:execute:importData' ? isImporting : false;
+
   return (
     <SettingWrapper>
       <div className="left">
@@ -56,12 +62,32 @@ export const Setting = ({ setting, handleSetting }: SettingProps) => {
             handleToggle={() => handleSwitchToggleOuter()}
           />
         ) : (
-          <ButtonMonoInvert
-            iconLeft={setting.buttonIcon}
-            text={setting.buttonText || ''}
-            iconTransform="shrink-2"
-            onClick={() => handleButtonClick()}
-          />
+          <SpinnerWrapper>
+            {getDisabled(setting.action) && (
+              <div
+                style={{ position: 'absolute', left: '26px', top: '10px' }}
+                className="lds-ellipsis"
+              >
+                <div></div>
+                <div></div>
+                <div></div>
+                <div></div>
+              </div>
+            )}
+
+            <ButtonMonoInvert
+              style={{
+                minWidth: '100px',
+                minHeight: '26px',
+                border: '1px solid var(--text-color-primary) !important',
+              }}
+              disabled={getDisabled(setting.action)}
+              iconLeft={setting.buttonIcon}
+              text={getDisabled(setting.action) ? '' : setting.buttonText || ''}
+              iconTransform="shrink-2"
+              onClick={() => handleButtonClick()}
+            />
+          </SpinnerWrapper>
         )}
       </div>
     </SettingWrapper>

--- a/src/renderer/screens/Settings/Wrappers.tsx
+++ b/src/renderer/screens/Settings/Wrappers.tsx
@@ -18,6 +18,74 @@ export const ContentWrapper = styled.div`
   }
 `;
 
+export const SpinnerWrapper = styled.div`
+  position: relative;
+
+  /* 3 Dot Spinner */
+  .lds-ellipsis {
+    /* change color here */
+    color: #afafaf;
+  }
+  .lds-ellipsis,
+  .lds-ellipsis div {
+    box-sizing: border-box;
+  }
+  .lds-ellipsis {
+    margin-left: 8px;
+    top: 12px;
+    display: inline-block;
+    position: relative;
+  }
+  .lds-ellipsis div {
+    position: absolute;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    animation-timing-function: cubic-bezier(0, 1, 1, 0);
+  }
+  .lds-ellipsis div:nth-child(1) {
+    left: 4px;
+    animation: lds-ellipsis1 0.6s infinite;
+  }
+  .lds-ellipsis div:nth-child(2) {
+    left: 4px;
+    animation: lds-ellipsis2 0.6s infinite;
+  }
+  .lds-ellipsis div:nth-child(3) {
+    left: 16px;
+    animation: lds-ellipsis2 0.6s infinite;
+  }
+  .lds-ellipsis div:nth-child(4) {
+    left: 28px;
+    animation: lds-ellipsis3 0.6s infinite;
+  }
+  @keyframes lds-ellipsis1 {
+    0% {
+      transform: scale(0);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  @keyframes lds-ellipsis3 {
+    0% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(0);
+    }
+  }
+  @keyframes lds-ellipsis2 {
+    0% {
+      transform: translate(0, 0);
+    }
+    100% {
+      transform: translate(12px, 0);
+    }
+  }
+`;
+
 export const SettingWrapper = styled(motion.div)`
   display: flex;
   column-gap: 1rem;

--- a/src/renderer/screens/Settings/index.tsx
+++ b/src/renderer/screens/Settings/index.tsx
@@ -15,11 +15,13 @@ import { useDebug } from '@/renderer/hooks/useDebug';
 import { useSettingsMessagePorts } from '@/renderer/hooks/useSettingsMessagePorts';
 import { AccordionCaretHeader } from '@/renderer/library/Accordion/AccordionCaretHeaders';
 import { Scrollable } from '@/renderer/utils/common';
+import { useAppModesSyncing } from '@/renderer/hooks/useAppModesSyncing';
 import type { OsPlatform, SettingItem } from './types';
 
 export const Settings: React.FC = () => {
   // Set up port communication for `settings` window.
   useSettingsMessagePorts();
+  useAppModesSyncing();
   useDebug(window.myAPI.getWindowId());
 
   /// Active accordion indices for settings panels.
@@ -32,7 +34,6 @@ export const Settings: React.FC = () => {
       const platform = await window.myAPI.getOsPlatform();
       setOsPlatform(platform as OsPlatform);
     };
-
     initOsPlatform();
   }, []);
 

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
 import type { ChainID } from '@/types/chains';
+import type { EventCallback } from '@/types/reporter';
 import type { IpcTask } from '@/types/communication';
 
 type ToastType = 'success' | 'error';
@@ -160,7 +161,7 @@ export const getSortedLocalLedgerAddresses = (
 
 /**
  * @name importAddresses
- * @summary Extract address data from imported serialized data and send to application.
+ * @summary Extract address data from an imported text file and send to application.
  * (main renderer)
  */
 export const importAddresses = async (serialized: string) => {
@@ -206,4 +207,27 @@ const postToImport = (
     task: 'import:account:add',
     data: { json: JSON.stringify(json), source },
   });
+};
+
+/**
+ * @name importEvents
+ * @summary Extract event data from an imported text file and send to application.
+ * (main renderer)
+ */
+export const importEvents = async (
+  serialized: string,
+  setEvents: (events: EventCallback[]) => void
+): Promise<void> => {
+  const s_array: [string, string][] = JSON.parse(serialized);
+  const s_map = new Map<string, string>(s_array);
+  const s_events = s_map.get('events');
+
+  // Send '[]' if no events received.
+  const updated = (await window.myAPI.sendEventTaskAsync({
+    action: 'events:import',
+    data: { events: s_events ? s_events : '[]' },
+  })) as string;
+
+  const parsed: EventCallback[] = JSON.parse(updated);
+  setEvents(parsed);
 };

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -10,8 +10,10 @@ import type {
   LocalAddress,
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
+import { IntervalsController } from '@/controller/renderer/IntervalsController';
 import type { ChainID } from '@/types/chains';
 import type { EventCallback } from '@/types/reporter';
+import type { IntervalSubscription } from '@/types/subscriptions';
 import type { IpcTask } from '@/types/communication';
 
 type ToastType = 'success' | 'error';
@@ -165,33 +167,142 @@ export const getSortedLocalLedgerAddresses = (
  * (main renderer)
  */
 export const importAddresses = async (serialized: string) => {
+  const s_addresses = getFromBackupFile('addresses', serialized);
+  if (!s_addresses) {
+    return;
+  }
+
+  const p_array: [AccountSource, string][] = JSON.parse(s_addresses);
+  const p_map = new Map<AccountSource, string>(p_array);
+  const importWindowOpen = await window.myAPI.isViewOpen('import');
+
+  for (const [source, ser] of p_map.entries()) {
+    const parsed =
+      source === 'ledger'
+        ? (JSON.parse(ser) as LedgerLocalAddress[])
+        : (JSON.parse(ser) as LocalAddress[]);
+
+    // Persist addresses to Electron store and update import window.
+    parsed.forEach(async (a) => {
+      await window.myAPI.rawAccountTask({
+        action: 'raw-account:persist',
+        data: { source, serialized: JSON.stringify(a) },
+      });
+
+      importWindowOpen && postToImport(a, source);
+    });
+  }
+};
+
+/**
+ * @name importEvents
+ * @summary Extract event data from an imported text file and send to application.
+ * (main renderer)
+ */
+export const importEvents = async (
+  serialized: string,
+  setEvents: (events: EventCallback[]) => void
+): Promise<void> => {
+  const s_events = getFromBackupFile('events', serialized);
+  if (!s_events) {
+    return;
+  }
+
+  // Send serialized events to main for processing.
+  const updated = (await window.myAPI.sendEventTaskAsync({
+    action: 'events:import',
+    data: { events: s_events },
+  })) as string;
+
+  const parsed: EventCallback[] = JSON.parse(updated);
+  setEvents(parsed);
+};
+
+/**
+ * @name importIntervalTasks
+ * @summary Extract interval task data from an imported text file and send to application.
+ * (main renderer)
+ */
+type IntervalFunc = (t: IntervalSubscription) => void;
+
+export const importIntervalTasks = async (
+  serialized: string,
+  tryAddIntervalSubscription: IntervalFunc,
+  tryUpdateDynamicIntervalTask: IntervalFunc,
+  addIntervalSubscription: IntervalFunc,
+  updateIntervalSubscription: IntervalFunc
+): Promise<void> => {
+  const s_tasks = getFromBackupFile('intervals', serialized);
+  if (!s_tasks) {
+    return;
+  }
+
+  // Receive new tasks after persisting them to store.
+  const s_data =
+    (await window.myAPI.sendIntervalTask({
+      action: 'interval:tasks:import',
+      data: { serialized: s_tasks },
+    })) || '[]';
+
+  // Parse received tasks to insert and update.
+  const s_array: [string, string][] = JSON.parse(s_data);
+  const map = new Map<string, string>(s_array);
+
+  const inserts: IntervalSubscription[] = JSON.parse(map.get('insert') || '[]');
+  const updates: IntervalSubscription[] = JSON.parse(map.get('update') || '[]');
+
+  // Update manage subscriptions in controller and update React state.
+  if (inserts.length > 0) {
+    IntervalsController.insertSubscriptions(inserts);
+    inserts.forEach((t) => {
+      tryAddIntervalSubscription(t);
+      addIntervalSubscription(t);
+    });
+  }
+
+  if (updates.length > 0) {
+    IntervalsController.removeSubscriptions(updates);
+    updates.forEach((t) => {
+      t.status === 'enable' && IntervalsController.insertSubscription(t);
+      tryUpdateDynamicIntervalTask(t);
+      updateIntervalSubscription(t);
+    });
+  }
+
+  // Update state in OpenGov window.
+  if (await window.myAPI.isViewOpen('openGov')) {
+    inserts.forEach((t) => {
+      ConfigRenderer.portToOpenGov?.postMessage({
+        task: 'openGov:task:add',
+        data: {
+          serialized: JSON.stringify(t),
+        },
+      });
+    });
+
+    updates.forEach((t) => {
+      ConfigRenderer.portToOpenGov?.postMessage({
+        task: 'openGov:task:update',
+        data: {
+          serialized: JSON.stringify(t),
+        },
+      });
+    });
+  }
+};
+
+/**
+ * @name getFromBackupFile
+ * @summary Get some serialized data from backup files.
+ * Key may be `addresses`, `events` or `intervals`.
+ */
+const getFromBackupFile = (
+  key: string,
+  serialized: string
+): string | undefined => {
   const s_array: [string, string][] = JSON.parse(serialized);
   const s_map = new Map<string, string>(s_array);
-  const s_addresses = s_map.get('addresses');
-
-  if (s_addresses) {
-    const p_array: [AccountSource, string][] = JSON.parse(s_addresses);
-    const p_map = new Map<AccountSource, string>(p_array);
-    const importWindowOpen = await window.myAPI.isViewOpen('import');
-
-    for (const [source, ser] of p_map.entries()) {
-      const parsed =
-        source === 'ledger'
-          ? (JSON.parse(ser) as LedgerLocalAddress[])
-          : (JSON.parse(ser) as LocalAddress[]);
-
-      parsed.forEach(async (a) => {
-        // Persist addresses to Electron store.
-        await window.myAPI.rawAccountTask({
-          action: 'raw-account:persist',
-          data: { source, serialized: JSON.stringify(a) },
-        });
-
-        // Update import window state only if it's open.
-        importWindowOpen && postToImport(a, source);
-      });
-    }
-  }
+  return s_map.get(key);
 };
 
 /**
@@ -207,27 +318,4 @@ const postToImport = (
     task: 'import:account:add',
     data: { json: JSON.stringify(json), source },
   });
-};
-
-/**
- * @name importEvents
- * @summary Extract event data from an imported text file and send to application.
- * (main renderer)
- */
-export const importEvents = async (
-  serialized: string,
-  setEvents: (events: EventCallback[]) => void
-): Promise<void> => {
-  const s_array: [string, string][] = JSON.parse(serialized);
-  const s_map = new Map<string, string>(s_array);
-  const s_events = s_map.get('events');
-
-  // Send '[]' if no events received.
-  const updated = (await window.myAPI.sendEventTaskAsync({
-    action: 'events:import',
-    data: { events: s_events ? s_events : '[]' },
-  })) as string;
-
-  const parsed: EventCallback[] = JSON.parse(updated);
-  setEvents(parsed);
 };

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -6,6 +6,7 @@ import { Config as ConfigRenderer } from '@/config/processes/renderer';
 import { Flip, toast } from 'react-toastify';
 import type {
   AccountSource,
+  FlattenedAccounts,
   LedgerLocalAddress,
   LocalAddress,
 } from '@/types/accounts';
@@ -175,7 +176,8 @@ export const getSortedLocalLedgerAddresses = (
 export const importAddresses = async (
   serialized: string,
   handleImportAddress: (ev: MessageEvent, fromBackup: boolean) => Promise<void>,
-  handleRemoveAddress: (ev: MessageEvent) => Promise<void>
+  handleRemoveAddress: (ev: MessageEvent) => Promise<void>,
+  setAddresses: (a: FlattenedAccounts) => void
 ) => {
   const s_addresses = getFromBackupFile('addresses', serialized);
   if (!s_addresses) {
@@ -226,7 +228,17 @@ export const importAddresses = async (
         await handleRemoveAddress(new MessageEvent('message', data));
         postToImport('import:address:update', { address: a, source });
       }
+
+      // Update managed account names.
+      const account = AccountsController.get(chainId, address);
+      if (account) {
+        account.name = name;
+        AccountsController.update(chainId, account);
+      }
     }
+
+    // Update account list state.
+    setAddresses(AccountsController.getAllFlattenedAccountData());
   }
 };
 

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -6,22 +6,13 @@ import { Config as ConfigRenderer } from '@/config/processes/renderer';
 import { Flip, toast } from 'react-toastify';
 import type {
   AccountSource,
-  FlattenedAccounts,
   LedgerLocalAddress,
   LocalAddress,
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
-import { IntervalsController } from '@/controller/renderer/IntervalsController';
 import type { AnyData } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
-import type { EventCallback } from '@/types/reporter';
-import type {
-  IntervalSubscription,
-  SubscriptionTask,
-} from '@/types/subscriptions';
 import type { IpcTask } from '@/types/communication';
-import { AccountsController } from '@/controller/renderer/AccountsController';
-import { SubscriptionsController } from '@/controller/renderer/SubscriptionsController';
 
 type ToastType = 'success' | 'error';
 
@@ -169,245 +160,11 @@ export const getSortedLocalLedgerAddresses = (
 };
 
 /**
- * @name importAddresses
- * @summary Extract address data from an imported text file and send to application.
- * (main renderer)
- */
-export const importAddresses = async (
-  serialized: string,
-  handleImportAddress: (ev: MessageEvent, fromBackup: boolean) => Promise<void>,
-  handleRemoveAddress: (ev: MessageEvent) => Promise<void>,
-  setAddresses: (a: FlattenedAccounts) => void
-) => {
-  const s_addresses = getFromBackupFile('addresses', serialized);
-  if (!s_addresses) {
-    return;
-  }
-
-  const p_array: [AccountSource, string][] = JSON.parse(s_addresses);
-  const p_map = new Map<AccountSource, string>(p_array);
-  const importWindowOpen = await window.myAPI.isViewOpen('import');
-
-  for (const [source, ser] of p_map.entries()) {
-    const parsed =
-      source === 'ledger'
-        ? (JSON.parse(ser) as LedgerLocalAddress[])
-        : (JSON.parse(ser) as LocalAddress[]);
-
-    // Check connection status and set isImported to `false` if app is offline.
-    const isOnline: boolean =
-      (await window.myAPI.sendConnectionTaskAsync({
-        action: 'connection:getStatus',
-        data: null,
-      })) || false;
-
-    // Process parsed addresses.
-    for (const a of parsed) {
-      a.isImported && !isOnline && (a.isImported = false);
-
-      // Persist or update address in Electron store.
-      await window.myAPI.rawAccountTask({
-        action: 'raw-account:import',
-        data: { source, serialized: JSON.stringify(a) },
-      });
-
-      // Add address and its status to import window's state.
-      importWindowOpen &&
-        postToImport('import:account:add', { json: JSON.stringify(a), source });
-
-      // Handle importing or removing account from main window and setting `isImported` flag state.
-      const { address, name } = a;
-      const chainId = getAddressChainId(address);
-
-      if (a.isImported) {
-        const data = { data: { data: { address, chainId, name, source } } };
-        await handleImportAddress(new MessageEvent('message', data), true);
-        postToImport('import:address:update', { address: a, source });
-      } else {
-        const data = { data: { data: { address, chainId } } };
-        await handleRemoveAddress(new MessageEvent('message', data));
-        postToImport('import:address:update', { address: a, source });
-      }
-
-      // Update managed account names.
-      const account = AccountsController.get(chainId, address);
-      if (account) {
-        account.name = name;
-        AccountsController.update(chainId, account);
-      }
-    }
-
-    // Update account list state.
-    setAddresses(AccountsController.getAllFlattenedAccountData());
-  }
-};
-
-/**
- * @name importEvents
- * @summary Extract event data from an imported text file and send to application.
- * (main renderer)
- */
-export const importEvents = async (
-  serialized: string,
-  setEvents: (events: EventCallback[]) => void
-): Promise<void> => {
-  const s_events = getFromBackupFile('events', serialized);
-  if (!s_events) {
-    return;
-  }
-
-  // Send serialized events to main for processing.
-  const updated = (await window.myAPI.sendEventTaskAsync({
-    action: 'events:import',
-    data: { events: s_events },
-  })) as string;
-
-  const parsed: EventCallback[] = JSON.parse(updated);
-  setEvents(parsed);
-};
-
-/**
- * @name importIntervalTasks
- * @summary Extract interval task data from an imported text file and send to application.
- * (main renderer)
- */
-type IntervalFunc = (t: IntervalSubscription) => void;
-
-export const importIntervalTasks = async (
-  serialized: string,
-  tryAddIntervalSubscription: IntervalFunc,
-  tryUpdateDynamicIntervalTask: IntervalFunc,
-  addIntervalSubscription: IntervalFunc,
-  updateIntervalSubscription: IntervalFunc
-): Promise<void> => {
-  const s_tasks = getFromBackupFile('intervals', serialized);
-  if (!s_tasks) {
-    return;
-  }
-
-  // Receive new tasks after persisting them to store.
-  const s_data =
-    (await window.myAPI.sendIntervalTask({
-      action: 'interval:tasks:import',
-      data: { serialized: s_tasks },
-    })) || '[]';
-
-  // Parse received tasks to insert and update.
-  const s_array: [string, string][] = JSON.parse(s_data);
-  const map = new Map<string, string>(s_array);
-
-  const inserts: IntervalSubscription[] = JSON.parse(map.get('insert') || '[]');
-  const updates: IntervalSubscription[] = JSON.parse(map.get('update') || '[]');
-
-  // Update manage subscriptions in controller and update React state.
-  if (inserts.length > 0) {
-    IntervalsController.insertSubscriptions(inserts);
-    inserts.forEach((t) => {
-      tryAddIntervalSubscription(t);
-      addIntervalSubscription(t);
-    });
-  }
-
-  if (updates.length > 0) {
-    IntervalsController.removeSubscriptions(updates);
-    updates.forEach((t) => {
-      t.status === 'enable' && IntervalsController.insertSubscription(t);
-      tryUpdateDynamicIntervalTask(t);
-      updateIntervalSubscription(t);
-    });
-  }
-
-  // Update state in OpenGov window.
-  if (await window.myAPI.isViewOpen('openGov')) {
-    inserts.forEach((t) => {
-      ConfigRenderer.portToOpenGov?.postMessage({
-        task: 'openGov:task:add',
-        data: {
-          serialized: JSON.stringify(t),
-        },
-      });
-    });
-
-    updates.forEach((t) => {
-      ConfigRenderer.portToOpenGov?.postMessage({
-        task: 'openGov:task:update',
-        data: {
-          serialized: JSON.stringify(t),
-        },
-      });
-    });
-  }
-};
-
-/**
- * @name importAccountSubscriptions
- * @summary Extract account subscription data from an imported text file and send to application.
- */
-export const importAccountSubscriptions = async (
-  serialized: string,
-  updateRenderedSubscriptions: (task: SubscriptionTask) => void,
-  setAccountSubscriptions: (m: Map<string, SubscriptionTask[]>) => void
-): Promise<void> => {
-  const s_tasks = getFromBackupFile('accountTasks', serialized);
-  if (!s_tasks) {
-    return;
-  }
-
-  const s_array: [string, string][] = JSON.parse(s_tasks);
-  const s_map = new Map<string, string>(s_array);
-
-  // Store tasks to persist to store.
-  const s_persistMap = new Map<string, string>();
-
-  // Iterate map of serialized tasks keyed by an account address.
-  for (const [address, serTasks] of s_map.entries()) {
-    const parsed: SubscriptionTask[] = JSON.parse(serTasks);
-    if (parsed.length === 0) {
-      continue;
-    }
-
-    const account = AccountsController.get(parsed[0].chainId, address);
-    const valid: SubscriptionTask[] = [];
-
-    if (account) {
-      for (const t of parsed) {
-        if (
-          (t.category === 'Nomination Pools' && !account.nominationPoolData) ||
-          (t.category === 'Nominating' && !account.nominatingData)
-        ) {
-          // Throw away task if necessary.
-          continue;
-        }
-
-        // Otherwise subscribe to task.
-        await account?.subscribeToTask(t);
-        updateRenderedSubscriptions(t);
-        valid.push(t);
-      }
-    }
-
-    // Serialize the account's subscribed tasks.
-    valid.length > 0 && s_persistMap.set(address, JSON.stringify(valid));
-  }
-
-  // Set subscriptions React state.
-  setAccountSubscriptions(
-    SubscriptionsController.getAccountSubscriptions(AccountsController.accounts)
-  );
-
-  // Send successfully imported tasks to main process.
-  await window.myAPI.sendSubscriptionTask({
-    action: 'subscriptions:account:import',
-    data: { serialized: JSON.stringify(Array.from(s_persistMap.entries())) },
-  });
-};
-
-/**
  * @name getFromBackupFile
  * @summary Get some serialized data from backup files.
  * Key may be `addresses`, `events` or `intervals`.
  */
-const getFromBackupFile = (
+export const getFromBackupFile = (
   key: string,
   serialized: string
 ): string | undefined => {
@@ -421,6 +178,24 @@ const getFromBackupFile = (
  * @summary Utility to post a message to the import window.
  * (main renderer)
  */
-const postToImport = (task: string, dataObj: AnyData) => {
+export const postToImport = (task: string, dataObj: AnyData) => {
   ConfigRenderer.portToImport?.postMessage({ task, data: dataObj });
+};
+
+/**
+ * @name postToOpenGov
+ * @summary Utility to post a message to the OpenGov window.
+ * (main renderer)
+ */
+export const postToOpenGov = (task: string, dataObj: AnyData) => {
+  ConfigRenderer.portToOpenGov?.postMessage({ task, data: dataObj });
+};
+
+/**
+ * @name postToSettings
+ * @summary Utility to post a message to the Settings window.
+ * (main renderer)
+ */
+export const postToSettings = (task: string, dataObj: AnyData) => {
+  ConfigRenderer.portToSettings?.postMessage({ task, data: dataObj });
 };

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -75,9 +75,10 @@ export interface ValidatorData {
  * Account data saved in Electron store.
  */
 export interface StoredAccount {
-  _source: AccountSource;
   _address: string;
+  _chain: ChainID;
   _name: string;
+  _source: AccountSource;
 }
 
 /**

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -49,11 +49,12 @@ export interface IpcTask {
     | 'subscriptions:chain:getAll'
     | 'subscriptions:chain:update'
     // Subscriptions (Interval)
-    | 'interval:task:get'
-    | 'interval:task:clear'
     | 'interval:task:add'
+    | 'interval:task:clear'
+    | 'interval:task:get'
     | 'interval:task:remove'
     | 'interval:task:update'
+    | 'interval:tasks:import'
     // Settings
     | 'settings:set:docked'
     | 'settings:toggle'

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -22,11 +22,12 @@ export interface PortPair {
 
 export interface IpcTask {
   action: // Addresses
-  | 'raw-account:persist'
+  | 'raw-account:add'
     | 'raw-account:delete'
-    | 'raw-account:add'
-    | 'raw-account:remove'
     | 'raw-account:get'
+    | 'raw-account:import'
+    | 'raw-account:persist'
+    | 'raw-account:remove'
     | 'raw-account:rename'
     // Accounts
     | 'account:import'
@@ -46,6 +47,7 @@ export interface IpcTask {
     // Subscriptions (Account)
     | 'subscriptions:account:getAll'
     | 'subscriptions:account:update'
+    | 'subscriptions:account:import'
     | 'subscriptions:chain:getAll'
     | 'subscriptions:chain:update'
     // Subscriptions (Interval)

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -42,6 +42,7 @@ export interface IpcTask {
     | 'events:remove'
     | 'events:makeStale'
     | 'events:update:accountName'
+    | 'events:import'
     // Subscriptions (Account)
     | 'subscriptions:account:getAll'
     | 'subscriptions:account:update'

--- a/src/types/preload.ts
+++ b/src/types/preload.ts
@@ -55,6 +55,12 @@ export interface PreloadAPI {
   closeWindow: ApiCloseWindow;
   quitApp: ApiEmptyPromiseRequest;
 
+  getModeFlag: (modeId: string) => Promise<boolean>;
+  syncModeFlags: (
+    callback: (_: IpcRendererEvent, modeId: string, flag: boolean) => void
+  ) => void;
+  relayModeFlag: (modeId: string, flag: boolean) => void;
+
   handleOpenTab: (
     callback: (_: IpcRendererEvent, tabData: TabData) => void
   ) => void;

--- a/src/utils/WindowUtils.ts
+++ b/src/utils/WindowUtils.ts
@@ -179,7 +179,7 @@ export const createBaseWindow = () => {
   const defaultY = screenHeight / 2 - baseHeight / 2;
 
   const baseWindow = new BaseWindow({
-    alwaysOnTop: false,
+    alwaysOnTop: true,
     x: defaultX,
     y: defaultY,
     frame: false,


### PR DESCRIPTION
# Summary

PR to implement exporting and importing additional data, including:

- Accounts
- Events
- Interval Subscriptions
- Account Subscriptions

The user should be able to backup and restore their Polkadot Live state.

## Merged PRs

[feat: export events data #703](https://github.com/polkadot-live/polkadot-live-app/pull/703)
[feat: import events data #704](https://github.com/polkadot-live/polkadot-live-app/pull/704)
[feat: export interval subscriptions #705](https://github.com/polkadot-live/polkadot-live-app/pull/705)
[feat: import interval subscriptions #706](https://github.com/polkadot-live/polkadot-live-app/pull/706)
[feat: account subscriptions backup #707](https://github.com/polkadot-live/polkadot-live-app/pull/707)
[chore: data backup ux #710](https://github.com/polkadot-live/polkadot-live-app/pull/710)
[chore: backup logic changes #711](https://github.com/polkadot-live/polkadot-live-app/pull/711)
[chore: data backup context #712](https://github.com/polkadot-live/polkadot-live-app/pull/712)
[fix: data backup debugging #713](https://github.com/polkadot-live/polkadot-live-app/pull/713)