### PR TITLE
fix: online status relay

### DIFF
--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -352,6 +352,12 @@ app.whenReady().then(async () => {
         break;
       }
 
+      case 'isOnlineMode': {
+        // Relay to renderers.
+        WindowsController.relayIpc('renderer:modeFlag:set', { modeId, flag });
+        break;
+      }
+
       case 'darkMode': {
         // Persist new flag to store.
         SettingsController.process({
@@ -379,6 +385,11 @@ app.whenReady().then(async () => {
     switch (modeId) {
       case 'isImporting': {
         return ConfigMain.importingData;
+      }
+      case 'isConnected': {
+        const status = OnlineStatusController.getStatus();
+        console.log(`> Online status: ${status}`);
+        return status;
       }
       default: {
         return false;

--- a/packages/preload/src/preload.ts
+++ b/packages/preload/src/preload.ts
@@ -191,12 +191,18 @@ export const API: PreloadAPI = {
     ipcRenderer.send('app:view:close', destroyViewId, showViewId),
   isViewOpen: (viewId) => ipcRenderer.invoke('app:view:isOpen', viewId),
 
+  /**
+   * Mode flags
+   */
+
   // Returns a mode flag cached in the main process to the requesting renderer.
   getModeFlag: async (modeId: string): Promise<boolean> =>
     await ipcRenderer.invoke('app:modeFlag:get', modeId),
+
   // Called when a mode flag changes in any renderer to broadcast it to every renderer.
   relayModeFlag: (modeId: string, flag: boolean) =>
     ipcRenderer.send('app:modeFlag:relay', modeId, flag),
+
   // Callback provided in useModeFlagsSyncing hook to sync state between renderers.
   syncModeFlags: (callback) =>
     ipcRenderer.on('renderer:modeFlag:set', callback),

--- a/packages/renderer/src/renderer/contexts/common/Connections/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/common/Connections/defaults.ts
@@ -7,8 +7,10 @@ import type { ConnectionsContextInterface } from './types';
 export const defaultConnectionsContext: ConnectionsContextInterface = {
   isConnected: false,
   isImporting: false,
+  isOnlineMode: false,
   darkMode: true,
   setIsConnected: (b) => {},
   setIsImporting: (b) => {},
+  setIsOnlineMode: (b) => {},
   setDarkMode: (b) => {},
 };

--- a/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
+++ b/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
@@ -28,6 +28,9 @@ export const ConnectionsProvider = ({
   // Flag set to `true` when app is in online mode.
   const [isConnected, setIsConnected] = useState(false);
 
+  // Flag shared between renderers (not main process).
+  const [isOnlineMode, setIsOnlineMode] = useState(false);
+
   // Flag set to `true` when app is importing data from backup file.
   const [isImporting, setIsImporting] = useState(false);
 
@@ -36,7 +39,11 @@ export const ConnectionsProvider = ({
 
   useEffect(() => {
     // Synchronize flags in store.
-    const syncModeFlags = async () => {
+    const syncModeFlagsOnMount = async () => {
+      const onlineStatus = await window.myAPI.getModeFlag('isConnected');
+      setIsConnected(onlineStatus);
+      setIsOnlineMode(onlineStatus);
+
       setIsImporting(await window.myAPI.getModeFlag('isImporting'));
       setDarkMode((await window.myAPI.getAppSettings()).appDarkMode);
     };
@@ -56,6 +63,10 @@ export const ConnectionsProvider = ({
             setDarkMode(flag);
             break;
           }
+          case 'isOnlineMode': {
+            setIsOnlineMode(flag);
+            break;
+          }
           default: {
             break;
           }
@@ -63,7 +74,7 @@ export const ConnectionsProvider = ({
       }
     );
 
-    syncModeFlags();
+    syncModeFlagsOnMount();
   }, []);
 
   return (
@@ -72,9 +83,11 @@ export const ConnectionsProvider = ({
         darkMode,
         isConnected,
         isImporting,
+        isOnlineMode,
         setDarkMode,
         setIsConnected,
         setIsImporting,
+        setIsOnlineMode,
       }}
     >
       {children}

--- a/packages/renderer/src/renderer/contexts/common/Connections/types.ts
+++ b/packages/renderer/src/renderer/contexts/common/Connections/types.ts
@@ -4,8 +4,10 @@
 export interface ConnectionsContextInterface {
   isConnected: boolean;
   isImporting: boolean;
+  isOnlineMode: boolean;
   darkMode: boolean;
   setIsConnected: React.Dispatch<React.SetStateAction<boolean>>;
   setIsImporting: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsOnlineMode: React.Dispatch<React.SetStateAction<boolean>>;
   setDarkMode: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/packages/renderer/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -198,7 +198,7 @@ export const BootstrappingProvider = ({
     // Report online status to renderer.
     setOnline(false);
 
-    // Notify import renderer of connection status.
+    // Notify renderers of connection status.
     for (const windowId of ['import', 'openGov']) {
       reportConnectionStatusToWindow(windowId, false);
     }

--- a/packages/renderer/src/renderer/contexts/main/CogMenu/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/CogMenu/index.tsx
@@ -60,6 +60,9 @@ export const CogMenuProvider = ({
       handleAbortConnecting();
     } else if (isOnline) {
       await handleInitializeAppOffline();
+
+      // Relay online mode flag to renderers.
+      window.myAPI.relayModeFlag('isOnlineMode', false);
     } else {
       // Confirm online connection.
       const status: boolean =
@@ -73,6 +76,9 @@ export const CogMenuProvider = ({
         setIsConnecting(true);
         await handleInitializeAppOnline();
         setIsConnecting(false);
+
+        // Relay online mode flag to renderers.
+        window.myAPI.relayModeFlag('isOnlineMode', true);
       } else {
         // Render error alert.
         toast.error('You are offline.', {


### PR DESCRIPTION
Renderers receive the app's online mode.

The device may be connected to the internet, but the app may still be in offline mode.

This PR sets up a new relayed flag to help renderers distinguish which mode the app is in.