### PR TITLE
feat: fetch stored extrinsics

### DIFF
--- a/packages/main/src/controller/ExtrinsicsController.ts
+++ b/packages/main/src/controller/ExtrinsicsController.ts
@@ -12,8 +12,11 @@ export class ExtrinsicsController {
   /**
    * Process an async IPC task.
    */
-  static processAsync(task: IpcTask): void {
+  static processAsync(task: IpcTask): string | void {
     switch (task.action) {
+      case 'extrinsics:getAll': {
+        return this.getAll();
+      }
       case 'extrinsics:persist': {
         this.persist(task);
         return;
@@ -26,6 +29,13 @@ export class ExtrinsicsController {
         return;
       }
     }
+  }
+
+  /**
+   * Get all stored extrinsics in serialized form.
+   */
+  private static getAll(): string {
+    return (store as Record<string, AnyJson>).get(this.storeKey) as string;
   }
 
   /**

--- a/packages/renderer/src/controller/ExtrinsicsController.ts
+++ b/packages/renderer/src/controller/ExtrinsicsController.ts
@@ -61,6 +61,17 @@ export class ExtrinsicsController {
       const { chainId, from } = info.actionMeta;
       const nonce = (await getAddressNonce(from, chainId)).toNumber();
 
+      // Create tx if it's not cached already.
+      if (!this.txPayloads.has(txId)) {
+        const origin = 'ExtrinsicsController.build';
+        const { api } = await getApiInstanceOrThrow(chainId, origin);
+
+        // Instantiate tx.
+        const { pallet, method, args } = info.actionMeta;
+        const tx = api.tx[pallet][method](...args);
+        this.txPayloads.set(txId, { tx });
+      }
+
       // Generate payload.
       const cached = this.txPayloads.get(txId);
       if (cached === undefined) {

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -156,7 +156,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
 
       renderToast(
         'Extrinsic already added.',
-        `toast-${actionMeta.eventUid}-${actionMeta.action}`,
+        `toast-already-exists-${actionMeta.eventUid}-${actionMeta.action}`,
         'error'
       );
 
@@ -210,7 +210,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
       info.estimatedFee = estimatedFee;
       setUpdateCache(true);
 
-      // Persist new extrinsic to store.
+      // Persist extrinsic to store.
       await window.myAPI.sendExtrinsicsTaskAsync({
         action: 'extrinsics:persist',
         data: { serialized: JSON.stringify(info) },
@@ -218,7 +218,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
 
       renderToast(
         'Extrinsic added.',
-        `toast-${info.actionMeta.eventUid}-${info.actionMeta.action}`,
+        `toast-added-${info.actionMeta.eventUid}-${info.actionMeta.action}`,
         'success'
       );
     } catch (err) {

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -70,7 +70,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         data: null,
       })) as string;
 
-      // Parse the array and store data the extrinsics map ref.
+      // Parse the array and set data in the extrinsics map ref.
       const parsed: ExtrinsicInfo[] = JSON.parse(ser);
 
       for (const info of parsed) {

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -61,6 +61,29 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
   const [showMockUI] = useState(false);
 
   /**
+   * Fetch stored extrinsics when window loads.
+   */
+  useEffect(() => {
+    const fetchExtrinsics = async () => {
+      const ser = (await window.myAPI.sendExtrinsicsTaskAsync({
+        action: 'extrinsics:getAll',
+        data: null,
+      })) as string;
+
+      // Parse the array and store data the extrinsics map ref.
+      const parsed: ExtrinsicInfo[] = JSON.parse(ser);
+
+      for (const info of parsed) {
+        extrinsicsRef.current.set(info.txId, { ...info });
+      }
+
+      // Trigger cache flag to update addresses state.
+      setUpdateCache(true);
+    };
+    fetchExtrinsics();
+  }, []);
+
+  /**
    * Mechanism to update the extrinsics map when its reference is updated.
    */
   useEffect(() => {

--- a/packages/types/src/communication.ts
+++ b/packages/types/src/communication.ts
@@ -58,6 +58,7 @@ export interface IpcTask {
     | 'events:update:accountName'
     | 'events:import'
     // Extrinsics
+    | 'extrinsics:getAll'
     | 'extrinsics:persist'
     | 'extrinsics:remove'
     // Subscriptions (Account)

--- a/packages/types/src/preload.ts
+++ b/packages/types/src/preload.ts
@@ -31,7 +31,7 @@ export interface PreloadAPI {
   sendEventTask: (task: IpcTask) => void;
   reportStaleEvent: ApiReportStaleEvent;
 
-  sendExtrinsicsTaskAsync: (task: IpcTask) => Promise<void>;
+  sendExtrinsicsTaskAsync: (task: IpcTask) => Promise<string | void>;
 
   sendWorkspaceTask: (task: IpcTask) => void;
   fetchPersistedWorkspaces: () => Promise<WorkspaceItem[]>;


### PR DESCRIPTION
When the Extrinsics window is opened, persisted extrinsics in the store are fetched and rendered in the window. 