### PR TITLE
feat: header dock toggle icon

### DIFF
--- a/packages/ui/src/components/Header/index.tsx
+++ b/packages/ui/src/components/Header/index.tsx
@@ -12,6 +12,7 @@ import {
 
 import { ButtonSecondary } from '../../kits/Buttons';
 import { HeaderWrapper } from './Wrapper';
+import { Padlock } from '../Padlock';
 import type { HeaderProps } from './types';
 
 export const Header = ({
@@ -77,6 +78,8 @@ export const Header = ({
                 />
               </button>
             )}
+
+            <Padlock />
           </div>
         ) : (
           <button

--- a/packages/ui/src/components/Header/index.tsx
+++ b/packages/ui/src/components/Header/index.tsx
@@ -4,13 +4,9 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faTimes,
-  faUnlock,
-  faLock,
   faWindowRestore,
   faCircleChevronDown,
 } from '@fortawesome/free-solid-svg-icons';
-
-import { ButtonSecondary } from '../../kits/Buttons';
 import { HeaderWrapper } from './Wrapper';
 import { Padlock } from '../Padlock';
 import type { HeaderProps } from './types';
@@ -38,17 +34,6 @@ export const Header = ({
       <div className="right">
         {showButtons ? (
           <div className="controls-wrapper">
-            {/* Dock window */}
-            {showDock && (
-              <ButtonSecondary
-                className="dock-btn"
-                text={dockToggled ? 'Detach' : 'Dock'}
-                iconLeft={dockToggled ? faUnlock : faLock}
-                iconTransform="shrink-5"
-                onClick={() => onDockToggle && onDockToggle()}
-              />
-            )}
-
             {/* Restore base window */}
             <button
               type="button"
@@ -79,7 +64,13 @@ export const Header = ({
               </button>
             )}
 
-            <Padlock />
+            {/* Dock button */}
+            {showDock && (
+              <Padlock
+                locked={Boolean(dockToggled)}
+                onClick={() => onDockToggle && onDockToggle()}
+              />
+            )}
           </div>
         ) : (
           <button

--- a/packages/ui/src/components/Padlock/Wrapper.ts
+++ b/packages/ui/src/components/Padlock/Wrapper.ts
@@ -1,0 +1,67 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import styled from 'styled-components';
+
+export const PadlockWrapper = styled.div`
+  .padlock,
+  .icon2 {
+    position: relative;
+    cursor: pointer;
+  }
+
+  svg {
+    width: 13px;
+    height: auto;
+  }
+
+  .padlock rect,
+  .padlock path,
+  .icon2 path {
+    transition: all 0.2s ease-in-out;
+  }
+
+  .padlock rect {
+    fill: var(--text-color-secondary);
+  }
+  .icon2 path#body {
+    fill: var(--text-color-secondary);
+  }
+
+  .padlock path,
+  .icon2 path#hook {
+    stroke: var(--text-color-secondary);
+    stroke-dasharray: 30;
+    stroke-dashoffset: 5;
+    fill: none;
+  }
+
+  .padlock.green rect,
+  .icon2#green path#body {
+    fill: var(--text-color-secondary);
+  }
+
+  .padlock.green path,
+  .icon2.green path#hook {
+    stroke: var(--text-color-secondary);
+    stroke-dasharray: 20;
+  }
+
+  /* keyhole */
+  .keyhole {
+    width: 4px;
+    height: 4px;
+    border-radius: 12px;
+    position: absolute;
+    top: 60%;
+    left: 50%;
+    background-color: black;
+    transform: translate(-50%, -50%) rotate(0deg);
+    transition: all 0.2s ease-in-out;
+    z-index: 1;
+  }
+
+  //.padlock.green .keyhole {
+  //  transform: translate(-50%, -50%) rotate(-180deg);
+  //}
+`;

--- a/packages/ui/src/components/Padlock/index.tsx
+++ b/packages/ui/src/components/Padlock/index.tsx
@@ -1,7 +1,6 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useState } from 'react';
 import styled from 'styled-components';
 
 const PadlockWrapper = styled.div`
@@ -67,35 +66,32 @@ const PadlockWrapper = styled.div`
   //}
 `;
 
-export const Padlock = () => {
-  const [lockState, setLockState] = useState(true);
+interface PadlockProps {
+  locked: boolean;
+  onClick: () => void;
+}
 
-  const handleClick = () => {
-    setLockState((pv) => !pv);
-  };
-
-  return (
-    <PadlockWrapper>
-      <div
-        className={`padlock ${lockState ? 'green' : ''}`}
-        style={{ marginLeft: '0.25rem' }}
-        onClick={handleClick}
-      >
-        <div className="keyhole"></div>
-        <svg viewBox="0 0 22 25">
-          <rect
-            x="0.505493"
-            y="10.1519"
-            width="21.3777"
-            height="14.2868"
-            rx="3"
-          />
-          <path
-            d="M5.73621 10.4592V7.32508C5.73621 4.31064 8.1799 1.86694 11.1943 1.86694V1.86694C14.2088 1.86694 16.6525 4.31064 16.6525 7.32508V10.4592"
-            strokeWidth="3.5"
-          />
-        </svg>
-      </div>
-    </PadlockWrapper>
-  );
-};
+export const Padlock = ({ locked, onClick }: PadlockProps) => (
+  <PadlockWrapper>
+    <div
+      className={`padlock ${locked ? '' : 'green'}`}
+      style={{ marginLeft: '0.25rem', marginTop: '0.15rem' }}
+      onClick={onClick}
+    >
+      <div className="keyhole"></div>
+      <svg viewBox="0 0 22 25">
+        <rect
+          x="0.505493"
+          y="10.1519"
+          width="21.3777"
+          height="14.2868"
+          rx="3"
+        />
+        <path
+          d="M5.73621 10.4592V7.32508C5.73621 4.31064 8.1799 1.86694 11.1943 1.86694V1.86694C14.2088 1.86694 16.6525 4.31064 16.6525 7.32508V10.4592"
+          strokeWidth="3.5"
+        />
+      </svg>
+    </div>
+  </PadlockWrapper>
+);

--- a/packages/ui/src/components/Padlock/index.tsx
+++ b/packages/ui/src/components/Padlock/index.tsx
@@ -1,0 +1,101 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useState } from 'react';
+import styled from 'styled-components';
+
+const PadlockWrapper = styled.div`
+  .padlock,
+  .icon2 {
+    position: relative;
+    cursor: pointer;
+  }
+
+  svg {
+    width: 13px;
+    height: auto;
+  }
+
+  .padlock rect,
+  .padlock path,
+  .icon2 path {
+    transition: all 0.2s ease-in-out;
+  }
+
+  .padlock rect {
+    fill: var(--text-color-secondary);
+  }
+  .icon2 path#body {
+    fill: var(--text-color-secondary);
+  }
+
+  .padlock path,
+  .icon2 path#hook {
+    stroke: var(--text-color-secondary);
+    stroke-dasharray: 30;
+    stroke-dashoffset: 5;
+    fill: none;
+  }
+
+  .padlock.green rect,
+  .icon2#green path#body {
+    fill: var(--text-color-secondary);
+  }
+
+  .padlock.green path,
+  .icon2.green path#hook {
+    stroke: var(--text-color-secondary);
+    stroke-dasharray: 20;
+  }
+
+  /* keyhole */
+  .keyhole {
+    width: 4px;
+    height: 4px;
+    border-radius: 12px;
+    position: absolute;
+    top: 60%;
+    left: 50%;
+    background-color: black;
+    transform: translate(-50%, -50%) rotate(0deg);
+    transition: all 0.2s ease-in-out;
+    z-index: 1;
+  }
+
+  //.padlock.green .keyhole {
+  //  transform: translate(-50%, -50%) rotate(-180deg);
+  //}
+`;
+
+export const Padlock = () => {
+  const [lockState, setLockState] = useState(true);
+
+  const handleClick = () => {
+    setLockState((pv) => !pv);
+  };
+
+  return (
+    <PadlockWrapper>
+      <div
+        className={`padlock ${lockState ? 'green' : ''}`}
+        style={{ marginLeft: '0.25rem' }}
+        onClick={handleClick}
+      >
+        <div className="keyhole"></div>
+        <svg viewBox="0 0 22 25">
+          <rect
+            x="0.505493"
+            y="10.1519"
+            width="21.3777"
+            height="14.2868"
+            rx="3"
+          />
+          <path
+            d="M5.73621 10.4592V7.32508C5.73621 4.31064 8.1799 1.86694 11.1943 1.86694V1.86694C14.2088 1.86694 16.6525 4.31064 16.6525 7.32508V10.4592"
+            strokeWidth="3.5"
+          />
+        </svg>
+      </div>
+    </PadlockWrapper>
+  );
+};

--- a/packages/ui/src/components/Padlock/index.tsx
+++ b/packages/ui/src/components/Padlock/index.tsx
@@ -1,75 +1,8 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import styled from 'styled-components';
-
-const PadlockWrapper = styled.div`
-  .padlock,
-  .icon2 {
-    position: relative;
-    cursor: pointer;
-  }
-
-  svg {
-    width: 13px;
-    height: auto;
-  }
-
-  .padlock rect,
-  .padlock path,
-  .icon2 path {
-    transition: all 0.2s ease-in-out;
-  }
-
-  .padlock rect {
-    fill: var(--text-color-secondary);
-  }
-  .icon2 path#body {
-    fill: var(--text-color-secondary);
-  }
-
-  .padlock path,
-  .icon2 path#hook {
-    stroke: var(--text-color-secondary);
-    stroke-dasharray: 30;
-    stroke-dashoffset: 5;
-    fill: none;
-  }
-
-  .padlock.green rect,
-  .icon2#green path#body {
-    fill: var(--text-color-secondary);
-  }
-
-  .padlock.green path,
-  .icon2.green path#hook {
-    stroke: var(--text-color-secondary);
-    stroke-dasharray: 20;
-  }
-
-  /* keyhole */
-  .keyhole {
-    width: 4px;
-    height: 4px;
-    border-radius: 12px;
-    position: absolute;
-    top: 60%;
-    left: 50%;
-    background-color: black;
-    transform: translate(-50%, -50%) rotate(0deg);
-    transition: all 0.2s ease-in-out;
-    z-index: 1;
-  }
-
-  //.padlock.green .keyhole {
-  //  transform: translate(-50%, -50%) rotate(-180deg);
-  //}
-`;
-
-interface PadlockProps {
-  locked: boolean;
-  onClick: () => void;
-}
+import { PadlockWrapper } from './Wrapper';
+import type { PadlockProps } from './types';
 
 export const Padlock = ({ locked, onClick }: PadlockProps) => (
   <PadlockWrapper>

--- a/packages/ui/src/components/Padlock/types.ts
+++ b/packages/ui/src/components/Padlock/types.ts
@@ -1,0 +1,7 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+export interface PadlockProps {
+  locked: boolean;
+  onClick: () => void;
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -12,6 +12,7 @@ export * from './Help';
 export * from './Identicon';
 export * from './Menu';
 export * from './Overlay';
+export * from './Padlock';
 export * from './ShiftingMeter';
 export * from './Spinners';
 export * from './SideNav';


### PR DESCRIPTION
Replace the header's `Dock` button in the main window's header with an animated padlock icon.

This refactor makes the header design consistent between Linux, Mac and Windows versions of Polkadot Live. 