### PR TITLE
feat: account subscriptions backup

### DIFF
--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -120,9 +120,7 @@ export class AddressesController {
         continue;
       }
 
-      // Set imported flag to false.
-      const updated = fetched.map((a) => ({ ...a, isImported: false }));
-      map.set(source, JSON.stringify(updated));
+      map.set(source, JSON.stringify(fetched));
     }
 
     return JSON.stringify(Array.from(map.entries()));

--- a/src/controller/main/BackupController.ts
+++ b/src/controller/main/BackupController.ts
@@ -7,6 +7,7 @@ import { promises as fsPromises } from 'fs';
 import { AddressesController } from '@/controller/main/AddressesController';
 import { EventsController } from '@/controller/main/EventsController';
 import { IntervalsController } from '@/controller/main/IntervalsController';
+import { SubscriptionsController } from './SubscriptionsController';
 import type { ExportResult, ImportResult } from '@/types/backup';
 
 export class BackupController {
@@ -95,10 +96,12 @@ export class BackupController {
     const addresses = AddressesController.getBackupData();
     const events = EventsController.getBackupData();
     const intervals = IntervalsController.getBackupData();
+    const accountTasks = SubscriptionsController.getBackupData();
 
     map.set('addresses', addresses);
     map.set('events', events);
     map.set('intervals', intervals);
+    map.set('accountTasks', accountTasks);
 
     return JSON.stringify(Array.from(map));
   }

--- a/src/controller/main/SubscriptionsController.ts
+++ b/src/controller/main/SubscriptionsController.ts
@@ -3,6 +3,7 @@
 
 import { store } from '@/main';
 import { Config as ConfigMain } from '@/config/processes/main';
+import { OnlineStatusController } from '@/controller/main/OnlineStatusController';
 import type { AnyData, AnyJson } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
 import type { FlattenedAccountData, StoredAccount } from '@/types/accounts';
@@ -96,9 +97,11 @@ export class SubscriptionsController {
       // Clear persisted tasks for an account.
       this.clearAccountTasksInStore(address);
 
-      // Persist backed up tasks to store.
-      const received: SubscriptionTask[] = JSON.parse(serTasks);
-      received.forEach((t) => this.update(t, address));
+      // Persist backed up tasks to store if online.
+      if (OnlineStatusController.getStatus()) {
+        const received: SubscriptionTask[] = JSON.parse(serTasks);
+        received.forEach((t) => this.update(t, address));
+      }
     }
   }
 

--- a/src/controller/main/SubscriptionsController.ts
+++ b/src/controller/main/SubscriptionsController.ts
@@ -34,30 +34,71 @@ export class SubscriptionsController {
     switch (task.action) {
       // Get an account's persisted tasks in serialized form.
       case 'subscriptions:account:getAll': {
-        const { address } = task.data;
-        const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
-        const stored = (store as Record<string, AnyData>).get(key) as string;
-        return stored ? stored : '';
+        return this.get(task.data.address);
       }
       // Get persisted chain subscription tasks.
       case 'subscriptions:chain:getAll': {
-        const key = ConfigMain.getChainSubscriptionsStorageKey();
-        const tasks = (store as Record<string, AnyData>).get(key) as string;
-        return tasks ? tasks : '';
+        const ser = this.getChainTasks();
+        return ser === '[]' ? '' : ser;
       }
       // Update a persisted account subscription task.
       case 'subscriptions:account:update': {
         const account: FlattenedAccountData = JSON.parse(task.data.serAccount);
         const subTask: SubscriptionTask = JSON.parse(task.data.serTask);
-        this.updateAccountTaskInStore(subTask, account);
+        this.update(subTask, account.address);
         return;
+      }
+      // Import tasks from a backup text file.
+      case 'subscriptions:account:import': {
+        return this.doImport(task);
       }
       // Update a persisted chain subscription task.
       case 'subscriptions:chain:update': {
         const { serTask }: { serTask: string } = task.data;
-        this.updateChainTaskInStore(JSON.parse(serTask));
+        this.updateChainTask(JSON.parse(serTask));
         return;
       }
+    }
+  }
+
+  /**
+   * @name get
+   * @summary Get serialized subscriptions from store for an address.
+   */
+  private static get(address: string): string {
+    const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
+    const stored = (store as Record<string, AnyData>).get(key) as string;
+    return stored ? stored : '';
+  }
+
+  /**
+   * @name getChainTasks
+   * @summary Return serialized chain tasks in the store.
+   */
+  private static getChainTasks(): string {
+    const key = ConfigMain.getChainSubscriptionsStorageKey();
+    const stored = (store as Record<string, AnyData>).get(key) as string;
+    return stored ? stored : '[]';
+  }
+
+  /**
+   * @name doImport
+   * @summary Persist new tasks to store and return them to renderer to process.
+   * Receives serialized tasks from an exported backup file.
+   */
+  private static doImport(ipcTask: IpcTask): void {
+    const { serialized }: { serialized: string } = ipcTask.data;
+    const s_array: [string, string][] = JSON.parse(serialized);
+    const s_map = new Map<string, string>(s_array);
+
+    // Iterate map of serialized tasks keyed by an account address.
+    for (const [address, serTasks] of s_map.entries()) {
+      // Clear persisted tasks for an account.
+      this.clearAccountTasksInStore(address);
+
+      // Persist backed up tasks to store.
+      const received: SubscriptionTask[] = JSON.parse(serTasks);
+      received.forEach((t) => this.update(t, address));
     }
   }
 
