### PR TITLE
chore: dynamic dock button

### DIFF
--- a/packages/renderer/src/config/settings.ts
+++ b/packages/renderer/src/config/settings.ts
@@ -12,7 +12,7 @@ export const SettingsList: SettingItem[] = [
     helpKey: 'help:settings:dockedWindow',
     settingType: 'switch',
     title: 'Docked Window',
-    platforms: ['darwin', 'win32', 'linux'],
+    platforms: ['darwin', 'win32'],
   },
   {
     action: 'settings:execute:showOnAllWorkspaces',

--- a/packages/renderer/src/renderer/screens/Home/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/index.tsx
@@ -93,6 +93,10 @@ export const Home = () => {
   /// Handle header dock toggle.
   // TODO: Move to file.
   const onDockToggle = () => {
+    if (platform === 'linux') {
+      return;
+    }
+
     handleDockedToggle();
 
     ConfigRenderer.portToSettings?.postMessage({
@@ -129,6 +133,7 @@ export const Home = () => {
         appLoading={appLoading}
         dockToggled={dockToggled}
         showButtons={true}
+        showDock={String(platform) !== 'linux'}
         showMinimize={String(platform) === 'linux'}
         onDockToggle={onDockToggle}
         onMinimizeWindow={onMinimizeWindow}

--- a/packages/ui/src/components/Header/index.tsx
+++ b/packages/ui/src/components/Header/index.tsx
@@ -18,6 +18,7 @@ export const Header = ({
   children,
   appLoading = false,
   showButtons = false,
+  showDock = true,
   showMinimize = false,
   dockToggled,
   version,
@@ -37,13 +38,15 @@ export const Header = ({
         {showButtons ? (
           <div className="controls-wrapper">
             {/* Dock window */}
-            <ButtonSecondary
-              className="dock-btn"
-              text={dockToggled ? 'Detach' : 'Dock'}
-              iconLeft={dockToggled ? faUnlock : faLock}
-              iconTransform="shrink-5"
-              onClick={() => onDockToggle && onDockToggle()}
-            />
+            {showDock && (
+              <ButtonSecondary
+                className="dock-btn"
+                text={dockToggled ? 'Detach' : 'Dock'}
+                iconLeft={dockToggled ? faUnlock : faLock}
+                iconTransform="shrink-5"
+                onClick={() => onDockToggle && onDockToggle()}
+              />
+            )}
 
             {/* Restore base window */}
             <button

--- a/packages/ui/src/components/Header/types.ts
+++ b/packages/ui/src/components/Header/types.ts
@@ -3,6 +3,7 @@
 
 export interface HeaderProps {
   showButtons?: boolean;
+  showDock?: boolean;
   showMinimize?: boolean;
   appLoading?: boolean;
   dockToggled?: boolean;


### PR DESCRIPTION
# Summary

Electron's `win.setMovable(movable)` method works on macOS and Windows only.

With this in mind, docking won't work as expected on Linux systems. Therefore, the dock button is not currently displayed on Linux environments.

It is possible to move and resize windows on Linux. A future PR could implement a UI presenting "docking" options on Linux platforms to align with the Mac and Windows versions.