### PR TITLE
feat: dynamic send screen

### DIFF
--- a/packages/main/src/controller/AddressesController.ts
+++ b/packages/main/src/controller/AddressesController.ts
@@ -29,6 +29,9 @@ export class AddressesController {
       case 'raw-account:get': {
         return this.get(task);
       }
+      case 'raw-account:getAll': {
+        return this.getAll();
+      }
       case 'raw-account:persist': {
         this.persist(task);
         break;
@@ -154,6 +157,28 @@ export class AddressesController {
     const { source } = task.data;
     const key = ConfigMain.getStorageKey(source);
     return store.has(key) ? this.getFromStore(key) : '[]';
+  }
+
+  /**
+   * @name getAll
+   * @summary Get all stored addresses and serialize as map.
+   */
+  private static getAll(): string {
+    const sources: AccountSource[] = [
+      'vault',
+      'ledger',
+      'read-only',
+      'wallet-connect',
+    ];
+
+    const map = new Map<AccountSource, string>();
+    for (const source of sources) {
+      const key = ConfigMain.getStorageKey(source);
+      const addresses = store.has(key) ? this.getFromStore(key) : '[]';
+      map.set(source, addresses);
+    }
+
+    return JSON.stringify(Array.from(map.entries()));
   }
 
   /**

--- a/packages/renderer/src/renderer/screens/Home/Send/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/Home/Send/Wrappers.ts
@@ -74,3 +74,27 @@ export const ProgressBarWrapper = styled.div`
     transition: width 0.2s ease-in-out;
   }
 `;
+
+export const NextStepArrowWrapper = styled.div<{ $complete: boolean }>`
+  margin-top: 0.75rem;
+  > button {
+    svg {
+      background-color: ${(props) =>
+        props.$complete ? '#417041' : 'var(--text-color-secondary)'};
+      width: 22px;
+      height: 22px;
+      border-radius: 100%;
+    }
+    text-align: center;
+    width: 100%;
+    color: var(--background-surface);
+    opacity: ${(props) => (props.$complete ? '1' : '0.15')};
+    transition: all 0.2s ease-out;
+    cursor: ${(props) => (props.$complete ? 'pointer' : 'not-allowed')};
+
+    &:hover {
+      filter: ${(props) =>
+        props.$complete ? 'brightness(140%)' : 'brightness(100%)'};
+    }
+  }
+`;

--- a/packages/renderer/src/renderer/screens/Home/Send/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/Home/Send/Wrappers.ts
@@ -17,6 +17,12 @@ export const InputWrapper = styled.div`
     font-weight: 500;
     width: 100%;
     text-align: left;
+    cursor: default;
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
   }
   span {
     color: var(--text-color-primary);

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -5,6 +5,8 @@ import * as Accordion from '@radix-ui/react-accordion';
 import * as Select from '@radix-ui/react-select';
 import * as UI from '@polkadot-live/ui/components';
 import * as themeVariables from '../../../theme/variables';
+
+import { chainCurrency } from '@ren/config/chains';
 import { Identicon, MainHeading } from '@polkadot-live/ui/components';
 import { useConnections } from '@app/contexts/common/Connections';
 import { ChevronDownIcon, ChevronUpIcon } from '@radix-ui/react-icons';
@@ -18,8 +20,13 @@ import {
   faCircleCheck,
   faCopy,
 } from '@fortawesome/free-solid-svg-icons';
-import { AddButton, InputWrapper, ProgressBarWrapper } from './Wrappers';
-import styled from 'styled-components';
+import {
+  AddButton,
+  InputWrapper,
+  NextStepArrowWrapper,
+  ProgressBarWrapper,
+} from './Wrappers';
+
 import type {
   AccountSource,
   LedgerLocalAddress,
@@ -27,8 +34,7 @@ import type {
 } from '@polkadot-live/types/accounts';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { ChangeEvent } from 'react';
-import type { SelectBoxProps } from './types';
-import { chainCurrency } from '@ren/config/chains';
+import type { SelectBoxProps, SendAccordionValue } from './types';
 
 /** Progress bar component */
 const ProgressBar = ({ value, max }: { value: number; max: number }) => {
@@ -97,7 +103,7 @@ export const Send: React.FC = () => {
   /**
    * Accordion state.
    */
-  const [accordionValue, setAccordionValue] = useState<string[]>([
+  const [accordionValue, setAccordionValue] = useState<SendAccordionValue[]>([
     'section-sender',
   ]);
 
@@ -275,7 +281,7 @@ export const Send: React.FC = () => {
   /**
    * Handle clicking a green next step arrow.
    */
-  const handleNextStep = (completed: string) => {
+  const handleNextStep = (completed: SendAccordionValue) => {
     switch (completed) {
       case 'section-sender': {
         setAccordionValue(['section-receiver']);
@@ -314,7 +320,9 @@ export const Send: React.FC = () => {
           style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}
           type="multiple"
           value={accordionValue}
-          onValueChange={(val) => setAccordionValue(val)}
+          onValueChange={(val) =>
+            setAccordionValue(val as SendAccordionValue[])
+          }
         >
           {/** Sender Section */}
           <Accordion.Item className="AccordionItem" value="section-sender">
@@ -579,30 +587,6 @@ const TriggerContent = ({
     </div>
   </>
 );
-
-const NextStepArrowWrapper = styled.div<{ $complete: boolean }>`
-  margin-top: 0.75rem;
-  > button {
-    svg {
-      background-color: ${(props) =>
-        props.$complete ? '#417041' : 'var(--text-color-secondary)'};
-      width: 22px;
-      height: 22px;
-      border-radius: 100%;
-    }
-    text-align: center;
-    width: 100%;
-    color: var(--background-surface);
-    opacity: ${(props) => (props.$complete ? '1' : '0.15')};
-    transition: all 0.2s ease-out;
-    cursor: ${(props) => (props.$complete ? 'pointer' : 'not-allowed')};
-
-    &:hover {
-      filter: ${(props) =>
-        props.$complete ? 'brightness(140%)' : 'brightness(100%)'};
-    }
-  }
-`;
 
 const NextStepArrow = ({
   complete,

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -79,7 +79,7 @@ export const Send: React.FC = () => {
    * Addresses fetched from main process.
    */
   const [addressMap, setAddressMap] = useState(
-    new Map<AccountSource, LocalAddress[] | LedgerLocalAddress[]>()
+    new Map<AccountSource, (LocalAddress | LedgerLocalAddress)[]>()
   );
   const addressMapRef = useRef<typeof addressMap>(addressMap);
   const [updateCache, setUpdateCache] = useState(false);
@@ -156,28 +156,16 @@ export const Send: React.FC = () => {
     return result;
   };
 
-  const mockAddresses = [
-    {
-      accountName: 'Mock Account 1',
-      address: 'MockAddress1',
-    },
-    {
-      accountName: 'Mock Account 2',
-      address: 'MockAddress2',
-    },
-    {
-      accountName: 'Mock Account 3',
-      address: 'MockAddress3',
-    },
-    {
-      accountName: 'Mock Account 4',
-      address: 'MockAddress4',
-    },
-    {
-      accountName: 'Mock Account 5',
-      address: 'MockAddress5',
-    },
-  ];
+  /**
+   * Return all addresses for receiver address list.
+   */
+  const getReceiverAccounts = () => {
+    let result: (LocalAddress | LedgerLocalAddress)[] = [];
+    for (const addresses of addressMap.values()) {
+      result = result.concat(addresses);
+    }
+    return result;
+  };
 
   return (
     <div
@@ -269,16 +257,21 @@ export const Send: React.FC = () => {
                   placeholder="Select Receiver"
                   onValueChange={(val) => setReceiver(val)}
                 >
-                  {mockAddresses.map(({ accountName, address }) => (
-                    <UI.SelectItem key={`receiver-${address}`} value={address}>
-                      <div className="innerRow">
-                        <div>
-                          <Identicon value={address} size={20} />
+                  {getReceiverAccounts().map(
+                    ({ name: accountName, address }) => (
+                      <UI.SelectItem
+                        key={`receiver-${address}`}
+                        value={address}
+                      >
+                        <div className="innerRow">
+                          <div>
+                            <Identicon value={address} size={20} />
+                          </div>
+                          <div>{accountName}</div>
                         </div>
-                        <div>{accountName}</div>
-                      </div>
-                    </UI.SelectItem>
-                  ))}
+                      </UI.SelectItem>
+                    )
+                  )}
                 </SelectBox>
                 <InfoPanel
                   label={'Receiving Address:'}

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -87,6 +87,7 @@ export const Send: React.FC = () => {
   );
   const addressMapRef = useRef<typeof addressMap>(addressMap);
   const [updateCache, setUpdateCache] = useState(false);
+  const [progress, setProgress] = useState(0);
 
   const [sender, setSender] = useState<null | string>(null);
   const [receiver, setReceiver] = useState<null | string>(null);
@@ -95,9 +96,6 @@ export const Send: React.FC = () => {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [estimatedFee, setEstimatedFee] = useState<string>('');
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [progress, setProgress] = useState(0);
 
   /**
    * Fetch stored addresss from main when component loads.
@@ -132,8 +130,6 @@ export const Send: React.FC = () => {
           }
         }
       }
-
-      console.log(addressMap);
     };
 
     fetch();

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -153,7 +153,7 @@ export const Send: React.FC = () => {
       }
       result = result.concat(addresses as LocalAddress[]);
     }
-    return result;
+    return result.sort((a, b) => a.name.localeCompare(b.name));
   };
 
   /**
@@ -164,7 +164,9 @@ export const Send: React.FC = () => {
     for (const addresses of addressMap.values()) {
       result = result.concat(addresses);
     }
-    return result;
+
+    // TODO: Filter accounts by sender address network.
+    return result.sort((a, b) => a.name.localeCompare(b.name));
   };
 
   return (

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -26,6 +26,7 @@ import type {
   LocalAddress,
 } from '@polkadot-live/types/accounts';
 import type { ChainID } from '@polkadot-live/types/chains';
+import type { ChangeEvent } from 'react';
 import type { SelectBoxProps } from './types';
 
 /** Progress bar component */
@@ -86,9 +87,10 @@ export const Send: React.FC = () => {
   const addressMapRef = useRef<typeof addressMap>(addressMap);
   const [updateCache, setUpdateCache] = useState(false);
 
-  const [sender, setSender] = useState('');
-  const [receiver, setReceiver] = useState('');
+  const [sender, setSender] = useState<null | string>(null);
+  const [receiver, setReceiver] = useState<null | string>(null);
   const [senderNetwork, setSenderNetwork] = useState<ChainID | null>(null);
+  const [sendAmount, setSendAmount] = useState<string>('');
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [progress, setProgress] = useState(20);
@@ -149,7 +151,19 @@ export const Send: React.FC = () => {
     setSender(senderAddress);
     setSenderNetwork(getAddressChainId(senderAddress));
 
-    // TODO: Reset other send fields.
+    // Reset other send fields.
+    setReceiver(null);
+    setSendAmount('0');
+  };
+
+  /**
+   * Send amount changed callback.
+   */
+  const handleSendAmountChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const val = event.target.value;
+    if (val === '' || !isNaN(Number(val))) {
+      setSendAmount(val === '' ? '' : val);
+    }
   };
 
   /**
@@ -225,7 +239,7 @@ export const Send: React.FC = () => {
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
                 <SelectBox
-                  value={sender}
+                  value={sender || ''}
                   ariaLabel="Sender"
                   placeholder="Select Sender"
                   onValueChange={(val) => handleSenderChange(val)}
@@ -251,7 +265,7 @@ export const Send: React.FC = () => {
                         alignItems: 'center',
                       }}
                     >
-                      {sender === '' ? (
+                      {!sender ? (
                         <span>-</span>
                       ) : (
                         <>
@@ -279,7 +293,7 @@ export const Send: React.FC = () => {
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
                 <SelectBox
-                  value={receiver}
+                  value={receiver || ''}
                   ariaLabel="Receiver"
                   placeholder="Select Receiver"
                   onValueChange={(val) => setReceiver(val)}
@@ -310,7 +324,7 @@ export const Send: React.FC = () => {
                         alignItems: 'center',
                       }}
                     >
-                      {receiver === '' ? (
+                      {!receiver ? (
                         <span>-</span>
                       ) : (
                         <>
@@ -339,9 +353,10 @@ export const Send: React.FC = () => {
                 <InputWrapper>
                   <input
                     type="number"
-                    disabled={false}
-                    defaultValue={0}
-                    onChange={(e) => console.log(e)}
+                    disabled={!sender}
+                    value={sendAmount}
+                    defaultValue={'0'}
+                    onChange={(e) => handleSendAmountChange(e)}
                   />
                   <span>DOT</span>
                 </InputWrapper>

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -91,13 +91,13 @@ export const Send: React.FC = () => {
   const [sender, setSender] = useState<null | string>(null);
   const [receiver, setReceiver] = useState<null | string>(null);
   const [senderNetwork, setSenderNetwork] = useState<ChainID | null>(null);
-  const [sendAmount, setSendAmount] = useState<string>('');
+  const [sendAmount, setSendAmount] = useState<string>('0');
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [estimatedFee, setEstimatedFee] = useState<string>('');
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [progress, setProgress] = useState(20);
+  const [progress, setProgress] = useState(0);
 
   /**
    * Fetch stored addresss from main when component loads.
@@ -147,6 +147,36 @@ export const Send: React.FC = () => {
       setAddressMap(addressMapRef.current);
     }
   }, [updateCache]);
+
+  /**
+   * Progress bar controller.
+   */
+  useEffect(() => {
+    let conditions = 0;
+
+    sender && (conditions += 1);
+    receiver && (conditions += 1);
+    sendAmount !== '0' && sendAmount !== '' && (conditions += 1);
+
+    switch (conditions) {
+      case 1: {
+        setProgress(100 / 3);
+        break;
+      }
+      case 2: {
+        setProgress((100 / 3) * 2);
+        break;
+      }
+      case 3: {
+        setProgress(100);
+        break;
+      }
+      default: {
+        setProgress(0);
+        break;
+      }
+    }
+  }, [sender, receiver, sendAmount]);
 
   /**
    * Sender value changed callback.
@@ -389,7 +419,7 @@ export const Send: React.FC = () => {
                 <InfoPanel
                   label={'Send Amount:'}
                   Content={
-                    sendAmount === ''
+                    sendAmount === '0'
                       ? '-'
                       : `${sendAmount} ${chainCurrency(senderNetwork!)}`
                   }

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -94,6 +94,13 @@ export const Send: React.FC = () => {
   const [senderNetwork, setSenderNetwork] = useState<ChainID | null>(null);
   const [sendAmount, setSendAmount] = useState<string>('0');
 
+  /**
+   * Accordion state.
+   */
+  const [accordionValue, setAccordionValue] = useState<string[]>([
+    'section-sender',
+  ]);
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [estimatedFee, setEstimatedFee] = useState<string>('');
 
@@ -265,6 +272,26 @@ export const Send: React.FC = () => {
     sendAmount === '0' ||
     sendAmount === '';
 
+  /**
+   * Handle clicking a green next step arrow.
+   */
+  const handleNextStep = (completed: string) => {
+    switch (completed) {
+      case 'section-sender': {
+        setAccordionValue(['section-receiver']);
+        break;
+      }
+      case 'section-receiver': {
+        setAccordionValue(['section-send-amount']);
+        break;
+      }
+      case 'section-send-amount': {
+        setAccordionValue(['section-summary']);
+        break;
+      }
+    }
+  };
+
   return (
     <div
       style={{
@@ -286,7 +313,8 @@ export const Send: React.FC = () => {
           className="AccordionRoot"
           style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}
           type="multiple"
-          defaultValue={['section-sender']}
+          value={accordionValue}
+          onValueChange={(val) => setAccordionValue(val)}
         >
           {/** Sender Section */}
           <Accordion.Item className="AccordionItem" value="section-sender">
@@ -337,7 +365,10 @@ export const Send: React.FC = () => {
                     </div>
                   }
                 />
-                <NextStepArrow complete={true} />
+                <NextStepArrow
+                  complete={sender !== null}
+                  onClick={() => handleNextStep('section-sender')}
+                />
               </FlexColumn>
             </UI.AccordionContent>
           </Accordion.Item>
@@ -395,7 +426,10 @@ export const Send: React.FC = () => {
                     </div>
                   }
                 />
-                <NextStepArrow complete={false} />
+                <NextStepArrow
+                  complete={receiver !== null}
+                  onClick={() => handleNextStep('section-receiver')}
+                />
               </FlexColumn>
             </UI.AccordionContent>
           </Accordion.Item>
@@ -423,7 +457,10 @@ export const Send: React.FC = () => {
                   <span>DOT</span>
                 </InputWrapper>
                 <InfoPanel label={'Spendable Balance:'} Content={'100 DOT'} />
-                <NextStepArrow complete={false} />
+                <NextStepArrow
+                  complete={!(sendAmount === '0' || sendAmount === '')}
+                  onClick={() => handleNextStep('section-send-amount')}
+                />
               </FlexColumn>
             </UI.AccordionContent>
           </Accordion.Item>
@@ -544,14 +581,18 @@ const TriggerContent = ({
 );
 
 const NextStepArrowWrapper = styled.div<{ $complete: boolean }>`
+  margin-top: 0.75rem;
   > button {
+    svg {
+      background-color: ${(props) =>
+        props.$complete ? '#417041' : 'var(--text-color-secondary)'};
+      width: 22px;
+      height: 22px;
+      border-radius: 100%;
+    }
     text-align: center;
     width: 100%;
-    font-size: 2rem;
-    color: ${(props) =>
-      props.$complete
-        ? 'var(--accent-success)'
-        : 'var(--text-color-secondary)'};
+    color: var(--background-surface);
     opacity: ${(props) => (props.$complete ? '1' : '0.15')};
     transition: all 0.2s ease-out;
     cursor: ${(props) => (props.$complete ? 'pointer' : 'not-allowed')};
@@ -563,10 +604,16 @@ const NextStepArrowWrapper = styled.div<{ $complete: boolean }>`
   }
 `;
 
-const NextStepArrow = ({ complete }: { complete: boolean }) => (
+const NextStepArrow = ({
+  complete,
+  onClick,
+}: {
+  complete: boolean;
+  onClick: () => void;
+}) => (
   <NextStepArrowWrapper $complete={complete}>
-    <button>
-      <FontAwesomeIcon icon={faCaretDown} />
+    <button disabled={!complete} onClick={() => onClick()}>
+      <FontAwesomeIcon icon={faCaretDown} transform={'shrink-6'} />
     </button>
   </NextStepArrowWrapper>
 );

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -201,6 +201,24 @@ export const Send: React.FC = () => {
   };
 
   /**
+   * Remove zero when send amount field focused.
+   */
+  const handleSendAmountFocus = () => {
+    if (sendAmount === '0') {
+      setSendAmount('');
+    }
+  };
+
+  /**
+   * Add zero when send amount field blurred and empty.
+   */
+  const handleSendAmountBlur = () => {
+    if (sendAmount === '') {
+      setSendAmount('0');
+    }
+  };
+
+  /**
    * Return all addresses capable of signing extrinsics.
    */
   const getSenderAccounts = () => {
@@ -242,6 +260,15 @@ export const Send: React.FC = () => {
     );
   };
 
+  /**
+   * Conditions to enable the proceed button.
+   */
+  const proceedDisabled = () =>
+    sender === null ||
+    receiver === null ||
+    sendAmount === '0' ||
+    sendAmount === '';
+
   return (
     <div
       style={{
@@ -268,7 +295,7 @@ export const Send: React.FC = () => {
           {/** Sender Section */}
           <Accordion.Item className="AccordionItem" value="section-sender">
             <UI.AccordionTrigger narrow={true}>
-              <TriggerContent label="Sender" complete={true} />
+              <TriggerContent label="Sender" complete={sender !== null} />
             </UI.AccordionTrigger>
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
@@ -322,7 +349,7 @@ export const Send: React.FC = () => {
           {/** Receiver Section */}
           <Accordion.Item className="AccordionItem" value="section-receiver">
             <UI.AccordionTrigger narrow={true}>
-              <TriggerContent label="Receiver" complete={false} />
+              <TriggerContent label="Receiver" complete={receiver !== null} />
             </UI.AccordionTrigger>
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
@@ -380,7 +407,10 @@ export const Send: React.FC = () => {
           {/** Send Amount Section */}
           <Accordion.Item className="AccordionItem" value="section-send-amount">
             <UI.AccordionTrigger narrow={true}>
-              <TriggerContent label="Send Amount" complete={false} />
+              <TriggerContent
+                label="Send Amount"
+                complete={sendAmount !== '0' && sendAmount !== ''}
+              />
             </UI.AccordionTrigger>
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
@@ -391,6 +421,8 @@ export const Send: React.FC = () => {
                     value={sendAmount}
                     defaultValue={'0'}
                     onChange={(e) => handleSendAmountChange(e)}
+                    onFocus={() => handleSendAmountFocus()}
+                    onBlur={() => handleSendAmountBlur()}
                   />
                   <span>DOT</span>
                 </InputWrapper>
@@ -432,7 +464,10 @@ export const Send: React.FC = () => {
                       : `${estimatedFee} ${chainCurrency(senderNetwork!)}`
                   }
                 />
-                <AddButton onClick={() => console.log('Add')} disabled={false}>
+                <AddButton
+                  onClick={() => console.log('Add')}
+                  disabled={proceedDisabled()}
+                >
                   <FontAwesomeIcon
                     icon={faChevronRight}
                     transform={'shrink-4'}

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -28,6 +28,7 @@ import type {
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { ChangeEvent } from 'react';
 import type { SelectBoxProps } from './types';
+import { chainCurrency } from '@ren/config/chains';
 
 /** Progress bar component */
 const ProgressBar = ({ value, max }: { value: number; max: number }) => {
@@ -91,6 +92,9 @@ export const Send: React.FC = () => {
   const [receiver, setReceiver] = useState<null | string>(null);
   const [senderNetwork, setSenderNetwork] = useState<ChainID | null>(null);
   const [sendAmount, setSendAmount] = useState<string>('');
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [estimatedFee, setEstimatedFee] = useState<string>('');
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [progress, setProgress] = useState(20);
@@ -373,11 +377,31 @@ export const Send: React.FC = () => {
             </UI.AccordionTrigger>
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
-                <InfoPanel label={'Network:'} Content={'Polkadot'} />
-                <InfoPanel label={'Sender:'} Content={'Mock Account 1'} />
-                <InfoPanel label={'Receiver:'} Content={'Mock Account 2'} />
-                <InfoPanel label={'Send Amount:'} Content={'10 DOT'} />
-                <InfoPanel label={'Estimated Fee:'} Content={'0.1 DOT'} />
+                <InfoPanel label={'Network:'} Content={senderNetwork || '-'} />
+                <InfoPanel
+                  label={'Sender:'}
+                  Content={!sender ? '-' : ellipsisFn(sender!, 12)}
+                />
+                <InfoPanel
+                  label={'Receiver:'}
+                  Content={!receiver ? '-' : ellipsisFn(receiver, 12)}
+                />
+                <InfoPanel
+                  label={'Send Amount:'}
+                  Content={
+                    sendAmount === ''
+                      ? '-'
+                      : `${sendAmount} ${chainCurrency(senderNetwork!)}`
+                  }
+                />
+                <InfoPanel
+                  label={'Estimated Fee:'}
+                  Content={
+                    estimatedFee === ''
+                      ? '-'
+                      : `${estimatedFee} ${chainCurrency(senderNetwork!)}`
+                  }
+                />
                 <AddButton onClick={() => console.log('Add')} disabled={false}>
                   <FontAwesomeIcon
                     icon={faChevronRight}

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -154,6 +154,7 @@ export const Send: React.FC = () => {
   useEffect(() => {
     if (updateCache) {
       setAddressMap(addressMapRef.current);
+      setUpdateCache(false);
     }
   }, [updateCache]);
 

--- a/packages/renderer/src/renderer/screens/Home/Send/types.ts
+++ b/packages/renderer/src/renderer/screens/Home/Send/types.ts
@@ -1,6 +1,12 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+export type SendAccordionValue =
+  | 'section-sender'
+  | 'section-receiver'
+  | 'section-send-amount'
+  | 'section-summary';
+
 export interface SelectBoxProps {
   children: React.ReactNode;
   ariaLabel: string;

--- a/packages/types/src/communication.ts
+++ b/packages/types/src/communication.ts
@@ -38,6 +38,7 @@ export interface IpcTask {
   | 'raw-account:add'
     | 'raw-account:delete'
     | 'raw-account:get'
+    | 'raw-account:getAll'
     | 'raw-account:import'
     | 'raw-account:persist'
     | 'raw-account:remove'


### PR DESCRIPTION
Implements dynamic state for the send screen and most of its intended behaviour.

The screen still requires some blockchain queries and copy-address functionality, which will be implemented in the next PRs.