### PR TITLE
feat: toggle extrinsics os notifications setting

### DIFF
--- a/packages/main/src/controller/SettingsController.ts
+++ b/packages/main/src/controller/SettingsController.ts
@@ -29,6 +29,7 @@ export class SettingsController {
         appDocked: false,
         appDarkMode: true,
         appSilenceOsNotifications: false,
+        appSilenceExtrinsicsOsNotifications: false,
         appShowOnAllWorkspaces: true,
         appShowDebuggingSubscriptions: false,
         appEnableAutomaticSubscriptions: true,
@@ -114,6 +115,11 @@ export class SettingsController {
       case 'settings:execute:silenceOsNotifications': {
         const flag = !settings.appSilenceOsNotifications;
         settings.appSilenceOsNotifications = flag;
+        break;
+      }
+      case 'settings:execute:silenceExtrinsicsOsNotifications': {
+        const flag = !settings.appSilenceExtrinsicsOsNotifications;
+        settings.appSilenceExtrinsicsOsNotifications = flag;
         break;
       }
       case 'settings:execute:enableAutomaticSubscriptions': {

--- a/packages/renderer/src/config/help.ts
+++ b/packages/renderer/src/config/help.ts
@@ -224,7 +224,7 @@ export const HelpConfig: HelpItems = [
     key: 'help:settings:silenceExtrinsicsOsNotifications',
     title: 'Silence OS Notifications for Extrinsics',
     definition: [
-      'Enable to silence native OS notifications that are shown when submitting extrinsics.',
+      'Turn on to silence native OS notifications that are shown when submitting extrinsics.',
       "OS notifications will not be displayed when a submitted extrinsic changes its status, such as when it's included in a block or finalized.",
     ],
   },

--- a/packages/renderer/src/config/help.ts
+++ b/packages/renderer/src/config/help.ts
@@ -221,6 +221,14 @@ export const HelpConfig: HelpItems = [
     ],
   },
   {
+    key: 'help:settings:silenceExtrinsicsOsNotifications',
+    title: 'Silence OS Notifications for Extrinsics',
+    definition: [
+      'Enable to silence native OS notifications that are shown when submitting extrinsics.',
+      "OS notifications will not be displayed when a submitted extrinsic changes its status, such as when it's included in a block or finalized.",
+    ],
+  },
+  {
     key: 'help:settings:importData',
     title: 'Import Data',
     definition: [

--- a/packages/renderer/src/config/settings.ts
+++ b/packages/renderer/src/config/settings.ts
@@ -78,6 +78,15 @@ export const SettingsList: SettingItem[] = [
     platforms: ['darwin', 'win32', 'linux'],
   },
   {
+    action: 'settings:execute:silenceExtrinsicsOsNotifications',
+    category: 'Extrinsics',
+    enabled: false,
+    helpKey: 'help:settings:silenceExtrinsicsOsNotifications',
+    settingType: 'switch',
+    title: 'Silence OS Notifications for Extrinsics',
+    platforms: ['darwin', 'win32', 'linux'],
+  },
+  {
     action: 'settings:execute:importData',
     category: 'Backup',
     buttonIcon: faFileImport,

--- a/packages/renderer/src/config/settings.ts
+++ b/packages/renderer/src/config/settings.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { SettingItem } from '@app/screens/Settings/types';
+import type { SettingItem } from '@polkadot-live/types/settings';
 import { faFileExport, faFileImport } from '@fortawesome/free-solid-svg-icons';
 
 export const SettingsList: SettingItem[] = [

--- a/packages/renderer/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -15,6 +15,7 @@ export const defaultAppSettingsContext: AppSettingsContextInterface = {
   setSilenceOsNotifications: (b) => {},
   handleDockedToggle: () => {},
   handleToggleSilenceOsNotifications: () => {},
+  handleToggleSilenceExtrinsicOsNotifications: () => {},
   handleToggleShowDebuggingSubscriptions: () => {},
   handleToggleEnableAutomaticSubscriptions: () => {},
   handleToggleEnablePolkassemblyApi: () => {},

--- a/packages/renderer/src/renderer/contexts/main/AppSettings/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/main/AppSettings/defaults.ts
@@ -7,6 +7,7 @@ import type { AppSettingsContextInterface } from './types';
 export const defaultAppSettingsContext: AppSettingsContextInterface = {
   dockToggled: true,
   silenceOsNotifications: false,
+  silenceExtrinsicsOsNotifications: false,
   showDebuggingSubscriptions: false,
   enableAutomaticSubscriptions: true,
   enablePolkassemblyApi: true,

--- a/packages/renderer/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/AppSettings/index.tsx
@@ -25,6 +25,12 @@ export const AppSettingsProvider = ({
   const [silenceOsNotifications, setSilenceOsNotifications] =
     useState<boolean>(false);
 
+  /// Silence extrinsics notifications.
+  const [
+    silenceExtrinsicsOsNotifications,
+    setSilenceExtrinsicsOsNotifications,
+  ] = useState<boolean>(false);
+
   /// Show debugging subscriptions.
   const [showDebuggingSubscriptions, setShowDebuggingSubscriptions] =
     useState<boolean>(false);
@@ -49,6 +55,7 @@ export const AppSettingsProvider = ({
       const {
         appDocked,
         appSilenceOsNotifications,
+        appSilenceExtrinsicsOsNotifications,
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
         appEnablePolkassemblyApi,
@@ -67,6 +74,7 @@ export const AppSettingsProvider = ({
       // Set settings state.
       setDockToggled(appDocked);
       setSilenceOsNotifications(appSilenceOsNotifications);
+      setSilenceExtrinsicsOsNotifications(appSilenceExtrinsicsOsNotifications);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
       setEnablePolkassemblyApi(appEnablePolkassemblyApi);
@@ -77,7 +85,7 @@ export const AppSettingsProvider = ({
     initSettings();
   }, []);
 
-  /// Handle toggling a setting.
+  /// Handle toggling a setting in main process.
   const handleToggleSetting = (settingAction: SettingAction) => {
     window.myAPI.sendSettingTask({
       action: 'settings:toggle',
@@ -108,6 +116,12 @@ export const AppSettingsProvider = ({
     });
 
     handleToggleSetting('settings:execute:silenceOsNotifications');
+  };
+
+  /// Handle toggling extrinsics native OS notifications.
+  const handleToggleSilenceExtrinsicOsNotifications = () => {
+    setSilenceExtrinsicsOsNotifications(!silenceExtrinsicsOsNotifications);
+    handleToggleSetting('settings:execute:silenceExtrinsicsOsNotifications');
   };
 
   /// Handle toggling show debugging subscriptions.
@@ -170,6 +184,7 @@ export const AppSettingsProvider = ({
         setSilenceOsNotifications,
         handleDockedToggle,
         handleToggleSilenceOsNotifications,
+        handleToggleSilenceExtrinsicOsNotifications,
         handleToggleShowDebuggingSubscriptions,
         handleToggleEnableAutomaticSubscriptions,
         handleToggleEnablePolkassemblyApi,

--- a/packages/renderer/src/renderer/contexts/main/AppSettings/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/AppSettings/index.tsx
@@ -176,6 +176,7 @@ export const AppSettingsProvider = ({
       value={{
         dockToggled,
         silenceOsNotifications,
+        silenceExtrinsicsOsNotifications,
         showDebuggingSubscriptions,
         enableAutomaticSubscriptions,
         enablePolkassemblyApi,

--- a/packages/renderer/src/renderer/contexts/main/AppSettings/types.ts
+++ b/packages/renderer/src/renderer/contexts/main/AppSettings/types.ts
@@ -4,6 +4,7 @@
 export interface AppSettingsContextInterface {
   dockToggled: boolean;
   silenceOsNotifications: boolean;
+  silenceExtrinsicsOsNotifications: boolean;
   showDebuggingSubscriptions: boolean;
   enableAutomaticSubscriptions: boolean;
   enablePolkassemblyApi: boolean;

--- a/packages/renderer/src/renderer/contexts/main/AppSettings/types.ts
+++ b/packages/renderer/src/renderer/contexts/main/AppSettings/types.ts
@@ -10,6 +10,7 @@ export interface AppSettingsContextInterface {
   hideDockIcon: boolean;
   sideNavCollapsed: boolean;
   setSilenceOsNotifications: (b: boolean) => void;
+  handleToggleSilenceExtrinsicOsNotifications: () => void;
   handleDockedToggle: () => void;
   handleToggleSilenceOsNotifications: () => void;
   handleToggleShowDebuggingSubscriptions: () => void;

--- a/packages/renderer/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/packages/renderer/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -5,7 +5,7 @@ import * as defaults from './defaults';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { Flip, toast } from 'react-toastify';
 import type { SettingFlagsContextInterface } from './types';
-import type { SettingItem } from '@app/screens/Settings/types';
+import type { SettingItem } from '@polkadot-live/types/settings';
 
 export const SettingFlagsContext = createContext<SettingFlagsContextInterface>(
   defaults.defaultSettingFlagsContext

--- a/packages/renderer/src/renderer/contexts/settings/SettingFlags/index.tsx
+++ b/packages/renderer/src/renderer/contexts/settings/SettingFlags/index.tsx
@@ -20,7 +20,11 @@ export const SettingFlagsProvider = ({
 }) => {
   /// Store state of switch settings.
   const [windowDocked, setWindowDocked] = useState(true);
-  const [silenceOsNotifications, setSilenceOsNotifications] = useState(true);
+  const [silenceOsNotifications, setSilenceOsNotifications] = useState(false);
+  const [
+    silenceExtrinsicsOsNotifications,
+    setSilenceExtrinsicsOsNotifications,
+  ] = useState(false);
   const [showOnAllWorkspaces, setShowOnAllWorkspaces] = useState(false);
   const [showDebuggingSubscriptions, setShowDebuggingSubscriptions] =
     useState(false);
@@ -36,6 +40,7 @@ export const SettingFlagsProvider = ({
       const {
         appDocked,
         appSilenceOsNotifications,
+        appSilenceExtrinsicsOsNotifications,
         appShowOnAllWorkspaces,
         appShowDebuggingSubscriptions,
         appEnableAutomaticSubscriptions,
@@ -46,6 +51,7 @@ export const SettingFlagsProvider = ({
 
       setWindowDocked(appDocked);
       setSilenceOsNotifications(appSilenceOsNotifications);
+      setSilenceExtrinsicsOsNotifications(appSilenceExtrinsicsOsNotifications);
       setShowOnAllWorkspaces(appShowOnAllWorkspaces);
       setShowDebuggingSubscriptions(appShowDebuggingSubscriptions);
       setEnableAutomaticSubscriptions(appEnableAutomaticSubscriptions);
@@ -67,6 +73,9 @@ export const SettingFlagsProvider = ({
       }
       case 'settings:execute:silenceOsNotifications': {
         return silenceOsNotifications;
+      }
+      case 'settings:execute:silenceExtrinsicsOsNotifications': {
+        return silenceExtrinsicsOsNotifications;
       }
       case 'settings:execute:showOnAllWorkspaces': {
         return showOnAllWorkspaces;
@@ -109,6 +118,14 @@ export const SettingFlagsProvider = ({
           toggledOn: !silenceOsNotifications,
         };
         setSilenceOsNotifications(!silenceOsNotifications);
+        break;
+      }
+      case 'settings:execute:silenceExtrinsicsOsNotifications': {
+        umamiData = {
+          settingId: 'silence-extrinsics-notifications',
+          toggledOn: !silenceExtrinsicsOsNotifications,
+        };
+        setSilenceExtrinsicsOsNotifications(!silenceExtrinsicsOsNotifications);
         break;
       }
       case 'settings:execute:showOnAllWorkspaces': {

--- a/packages/renderer/src/renderer/contexts/settings/SettingFlags/types.ts
+++ b/packages/renderer/src/renderer/contexts/settings/SettingFlags/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { SettingItem } from '@app/screens/Settings/types';
+import type { SettingItem } from '@polkadot-live/types/settings';
 
 export interface SettingFlagsContextInterface {
   getSwitchState: (setting: SettingItem) => boolean;

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -65,6 +65,7 @@ export const useMainMessagePorts = () => {
   const {
     handleDockedToggle,
     handleToggleSilenceOsNotifications,
+    handleToggleSilenceExtrinsicOsNotifications,
     handleToggleShowDebuggingSubscriptions,
     handleToggleEnableAutomaticSubscriptions,
     handleToggleEnablePolkassemblyApi,
@@ -717,6 +718,10 @@ export const useMainMessagePorts = () => {
             }
             case 'settings:execute:silenceOsNotifications': {
               handleToggleSilenceOsNotifications();
+              break;
+            }
+            case 'settings:execute:silenceExtrinsicsOsNotifications': {
+              handleToggleSilenceExtrinsicOsNotifications();
               break;
             }
             case 'settings:execute:showDebuggingSubscriptions': {

--- a/packages/renderer/src/renderer/screens/Settings/Setting.tsx
+++ b/packages/renderer/src/renderer/screens/Settings/Setting.tsx
@@ -9,8 +9,8 @@ import { useHelp } from '@app/contexts/common/Help';
 import { ButtonMonoInvert } from '@polkadot-live/ui/kits/buttons';
 import { useConnections } from '@app/contexts/common/Connections';
 import { useSettingFlags } from '@app/contexts/settings/SettingFlags';
-import type { SettingItem, SettingProps } from './types';
-import type { SettingAction } from '@polkadot-live/types/settings';
+import type { SettingProps } from './types';
+import type { SettingAction, SettingItem } from '@polkadot-live/types/settings';
 
 export const Setting = ({ setting, handleSetting }: SettingProps) => {
   const { title, settingType, helpKey } = setting;

--- a/packages/renderer/src/renderer/screens/Settings/index.tsx
+++ b/packages/renderer/src/renderer/screens/Settings/index.tsx
@@ -16,8 +16,7 @@ import { useDebug } from '@app/hooks/useDebug';
 import { useSettingsMessagePorts } from '@app/hooks/useSettingsMessagePorts';
 import { Scrollable } from '@polkadot-live/ui/styles';
 import { ItemsColumn } from '../Home/Manage/Wrappers';
-import type { OsPlatform } from '@polkadot-live/types/settings';
-import type { SettingItem } from './types';
+import type { OsPlatform, SettingItem } from '@polkadot-live/types/settings';
 
 export const Settings: React.FC = () => {
   // Set up port communication for `settings` window.

--- a/packages/renderer/src/renderer/screens/Settings/index.tsx
+++ b/packages/renderer/src/renderer/screens/Settings/index.tsx
@@ -46,7 +46,12 @@ export const Settings: React.FC = () => {
     }
 
     // Insert categories in a desired order.
-    for (const category of ['General', 'Subscriptions', 'Backup']) {
+    for (const category of [
+      'General',
+      'Subscriptions',
+      'Extrinsics',
+      'Backup',
+    ]) {
       map.set(category, []);
     }
 

--- a/packages/renderer/src/renderer/screens/Settings/types.ts
+++ b/packages/renderer/src/renderer/screens/Settings/types.ts
@@ -1,22 +1,8 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { IconProp } from '@fortawesome/fontawesome-svg-core';
-import type { HelpItemKey } from '@polkadot-live/types/help';
 import type { WorkspaceItem } from '@polkadot-live/types/developerConsole/workspaces';
-import type { OsPlatform, SettingAction } from '@polkadot-live/types/settings';
-
-export interface SettingItem {
-  action: SettingAction;
-  category: string;
-  title: string;
-  enabled: boolean;
-  helpKey: HelpItemKey;
-  settingType: string;
-  buttonText?: string;
-  buttonIcon?: IconProp;
-  platforms: OsPlatform[];
-}
+import type { SettingItem } from '@polkadot-live/types/settings';
 
 export interface SettingProps {
   setting: SettingItem;

--- a/packages/types/src/help.ts
+++ b/packages/types/src/help.ts
@@ -41,6 +41,7 @@ export type HelpItemKey =
   | 'help:settings:enablePolkassembly'
   | 'help:settings:hideDockIcon'
   | 'help:settings:keepOutdatedEvents'
+  | 'help:settings:silenceExtrinsicsOsNotifications'
   | 'help:openGov:track'
   | 'help:openGov:origin'
   | 'help:openGov:maxDeciding'

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,6 +1,11 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { HelpItemKey } from './help';
+import type { IconProp } from '@fortawesome/fontawesome-svg-core';
+
+export type OsPlatform = 'darwin' | 'linux' | 'win32';
+
 export interface PersistedSettings {
   appDocked: boolean;
   appDarkMode: boolean;
@@ -14,8 +19,6 @@ export interface PersistedSettings {
   appCollapseSideNav: boolean;
 }
 
-export type OsPlatform = 'darwin' | 'linux' | 'win32';
-
 export type SettingAction =
   | 'settings:execute:dockedWindow'
   | 'settings:execute:showOnAllWorkspaces'
@@ -28,3 +31,15 @@ export type SettingAction =
   | 'settings:execute:keepOutdatedEvents'
   | 'settings:execute:hideDockIcon'
   | 'settings:execute:collapseSideNav';
+
+export interface SettingItem {
+  action: SettingAction;
+  category: string;
+  title: string;
+  enabled: boolean;
+  helpKey: HelpItemKey;
+  settingType: string;
+  buttonText?: string;
+  buttonIcon?: IconProp;
+  platforms: OsPlatform[];
+}

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -10,6 +10,7 @@ export interface PersistedSettings {
   appDocked: boolean;
   appDarkMode: boolean;
   appSilenceOsNotifications: boolean;
+  appSilenceExtrinsicsOsNotifications: boolean;
   appShowOnAllWorkspaces: boolean;
   appShowDebuggingSubscriptions: boolean;
   appEnableAutomaticSubscriptions: boolean;

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -30,7 +30,8 @@ export type SettingAction =
   | 'settings:execute:enablePolkassembly'
   | 'settings:execute:keepOutdatedEvents'
   | 'settings:execute:hideDockIcon'
-  | 'settings:execute:collapseSideNav';
+  | 'settings:execute:collapseSideNav'
+  | 'settings:execute:silenceExtrinsicsOsNotifications';
 
 export interface SettingItem {
   action: SettingAction;


### PR DESCRIPTION
New extrinsics setting in Settings window labelled **Silence OS Notifications for Extrinsics**.

A native OS notification will not be shown during an extrinsic submission if either of the following settings are enabled:

- **Extrinscs --> Silence OS Notifications for Extrinsics**
- **General --> Silence OS Notifications**
