### PR TITLE
fix: linux overlay window alternative

### DIFF
--- a/packages/main/src/controller/WindowsController.ts
+++ b/packages/main/src/controller/WindowsController.ts
@@ -92,6 +92,10 @@ export class WindowsController {
   /* Overlay Window                           */
   /* ---------------------------------------- */
 
+  static setBaseAlwaysOnTop = (alwaysOnTop: boolean) => {
+    this.base?.window.setAlwaysOnTop(alwaysOnTop);
+  };
+
   static overlayExists = (): boolean => this.overlay !== null;
 
   static getOverlay = (): BrowserWindow | null => {


### PR DESCRIPTION
# Summary

The overlay window that's rendered on top of the base window when the `Import` or `Export` buttons are clicked causes graphical bugs on Wayland Linux.

If Polkadot Live is running on Linux, the base window's `alwaysOnTop` property is temporarily set to `false` when the `Import` or `Export` buttons are clicked. When the native OS dialogs are closed, `alwaysOnTop` is set back to `true`. This implementation doesn't require the overlay window to be used on Linux.