### PR TITLE
chore: backup logic changes

### DIFF
--- a/src/controller/main/AddressesController.ts
+++ b/src/controller/main/AddressesController.ts
@@ -53,7 +53,7 @@ export class AddressesController {
    * @summary Set the import flag of an address to `true`.
    */
   private static add(task: IpcTask) {
-    const { source, address } = task.data;
+    const { address, source, name } = task.data;
     const key = ConfigMain.getStorageKey(source);
 
     if (source === 'ledger') {
@@ -61,7 +61,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
       const serialized = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: true } : a
+          a.address === address ? { ...a, name, isImported: true } : a
         )
       );
 
@@ -71,7 +71,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key) as LocalAddress[];
       const serialized = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: true } : a
+          a.address === address ? { ...a, name, isImported: true } : a
         )
       );
 
@@ -153,22 +153,22 @@ export class AddressesController {
 
   /**
    * @name doImport
-   * @summary Persist an address to store being imported from a backup file.
+   * @summary Persist an address to store that's being imported from a backup file.
    */
   private static doImport(task: IpcTask) {
     const { source, serialized } = task.data;
     const parsed: LocalAddress | LedgerLocalAddress = JSON.parse(serialized);
-    const { address, isImported } = parsed;
+    const { address, isImported, name } = parsed;
 
     if (this.isAlreadyPersisted(address)) {
       isImported
         ? this.add({
             action: 'raw-account:add',
-            data: { source, address },
+            data: { source, address, name },
           })
         : this.remove({
             action: 'raw-account:remove',
-            data: { source, address },
+            data: { source, address, name },
           });
     } else {
       this.persist({
@@ -215,7 +215,7 @@ export class AddressesController {
    * @summary Set the import flag of an address to `false`.
    */
   private static remove(task: IpcTask) {
-    const { source, address } = task.data;
+    const { address, source, name } = task.data;
     const key = ConfigMain.getStorageKey(source);
 
     if (source === 'ledger') {
@@ -223,7 +223,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key, true) as LedgerLocalAddress[];
       const serialised = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: false } : a
+          a.address === address ? { ...a, name, isImported: false } : a
         )
       );
 
@@ -233,7 +233,7 @@ export class AddressesController {
       const stored = this.getStoredAddresses(key) as LocalAddress[];
       const serialized = JSON.stringify(
         stored.map((a) =>
-          a.address === address ? { ...a, isImported: false } : a
+          a.address === address ? { ...a, name, isImported: false } : a
         )
       );
 

--- a/src/controller/renderer/AccountsController.ts
+++ b/src/controller/renderer/AccountsController.ts
@@ -184,8 +184,6 @@ export class AccountsController {
   /**
    * @name set
    * @summary Updates an Account in the `accounts` property.
-   * @param {ChainID} chain - the chain the account belongs to.
-   * @param {Account} account - the account to set.
    */
   static set = async (chain: ChainID, account: Account) => {
     this.accounts.set(
@@ -200,6 +198,19 @@ export class AccountsController {
       action: 'account:updateAll',
       data: { accounts: this.serializeAccounts() },
     });
+  };
+
+  /**
+   * @name update
+   * @summary Update an existing account.
+   */
+  static update = (chain: ChainID, account: Account) => {
+    this.accounts.set(
+      chain,
+      this.accounts
+        .get(chain)
+        ?.map((a) => (a.address === account.address ? account : a)) || []
+    );
   };
 
   /**

--- a/src/renderer/hooks/useMainMessagePorts.ts
+++ b/src/renderer/hooks/useMainMessagePorts.ts
@@ -348,7 +348,8 @@ export const useMainMessagePorts = () => {
           await importAddresses(
             serialized,
             handleImportAddress,
-            handleRemoveAddress
+            handleRemoveAddress,
+            setAddresses
           );
 
           // Events.

--- a/src/renderer/utils/ImportUtils.ts
+++ b/src/renderer/utils/ImportUtils.ts
@@ -6,6 +6,7 @@ import { Config as ConfigRenderer } from '@/config/processes/renderer';
 import { Flip, toast } from 'react-toastify';
 import type {
   AccountSource,
+  FlattenedAccounts,
   LedgerLocalAddress,
   LocalAddress,
 } from '@/types/accounts';
@@ -175,7 +176,8 @@ export const getSortedLocalLedgerAddresses = (
 export const importAddresses = async (
   serialized: string,
   handleImportAddress: (ev: MessageEvent, fromBackup: boolean) => Promise<void>,
-  handleRemoveAddress: (ev: MessageEvent) => Promise<void>
+  handleRemoveAddress: (ev: MessageEvent) => Promise<void>,
+  setAddresses: (a: FlattenedAccounts) => void
 ) => {
   const s_addresses = getFromBackupFile('addresses', serialized);
   if (!s_addresses) {
@@ -226,7 +228,17 @@ export const importAddresses = async (
         await handleRemoveAddress(new MessageEvent('message', data));
         postToImport('import:address:update', { address: a, source });
       }
+
+      // Update managed account names.
+      const account = AccountsController.get(chainId, address);
+      if (account) {
+        account.name = name;
+        AccountsController.update(chainId, account);
+      }
     }
+
+    // Update account list state.
+    setAddresses(AccountsController.getAllFlattenedAccountData());
   }
 };
 


### PR DESCRIPTION
Tweaks and polishes to the backup system iteration.

- [x] Account names stored in the backup file take precedence over the application's current state.
  Account names stored in address, account and event structures are updated on import.

- [ ] App version encoded in backup file.
  The import process needs to know how to parse the backed up data in future versions. Data structures will change, and the app version will dictate how to parse backed up data correctly.

- [ ] Base window always on top.
  When clicking export or import, render an invisible `BrowserWindow` over the base window. This will allow the base window to be always on top, and render the native OS dialog correctly.