@@ -89,40 +130,24 @@ export class SubscriptionsController {
   }
 
   /**
-   * @name updateAccountTaskInStore
+   * @name update
    * @summary Update a persisted account task with the received data.
    */
-  private static updateAccountTaskInStore(
-    task: SubscriptionTask,
-    account: FlattenedAccountData
-  ) {
-    const key = ConfigMain.getSubscriptionsStorageKeyFor(account.address);
-
-    // Deserialize the account's tasks from store.
-    const tasks: SubscriptionTask[] = (store as Record<string, AnyJson>).get(
-      key
-    )
-      ? JSON.parse((store as Record<string, AnyJson>).get(key) as string)
-      : [];
-
-    this.updateTaskInStore(tasks, task, key);
+  private static update(task: SubscriptionTask, address: string) {
+    const ser = this.get(address);
+    const tasks: SubscriptionTask[] = ser === '' ? [] : JSON.parse(ser);
+    const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
+    this.updateTask(tasks, task, key);
   }
 
   /**
-   * @name updateChainTaskInStore
+   * @name updateChainTask
    * @summary Update a persisted chain task with the received data.
    */
-  private static updateChainTaskInStore(task: SubscriptionTask) {
+  private static updateChainTask(task: SubscriptionTask) {
     const key = ConfigMain.getChainSubscriptionsStorageKey();
-
-    // Deserialize all tasks from store.
-    const tasks: SubscriptionTask[] = (store as Record<string, AnyJson>).get(
-      key
-    )
-      ? JSON.parse((store as Record<string, AnyJson>).get(key) as string)
-      : [];
-
-    this.updateTaskInStore(tasks, task, key);
+    const tasks: SubscriptionTask[] = JSON.parse(this.getChainTasks());
+    this.updateTask(tasks, task, key);
   }
 
   /**
@@ -140,14 +165,9 @@ export class SubscriptionsController {
    * @summary Called when an account is renamed.
    */
   static updateCachedAccountNameForTasks(address: string, newName: string) {
-    const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
-    const stored = (store as Record<string, AnyData>).get(key) as string;
+    const ser = this.get(address);
+    const parsed: SubscriptionTask[] = ser === '' ? [] : JSON.parse(ser);
 
-    if (!stored) {
-      return;
-    }
-
-    const parsed: SubscriptionTask[] = JSON.parse(stored);
     if (parsed.length === 0) {
       return;
     }
@@ -157,6 +177,7 @@ export class SubscriptionsController {
       account: { ...task.account, name: newName },
     }));
 
+    const key = ConfigMain.getSubscriptionsStorageKeyFor(address);
     (store as Record<string, AnyJson>).set(key, JSON.stringify(updated));
   }
 
