### PR TITLE
feat: persist side nav collapsed state

### DIFF
--- a/src/controller/main/SettingsController.ts
+++ b/src/controller/main/SettingsController.ts
@@ -34,6 +34,7 @@ export class SettingsController {
         appEnablePolkassemblyApi: true,
         appKeepOutdatedEvents: true,
         appHideDockIcon: false,
+        appCollapseSideNav: false,
       };
 
       // Persist default settings to store and return them.
@@ -128,6 +129,11 @@ export class SettingsController {
 
         // Hide or show dock icon.
         flag ? hideDockIcon() : showDockIcon();
+        break;
+      }
+      case 'settings:execute:collapseSideNav': {
+        const flag = !settings.appCollapseSideNav;
+        settings.appCollapseSideNav = flag;
         break;
       }
       default: {

--- a/src/renderer/Providers.tsx
+++ b/src/renderer/Providers.tsx
@@ -60,13 +60,14 @@ const getProvidersForWindow = () => {
     }
     case 'main': {
       return withProviders(
-        SideNavProvider,
         HelpProvider,
         OverlayProvider,
         TooltipProvider,
         ConnectionsProvider,
         AddressesProvider,
         AppSettingsProvider,
+        // Side nav relies on app settings.
+        SideNavProvider,
         ChainsProvider,
         SubscriptionsProvider,
         IntervalSubscriptionsProvider,

--- a/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -11,6 +11,7 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   enableAutomaticSubscriptions: true,
   enablePolkassemblyApi: true,
   hideDockIcon: false,
+  sideNavCollapsed: false,
   setSilenceOsNotifications: (b) => {},
   handleDockedToggle: () => {},
   handleToggleSilenceOsNotifications: () => {},
@@ -19,4 +20,5 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   handleToggleEnablePolkassemblyApi: () => {},
   handleToggleKeepOutdatedEvents: () => {},
   handleToggleHideDockIcon: () => {},
+  handleSideNavCollapse: () => {},
 };

--- a/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/src/renderer/contexts/main/AppSettings/index.tsx
@@ -40,6 +40,9 @@ export const AppSettingsProvider = ({
   /// Hide dock icon.
   const [hideDockIcon, setHideDockIcon] = useState<boolean>(false);
 
+  /// Side nav collapsed flag.
+  const [sideNavCollapsed, setSideNavCollapsed] = useState<boolean>(false);
+
   /// Get settings from main and initialise state.
   useEffect(() => {
     const initSettings = async () => {
@@ -51,6 +54,7 @@ export const AppSettingsProvider = ({
         appEnablePolkassemblyApi,
         appKeepOutdatedEvents,
         appHideDockIcon,
+        appCollapseSideNav,
       } = await window.myAPI.getAppSettings();
 
       // Set cached notifications flag in renderer config.
@@ -67,6 +71,7 @@ export const AppSettingsProvider = ({
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
       setEnablePolkassemblyApi(appEnablePolkassemblyApi);
       setHideDockIcon(appHideDockIcon);
+      setSideNavCollapsed(appCollapseSideNav);
     };
 
     initSettings();
@@ -146,6 +151,12 @@ export const AppSettingsProvider = ({
     handleToggleSetting('settings:execute:hideDockIcon');
   };
 
+  /// Handle collapse/expand side nav.
+  const handleSideNavCollapse = () => {
+    setSideNavCollapsed((pv) => !pv);
+    handleToggleSetting('settings:execute:collapseSideNav');
+  };
+
   return (
     <AppSettingsContext.Provider
       value={{
@@ -155,6 +166,7 @@ export const AppSettingsProvider = ({
         enableAutomaticSubscriptions,
         enablePolkassemblyApi,
         hideDockIcon,
+        sideNavCollapsed,
         handleDockedToggle,
         handleToggleSilenceOsNotifications,
         handleToggleShowDebuggingSubscriptions,
@@ -163,6 +175,7 @@ export const AppSettingsProvider = ({
         handleToggleKeepOutdatedEvents,
         handleToggleHideDockIcon,
         setSilenceOsNotifications,
+        handleSideNavCollapse,
       }}
     >
       {children}

--- a/src/renderer/contexts/main/AppSettings/types.ts
+++ b/src/renderer/contexts/main/AppSettings/types.ts
@@ -8,6 +8,7 @@ export interface AppSettingsContextInterface {
   enableAutomaticSubscriptions: boolean;
   enablePolkassemblyApi: boolean;
   hideDockIcon: boolean;
+  sideNavCollapsed: boolean;
   setSilenceOsNotifications: (b: boolean) => void;
   handleDockedToggle: () => void;
   handleToggleSilenceOsNotifications: () => void;
@@ -16,4 +17,5 @@ export interface AppSettingsContextInterface {
   handleToggleEnablePolkassemblyApi: () => void;
   handleToggleKeepOutdatedEvents: () => void;
   handleToggleHideDockIcon: () => void;
+  handleSideNavCollapse: () => void;
 }

--- a/src/renderer/library/SideNav/SideNav.tsx
+++ b/src/renderer/library/SideNav/SideNav.tsx
@@ -12,9 +12,11 @@ import {
   faUpRightAndDownLeftFromCenter,
 } from '@fortawesome/free-solid-svg-icons';
 import { useSideNav } from '../contexts';
+import { useAppSettings } from '@/renderer/contexts/main/AppSettings';
 
 export const SideNav = () => {
-  const { isCollapsed, setIsCollapsed } = useSideNav();
+  const { handleSideNavCollapse } = useAppSettings();
+  const { isCollapsed } = useSideNav();
 
   return (
     <SideNavWrapper $isCollapsed={isCollapsed}>
@@ -29,7 +31,7 @@ export const SideNav = () => {
             ? { marginTop: 'auto' }
             : { marginTop: 'auto', maxWidth: '48px' }
         }
-        onClick={() => setIsCollapsed((pv) => !pv)}
+        onClick={() => handleSideNavCollapse()}
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 0.95 }}
       >

--- a/src/renderer/library/contexts/SideNavContext/defaults.ts
+++ b/src/renderer/library/contexts/SideNavContext/defaults.ts
@@ -8,5 +8,4 @@ export const defaultSideNavContext: SideNavContextInterface = {
   isCollapsed: false,
   selectedId: 0,
   setSelectedId: () => {},
-  setIsCollapsed: () => {},
 };

--- a/src/renderer/library/contexts/SideNavContext/index.tsx
+++ b/src/renderer/library/contexts/SideNavContext/index.tsx
@@ -3,6 +3,7 @@
 
 import { createContext, useContext, useState } from 'react';
 import { defaultSideNavContext } from './defaults';
+import { useAppSettings } from '@/renderer/contexts/main/AppSettings';
 import type { SideNavContextInterface, SideNavProviderProps } from './types';
 
 const SideNavContext = createContext<SideNavContextInterface>(
@@ -12,16 +13,15 @@ const SideNavContext = createContext<SideNavContextInterface>(
 export const useSideNav = () => useContext(SideNavContext);
 
 export const SideNavProvider = ({ children }: SideNavProviderProps) => {
+  const { sideNavCollapsed } = useAppSettings();
   const [selectedId, setSelectedId] = useState(0);
-  const [isCollapsed, setIsCollapsed] = useState(false);
 
   return (
     <SideNavContext.Provider
       value={{
-        isCollapsed,
+        isCollapsed: sideNavCollapsed,
         selectedId,
         setSelectedId,
-        setIsCollapsed,
       }}
     >
       {children}

--- a/src/renderer/library/contexts/SideNavContext/types.ts
+++ b/src/renderer/library/contexts/SideNavContext/types.ts
@@ -4,7 +4,6 @@
 export interface SideNavContextInterface {
   isCollapsed: boolean;
   selectedId: number;
-  setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedId: React.Dispatch<React.SetStateAction<number>>;
 }
 

--- a/src/renderer/screens/Settings/types.ts
+++ b/src/renderer/screens/Settings/types.ts
@@ -14,6 +14,7 @@ export interface PersistedSettings {
   appEnablePolkassemblyApi: boolean;
   appKeepOutdatedEvents: boolean;
   appHideDockIcon: boolean;
+  appCollapseSideNav: boolean;
 }
 
 export type OsPlatform = 'darwin' | 'linux' | 'win32';
@@ -28,7 +29,8 @@ export type SettingAction =
   | 'settings:execute:enableAutomaticSubscriptions'
   | 'settings:execute:enablePolkassembly'
   | 'settings:execute:keepOutdatedEvents'
-  | 'settings:execute:hideDockIcon';
+  | 'settings:execute:hideDockIcon'
+  | 'settings:execute:collapseSideNav';
 
 export interface SettingItem {
   action: SettingAction;


### PR DESCRIPTION
The flag that controls whether the side nav bar is collapsed or expanded is persisted to the store.

The side nav's collapsed state will be restored when the app is relaunched.