### PR TITLE
fix: linux base window glitch

### DIFF
--- a/packages/main/src/utils/WindowUtils.ts
+++ b/packages/main/src/utils/WindowUtils.ts
@@ -191,7 +191,7 @@ export const createBaseWindow = () => {
     x: defaultX,
     y: defaultY,
     frame: false,
-    show: true,
+    show: false,
     resizable: true,
     height: baseHeight,
     minHeight: 475,
@@ -208,7 +208,6 @@ export const createBaseWindow = () => {
   });
 
   // Hide base window and menu bar on Linux and Windows.
-  baseWindow.hide();
   setWindowMenuVisibility(baseWindow);
 
   // TODO: Register local shortcut Ctrl+Q and Ctrl+W


### PR DESCRIPTION
# Summary

Graphical glitch occurred when programatically hiding the base window immediately after creating it.

Fixed by setting the `BrowserWindow` constructor's `show` option to `false` on creation.