@@ -164,14 +185,24 @@ export class SubscriptionsController {
    * Utilities
    *------------------------------------------------------------*/
 
-  static updateTaskInStore(
+  /**
+   * @name exists
+   * @summary Check if a given subscription task exists in the given array.
+   */
+  private static exists(tasks: SubscriptionTask[], task: SubscriptionTask) {
+    return tasks.some(
+      (t) => t.action === task.action && t.chainId === t.chainId
+    );
+  }
+
+  static updateTask(
     tasks: SubscriptionTask[],
     task: SubscriptionTask,
     key: string
   ) {
     if (task.status === 'enable') {
       // Remove task from array if it already exists.
-      this.taskExistsInArray(tasks, task) &&
+      this.exists(tasks, task) &&
         (tasks = this.removeTaskFromArray(tasks, task));
 
       tasks.push(task);
@@ -184,15 +215,6 @@ export class SubscriptionsController {
 
     // Persist new array to store.
     (store as Record<string, AnyJson>).set(key, JSON.stringify(tasks));
-  }
-
-  private static taskExistsInArray(
-    tasks: SubscriptionTask[],
-    task: SubscriptionTask
-  ) {
-    return tasks.some(
-      (t) => t.action === task.action && t.chainId === t.chainId
-    );
   }
 
   private static removeTaskFromArray(

--- a/src/controller/main/SubscriptionsController.ts
+++ b/src/controller/main/SubscriptionsController.ts
@@ -4,7 +4,8 @@
 import { store } from '@/main';
 import { Config as ConfigMain } from '@/config/processes/main';
 import type { AnyData, AnyJson } from '@/types/misc';
-import type { FlattenedAccountData } from '@/types/accounts';
+import type { ChainID } from '@/types/chains';
+import type { FlattenedAccountData, StoredAccount } from '@/types/accounts';
 import type { IpcTask } from '@/types/communication';
 import type { SubscriptionTask } from '@/types/subscriptions';
 
@@ -58,6 +59,33 @@ export class SubscriptionsController {
         return;
       }
     }
+  }
+
+  /**
+   * @name getBackupData
+   * @summary Return a serialized map of account subscription tasks for backup.
+   */
+
+  static getBackupData(): string {
+    // Get imported accounts from store.
+    const ser = (store as Record<string, AnyData>).get('imported_accounts');
+    const ser_array: [ChainID, StoredAccount[]][] = JSON.parse(ser);
+    const map_accounts = new Map<ChainID, StoredAccount[]>(ser_array);
+
+    // Address as key and its serialized subscription tasks as value.
+    const map = new Map<string, string>();
+
+    // Copy stored account's serialized tasks into map.
+    for (const accounts of map_accounts.values()) {
+      for (const { _address } of accounts) {
+        const key = ConfigMain.getSubscriptionsStorageKeyFor(_address);
+        const ser_tasks: string =
+          (store as Record<string, AnyData>).get(key) || '[]';
+        map.set(_address, ser_tasks);
+      }
+    }
+
+    return JSON.stringify(Array.from(map.entries()));
   }
 
   /**

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -27,36 +27,29 @@ export class AccountsController {
    * @summary Injects accounts into class from store.
    */
   static async initialize() {
-    const stored: string =
+    const serialized: string =
       (await window.myAPI.sendAccountTask({
         action: 'account:getAll',
         data: null,
       })) || '';
 
-    // Instantiate empty map if no accounts found in store.
-    if (stored === '') {
+    // Instantiate empty map if no accounts exist.
+    if (serialized === '') {
       this.accounts = new Map();
       return;
     }
 
-    // Parse serialized data into a map of StoredAccounts.
-    const parsed = new Map<ChainID, StoredAccount[]>(JSON.parse(stored));
-    const importedAccounts: ImportedAccounts = new Map();
-
-    for (const [chain, accounts] of parsed) {
-      const imported: Account[] = [];
-
-      for (const a of accounts) {
-        // Instantiate account.
-        const account = new Account(chain, a._source, a._address, a._name);
-        imported.push(account);
-      }
-
-      importedAccounts.set(chain, imported);
+    // Instantiate accounts.
+    const parsed = new Map<ChainID, StoredAccount[]>(JSON.parse(serialized));
+    for (const [chain, stored] of parsed) {
+      this.accounts.set(
+        chain,
+        stored.map(
+          ({ _source, _address, _name }) =>
+            new Account(chain, _source, _address, _name)
+        )
+      );
     }
-
-    // Inject imported accounts into controller.
-    this.accounts = importedAccounts;
   }
 
   /**

--- a/src/controller/renderer/SubscriptionsController.ts
+++ b/src/controller/renderer/SubscriptionsController.ts
@@ -212,11 +212,14 @@ export class SubscriptionsController {
    * @name enableAllSubscriptionsForAccount
    * @summary Activate all subscriptions when an account is imported.
    */
-  static getAllSubscriptionsForAccount = (account: Account) =>
+  static getAllSubscriptionsForAccount = (
+    account: Account,
+    status: 'enable' | 'disable'
+  ) =>
     allAccountTasks
       .filter((t) => t.chainId === account.chain)
       .map((t) => SubscriptionsController.getTaskArgsForAccount(account, t))
-      .map((t) => ({ ...t, status: 'enable' }) as SubscriptionTask);
+      .map((t) => ({ ...t, status }) as SubscriptionTask);
 
   /**
    * @name getTaskArgsForAccount

--- a/src/controller/renderer/SubscriptionsController.ts
+++ b/src/controller/renderer/SubscriptionsController.ts
@@ -187,19 +187,17 @@ export class SubscriptionsController {
     for (const accounts of accountsMap.values()) {
       for (const a of accounts) {
         const tasks = allAccountTasks
-          // Get all possible tasks for account's chain ID.
+          // Filter on account's chain ID.
           .filter((t) => t.chainId === a.chain)
-          // Populate tasks with correct arguments.
-          .map((t) => SubscriptionsController.getTaskArgsForAccount(a, t))
-          // Merge active tasks in the array.
-          .map((t) => {
-            for (const active of a.getSubscriptionTasks() || []) {
-              if (active.action === t.action && active.chainId === t.chainId) {
-                return active;
-              }
-            }
-            return t;
-          });
+          // Fill task arguments.
+          .map((t) => this.getTaskArgsForAccount(a, t))
+          // Merge active tasks.
+          .map(
+            (t) =>
+              (a.getSubscriptionTasks() || []).find(
+                (next) => next.action === t.action && next.chainId === t.chainId
+              ) || t
+          );
 
         result.set(a.address, tasks);
       }

--- a/src/renderer/contexts/import/ImportHandler/index.tsx
+++ b/src/renderer/contexts/import/ImportHandler/index.tsx
@@ -69,15 +69,19 @@ export const ImportHandlerProvider = ({
     imported: LocalAddress | LedgerLocalAddress,
     source: AccountSource
   ) => {
-    const { address } = imported;
+    const { address, isImported } = imported;
 
     // Return if address is already imported.
     if (isAlreadyImported(address)) {
       return;
     }
 
+    // Set processing flag for account if it needs importing.
+    isImported
+      ? setStatusForAccount(address, source, true)
+      : insertAccountStatus(address, source);
+
     // Update addresses state and references.
-    insertAccountStatus(address, source);
     handleAddressImport(source, imported);
   };
 

--- a/src/renderer/contexts/main/Addresses/index.tsx
+++ b/src/renderer/contexts/main/Addresses/index.tsx
@@ -48,21 +48,24 @@ export const AddressesProvider = ({
     chain: ChainID,
     source: AccountSource,
     address: string,
-    name: string
+    name: string,
+    fromBackup = false
   ) => {
     // Update accounts state.
     setAddresses(AccountsController.getAllFlattenedAccountData());
 
-    // Have main process send OS notification.
-    await window.myAPI.sendAccountTask({
-      action: 'account:import',
-      data: {
-        chainId: chain,
-        source,
-        address,
-        name,
-      },
-    });
+    // Show OS notification for new address imports.
+    if (!fromBackup) {
+      await window.myAPI.sendAccountTask({
+        action: 'account:import',
+        data: {
+          chainId: chain,
+          source,
+          address,
+          name,
+        },
+      });
+    }
   };
 
   // Removes an imported address.

--- a/src/renderer/contexts/main/Addresses/types.ts
+++ b/src/renderer/contexts/main/Addresses/types.ts
@@ -17,7 +17,8 @@ export interface AddressesContextInterface {
     n: ChainID,
     s: AccountSource,
     a: string,
-    b: string
+    b: string,
+    fromBackup: boolean
   ) => Promise<void>;
   removeAddress: (n: ChainID, a: string) => Promise<void>;
   getAddress: (a: string) => FlattenedAccountData | null;

--- a/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -132,11 +132,8 @@ export const BootstrappingProvider = ({
         );
 
         await Promise.all([
-          // Fetch account nonce and balance.
           fetchAccountBalances(),
-          // Use API instance to initialize account nomination pool data.
           fetchAccountNominationPoolData(),
-          // Initialize account nominating data.
           fetchAccountNominatingData(),
         ]);
       }
@@ -259,11 +256,8 @@ export const BootstrappingProvider = ({
     // Fetch up-to-date account data.
     if (!aborted) {
       await Promise.all([
-        // Fetch account nonce and balance.
         fetchAccountBalances(),
-        // Use API instance to initialize account nomination pool data.
         fetchAccountNominationPoolData(),
-        // Initialize account nominating data.
         fetchAccountNominatingData(),
       ]);
     }

--- a/src/renderer/contexts/main/Manage/index.tsx
+++ b/src/renderer/contexts/main/Manage/index.tsx
@@ -42,7 +42,7 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
   const updateRenderedSubscriptions = (task: SubscriptionTask) => {
     setRenderedSubscriptionsState((prev) => ({
       ...prev,
-      tasks: prev.tasks.map((t) => (t.action === task.action ? task : t)),
+      tasks: prev.tasks.map((t) => (compareTasks(task, t) ? task : t)),
     }));
   };
 
@@ -137,6 +137,30 @@ export const ManageProvider = ({ children }: { children: ReactNode }) => {
     }
 
     return map;
+  };
+
+  /// Determine if two tasks are the same task.
+  const compareTasks = (a: SubscriptionTask, b: SubscriptionTask): boolean => {
+    // Different task types.
+    if (!a.account && b.account) {
+      return false;
+    }
+
+    // Compare chain tasks.
+    if (!a.account && !b.account) {
+      return a.chainId === b.chainId && a.action === b.action;
+    }
+
+    // Account account tasks.
+    if (a.account && b.account) {
+      return (
+        a.account.address === b.account.address &&
+        a.action === b.action &&
+        a.chainId === b.chainId
+      );
+    }
+
+    return false;
   };
 
   return (

--- a/src/renderer/hooks/useImportMessagePorts.ts
+++ b/src/renderer/hooks/useImportMessagePorts.ts
@@ -36,6 +36,7 @@ export const useImportMessagePorts = () => {
           // Message received from `main`.
           switch (ev.data.task) {
             case 'import:account:add': {
+              // Import an address from a backup file.
               const { json, source }: { json: string; source: AccountSource } =
                 ev.data.data;
 
@@ -58,6 +59,7 @@ export const useImportMessagePorts = () => {
               break;
             }
             case 'import:address:update': {
+              // Update state for an address.
               const { address, source } = ev.data.data;
               handleAddressImport(source, address);
               break;

--- a/src/renderer/hooks/useImportMessagePorts.ts
+++ b/src/renderer/hooks/useImportMessagePorts.ts
@@ -4,6 +4,7 @@
 import { Config as ConfigImport } from '@/config/processes/import';
 
 /// Import window contexts.
+import { useAddresses } from '@app/contexts/import/Addresses';
 import { useImportHandler } from '@app/contexts/import/ImportHandler';
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useConnections } from '@/renderer/contexts/common/Connections';
@@ -18,6 +19,7 @@ export const useImportMessagePorts = () => {
   const { handleImportAddressFromBackup } = useImportHandler();
   const { setIsConnected } = useConnections();
   const { setStatusForAccount } = useAccountStatuses();
+  const { handleAddressImport } = useAddresses();
 
   /**
    * @name handleReceivedPort
@@ -53,6 +55,11 @@ export const useImportMessagePorts = () => {
             case 'import:connection:status': {
               const { status } = ev.data.data;
               setIsConnected(status);
+              break;
+            }
+            case 'import:address:update': {
+              const { address, source } = ev.data.data;
+              handleAddressImport(source, address);
               break;
             }
             default: {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -104,7 +104,7 @@ export const useMainMessagePorts = () => {
    * @name handleImportAddress
    * @summary Imports a new account when a message is received from `import` window.
    */
-  const handleImportAddress = async (ev: MessageEvent) => {
+  const handleImportAddress = async (ev: MessageEvent, fromBackup: boolean) => {
     const { chainId, source, address, name } = ev.data.data;
     // Add address to accounts controller.
     const account = AccountsController.add(chainId, source, address, name);
@@ -151,7 +151,8 @@ export const useMainMessagePorts = () => {
       }
 
       // Subscribe to tasks if app setting enabled.
-      ConfigRenderer.enableAutomaticSubscriptions &&
+      !fromBackup &&
+        ConfigRenderer.enableAutomaticSubscriptions &&
         (await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti));
 
       // Update React subscriptions state.
@@ -677,7 +678,7 @@ export const useMainMessagePorts = () => {
           // Message received from `import`.
           switch (ev.data.task) {
             case 'renderer:address:import': {
-              await handleImportAddress(ev);
+              await handleImportAddress(ev, false);
               break;
             }
             case 'renderer:address:remove': {

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -15,6 +15,7 @@ import {
   fetchNominationPoolDataForAccount,
 } from '@/utils/AccountUtils';
 import {
+  importAccountSubscriptions,
   importAddresses,
   importEvents,
   importIntervalTasks,
@@ -340,18 +341,31 @@ export const useMainMessagePorts = () => {
           }
 
           const { serialized } = response.data;
+
+          // Addresses.
           await importAddresses(
             serialized,
             handleImportAddress,
             handleRemoveAddress
           );
+
+          // Events.
           await importEvents(serialized, setEvents);
+
+          // Interval subscriptions.
           await importIntervalTasks(
             serialized,
             tryAddIntervalSubscription,
             tryUpdateDynamicIntervalTask,
             addIntervalSubscription,
             updateIntervalSubscription
+          );
+
+          // Account subscriptions.
+          await importAccountSubscriptions(
+            serialized,
+            updateRenderedSubscriptions,
+            setAccountSubscriptions
           );
 
           postToSettings(response.result, 'Data imported successfully.');

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -340,7 +340,11 @@ export const useMainMessagePorts = () => {
           }
 
           const { serialized } = response.data;
-          await importAddresses(serialized, handleImportAddress);
+          await importAddresses(
+            serialized,
+            handleImportAddress,
+            handleRemoveAddress
+          );
           await importEvents(serialized, setEvents);
           await importIntervalTasks(
             serialized,

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -106,7 +106,6 @@ export const useMainMessagePorts = () => {
    */
   const handleImportAddress = async (ev: MessageEvent) => {
     const { chainId, source, address, name } = ev.data.data;
-
     // Add address to accounts controller.
     const account = AccountsController.add(chainId, source, address, name);
 
@@ -314,7 +313,7 @@ export const useMainMessagePorts = () => {
           }
 
           const { serialized } = response.data;
-          await importAddresses(serialized);
+          await importAddresses(serialized, handleImportAddress);
           await importEvents(serialized, setEvents);
           await importIntervalTasks(
             serialized,

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/types/accounts';
 import { getAddressChainId } from '../Utils';
 import { IntervalsController } from '@/controller/renderer/IntervalsController';
+import type { AnyData } from '@/types/misc';
 import type { ChainID } from '@/types/chains';
 import type { EventCallback } from '@/types/reporter';
 import type { IntervalSubscription } from '@/types/subscriptions';
@@ -189,7 +190,8 @@ export const importAddresses = async (serialized: string) => {
         data: { source, serialized: JSON.stringify(a) },
       });
 
-      importWindowOpen && postToImport(a, source);
+      importWindowOpen &&
+        postToImport('import:account:add', { json: JSON.stringify(a), source });
     });
   }
 };
@@ -307,15 +309,9 @@ const getFromBackupFile = (
 
 /**
  * @name postToImport
- * @summary Utility to post message to import window.
+ * @summary Utility to post a message to the import window.
  * (main renderer)
  */
-const postToImport = (
-  json: LocalAddress | LedgerLocalAddress,
-  source: AccountSource
-) => {
-  ConfigRenderer.portToImport?.postMessage({
-    task: 'import:account:add',
-    data: { json: JSON.stringify(json), source },
-  });
+const postToImport = (task: string, dataObj: AnyData) => {
+  ConfigRenderer.portToImport?.postMessage({ task, data: dataObj });
 };

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -208,19 +208,17 @@ export const importAddresses = async (
       importWindowOpen &&
         postToImport('import:account:add', { json: JSON.stringify(a), source });
 
-      // Handle importing or removing account from main window.
+      // Handle importing or removing account from main window and setting `isImported` flag state.
       const { address, name } = a;
       const chainId = getAddressChainId(address);
 
       if (a.isImported) {
         const data = { data: { data: { address, chainId, name, source } } };
         await handleImportAddress(new MessageEvent('message', data), true);
-        // Update account isImported in import window.
         postToImport('import:address:update', { address: a, source });
       } else {
         const data = { data: { data: { address, chainId } } };
         await handleRemoveAddress(new MessageEvent('message', data));
-        // Update account isImported in import window.
         postToImport('import:address:update', { address: a, source });
       }
     }

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -178,7 +178,7 @@ interface QueueData {
 
 export const importAddresses = async (
   serialized: string,
-  handleImportAddress: (ev: MessageEvent) => Promise<void>
+  handleImportAddress: (ev: MessageEvent, fromBackup: boolean) => Promise<void>
 ) => {
   const s_addresses = getFromBackupFile('addresses', serialized);
   if (!s_addresses) {
@@ -227,7 +227,10 @@ export const importAddresses = async (
 
   // Synchronously import marked addresses to the main window.
   for (const dataObj of importQueue) {
-    await handleImportAddress(new MessageEvent('message', { data: dataObj }));
+    await handleImportAddress(
+      new MessageEvent('message', { data: dataObj }),
+      true
+    );
   }
 };
 

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -198,9 +198,9 @@ export const importAddresses = async (
     for (const a of parsed) {
       a.isImported && !isOnline && (a.isImported = false);
 
-      // Persist address to Electron store.
+      // Persist or update address in Electron store.
       await window.myAPI.rawAccountTask({
-        action: 'raw-account:persist',
+        action: 'raw-account:import',
         data: { source, serialized: JSON.stringify(a) },
       });
 

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -215,21 +215,13 @@ export const importAddresses = async (
       if (a.isImported) {
         const data = { data: { data: { address, chainId, name, source } } };
         await handleImportAddress(new MessageEvent('message', data), true);
-
         // Update account isImported in import window.
-        ConfigRenderer.portToImport?.postMessage({
-          task: 'import:address:update',
-          data: { address: a, source },
-        });
+        postToImport('import:address:update', { address: a, source });
       } else {
         const data = { data: { data: { address, chainId } } };
         await handleRemoveAddress(new MessageEvent('message', data));
-
         // Update account isImported in import window.
-        ConfigRenderer.portToImport?.postMessage({
-          task: 'import:address:update',
-          data: { address: a, source },
-        });
+        postToImport('import:address:update', { address: a, source });
       }
     }
   }

--- a/src/types/accounts.ts
+++ b/src/types/accounts.ts
@@ -75,9 +75,10 @@ export interface ValidatorData {
  * Account data saved in Electron store.
  */
 export interface StoredAccount {
-  _source: AccountSource;
   _address: string;
+  _chain: ChainID;
   _name: string;
+  _source: AccountSource;
 }
 
 /**

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -47,6 +47,7 @@ export interface IpcTask {
     // Subscriptions (Account)
     | 'subscriptions:account:getAll'
     | 'subscriptions:account:update'
+    | 'subscriptions:account:import'
     | 'subscriptions:chain:getAll'
     | 'subscriptions:chain:update'
     // Subscriptions (Interval)

--- a/src/types/communication.ts
+++ b/src/types/communication.ts
@@ -22,11 +22,12 @@ export interface PortPair {
 
 export interface IpcTask {
   action: // Addresses
-  | 'raw-account:persist'
+  | 'raw-account:add'
     | 'raw-account:delete'
-    | 'raw-account:add'
-    | 'raw-account:remove'
     | 'raw-account:get'
+    | 'raw-account:import'
+    | 'raw-account:persist'
+    | 'raw-account:remove'
     | 'raw-account:rename'
     // Accounts
     | 'account:import'


### PR DESCRIPTION
Augments the backup system by implementing the exporting and importing of account subscriptions.

- [x] If an imported address `isImported` flag is `true`, it gets added to the main window automatically.
- [x] If an imported address `isImported` flag is `false` and it's currently added to the main window, it gets removed.
  - Data from the backup file takes precedence.
- [x] Export account subscriptions to text file.
- [x] Import account subscriptions from text file and enable on accounts.

## Merged PRs

[feat: export account subscriptions #708](https://github.com/polkadot-live/polkadot-live-app/pull/708)
[feat: import account subscriptions #709](https://github.com/polkadot-live/polkadot-live-app/pull/709)