### PR TITLE
chore: copy address button polish

### DIFF
--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -3,7 +3,6 @@
 
 import { Config as ConfigAction } from '@ren/config/processes/action';
 import { chainIcon } from '@ren/config/chains';
-import { Flip, toast } from 'react-toastify';
 import React, {
   createContext,
   useContext,
@@ -13,7 +12,6 @@ import React, {
 } from 'react';
 import * as defaults from './defaults';
 import type { AnyJson } from '@polkadot-live/types/misc';
-import type { ToastOptions } from 'react-toastify';
 import type { TxMetaContextInterface } from './types';
 import type {
   ActionMeta,
@@ -25,6 +23,7 @@ import type {
 import { setStateWithRef } from '@w3ux/utils';
 import { SignOverlay } from '@app/screens/Action/SignOverlay';
 import { useOverlay } from '@polkadot-live/ui/contexts';
+import { renderToast } from '@polkadot-live/ui/utils';
 
 export const TxMetaContext = createContext<TxMetaContextInterface>(
   defaults.defaultTxMeta
@@ -535,33 +534,6 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         return 'Claim Rewards';
       }
     }
-  };
-
-  /**
-   * Util for rendering a toast notification.
-   */
-  const renderToast = (
-    message: string,
-    toastId: string,
-    toastType: 'error' | 'success'
-  ) => {
-    const args: ToastOptions<unknown> = {
-      position: 'top-center',
-      autoClose: 3000,
-      hideProgressBar: true,
-      closeOnClick: true,
-      closeButton: false,
-      pauseOnHover: false,
-      draggable: false,
-      progress: undefined,
-      theme: 'dark',
-      transition: Flip,
-      toastId,
-    };
-
-    toastType === 'success'
-      ? toast.success(message, args)
-      : toast.error(message, args);
   };
 
   // Transaction state.

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -105,6 +105,15 @@ export const Send: React.FC = () => {
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
 
   /**
+   * Tooltips state.
+   */
+  const [tooltipAOpen, setTooltipAOpen] = useState<boolean>(false);
+  const [tooltipAText, setTooltipAText] = useState('Copy Address');
+
+  const [tooltipBOpen, setTooltipBOpen] = useState<boolean>(false);
+  const [tooltipBText, setTooltipBText] = useState('Copy Address');
+
+  /**
    * Accordion state.
    */
   const [accordionValue, setAccordionValue] = useState<SendAccordionValue[]>([
@@ -371,11 +380,23 @@ export const Send: React.FC = () => {
                     ) : (
                       <>
                         <span>{ellipsisFn(sender, 12)}</span>
-                        <UI.TooltipRx theme={theme} text={'Copy Address'}>
-                          <CopyButton
-                            onClick={async () =>
-                              await handleClipboardCopy(sender)
+                        <UI.TooltipRx
+                          theme={theme}
+                          open={tooltipAOpen}
+                          text={tooltipAText}
+                          onOpenChange={(val) => {
+                            setTooltipAOpen(val);
+                            if (!val) {
+                              setTooltipAText('Copy Address');
                             }
+                          }}
+                        >
+                          <CopyButton
+                            onClick={async () => {
+                              await handleClipboardCopy(sender);
+                              setTooltipAText('Copied!');
+                              setTooltipAOpen(true);
+                            }}
                           >
                             <FontAwesomeIcon
                               icon={faCopy}
@@ -437,11 +458,23 @@ export const Send: React.FC = () => {
                     ) : (
                       <>
                         <span>{ellipsisFn(receiver, 12)}</span>
-                        <UI.TooltipRx theme={theme} text={'Copy Address'}>
-                          <CopyButton
-                            onClick={async () =>
-                              await handleClipboardCopy(receiver)
+                        <UI.TooltipRx
+                          theme={theme}
+                          open={tooltipBOpen}
+                          text={tooltipBText}
+                          onOpenChange={(val) => {
+                            setTooltipBOpen(val);
+                            if (!val) {
+                              setTooltipBText('Copy Address');
                             }
+                          }}
+                        >
+                          <CopyButton
+                            onClick={async () => {
+                              await handleClipboardCopy(receiver);
+                              setTooltipBText('Copied!');
+                              setTooltipBOpen(true);
+                            }}
                           >
                             <FontAwesomeIcon
                               icon={faCopy}

--- a/packages/ui/src/components/TooltipRx/TooltipRx.tsx
+++ b/packages/ui/src/components/TooltipRx/TooltipRx.tsx
@@ -7,10 +7,10 @@ import type { RadixTooltipProps } from './types';
 
 /** Tooltip component */
 export const TooltipRx = ({
+  open,
   text,
   theme,
   onOpenChange,
-  open,
   children,
 }: RadixTooltipProps) => (
   <Tooltip.Provider>

--- a/packages/ui/src/components/TooltipRx/TooltipRx.tsx
+++ b/packages/ui/src/components/TooltipRx/TooltipRx.tsx
@@ -6,9 +6,15 @@ import { TooltipContent } from './TooltipRx.styles';
 import type { RadixTooltipProps } from './types';
 
 /** Tooltip component */
-export const TooltipRx = ({ text, theme, children }: RadixTooltipProps) => (
+export const TooltipRx = ({
+  text,
+  theme,
+  onOpenChange,
+  open,
+  children,
+}: RadixTooltipProps) => (
   <Tooltip.Provider>
-    <Tooltip.Root delayDuration={0}>
+    <Tooltip.Root open={open} onOpenChange={onOpenChange} delayDuration={0}>
       <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
       <Tooltip.Portal>
         <TooltipContent

--- a/packages/ui/src/components/TooltipRx/types.ts
+++ b/packages/ui/src/components/TooltipRx/types.ts
@@ -7,4 +7,6 @@ export interface RadixTooltipProps {
   children: React.ReactNode;
   text: string;
   theme: AnyData;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }

--- a/packages/ui/src/components/TooltipRx/types.ts
+++ b/packages/ui/src/components/TooltipRx/types.ts
@@ -5,8 +5,8 @@ import type { AnyData } from '@polkadot-live/types/misc';
 
 export interface RadixTooltipProps {
   children: React.ReactNode;
+  open: boolean;
   text: string;
   theme: AnyData;
-  open: boolean;
   onOpenChange: (open: boolean) => void;
 }

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 export * from './helpers';
+export * from './toast';

--- a/packages/ui/src/utils/toast.tsx
+++ b/packages/ui/src/utils/toast.tsx
@@ -1,0 +1,32 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Zoom, toast } from 'react-toastify';
+import type { ToastOptions } from 'react-toastify';
+
+/**
+ * Util for rendering a toast notification.
+ */
+export const renderToast = (
+  message: string,
+  toastId: string,
+  toastType: 'error' | 'success'
+) => {
+  const args: ToastOptions<unknown> = {
+    position: 'top-center',
+    autoClose: 3000,
+    hideProgressBar: true,
+    closeOnClick: true,
+    closeButton: false,
+    pauseOnHover: false,
+    draggable: false,
+    progress: undefined,
+    theme: 'dark',
+    transition: Zoom,
+    toastId,
+  };
+
+  toastType === 'success'
+    ? toast.success(message, args)
+    : toast.error(message, args);
+};


### PR DESCRIPTION
UX improvements when copying an address.

The tooltip remains open and its text changes to `Copied!` when the copy address button is clicked.

The `renderToast` utility has been moved to the `ui` package.