### PR TITLE
chore: send screen node interactions

### DIFF
--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -142,7 +142,9 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         ({ action, from, txStatus }) =>
           from === actionMeta.from &&
           action === actionMeta.action &&
-          txStatus === 'pending'
+          txStatus === 'pending' &&
+          // Allow duplicate balance extrinsics.
+          action !== 'balances_transferKeepAlive'
       );
 
     if (alreadyExists !== undefined) {

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -24,6 +24,7 @@ import { setStateWithRef } from '@w3ux/utils';
 import { SignOverlay } from '@app/screens/Action/SignOverlay';
 import { useOverlay } from '@polkadot-live/ui/contexts';
 import { renderToast } from '@polkadot-live/ui/utils';
+import { generateUID } from '@ren/utils/AccountUtils';
 
 export const TxMetaContext = createContext<TxMetaContextInterface>(
   defaults.defaultTxMeta
@@ -120,20 +121,6 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
       setUpdateCache(false);
     }
   }, [updateCache]);
-
-  /**
-   * Util for generating a UID in the browser.
-   */
-  const generateUID = (): string => {
-    // Generate a random 16-byte array.
-    const array = new Uint8Array(16);
-    crypto.getRandomValues(array);
-
-    // Convert to a hexadecimal string.
-    return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join(
-      ''
-    );
-  };
 
   /**
    * Initialize an extrinsic.
@@ -516,6 +503,9 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
       case 'nominationPools': {
         return 'Nomination Pools';
       }
+      case 'balances': {
+        return 'Balances';
+      }
       default: {
         return 'Unknown.';
       }
@@ -532,6 +522,9 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
       }
       case 'nominationPools_pendingRewards_withdraw': {
         return 'Claim Rewards';
+      }
+      default: {
+        return 'Unknown';
       }
     }
   };

--- a/packages/renderer/src/renderer/screens/Action/TxActionItem.tsx
+++ b/packages/renderer/src/renderer/screens/Action/TxActionItem.tsx
@@ -38,6 +38,12 @@ export const ComponentFactory = {
       </p>
     ),
   },
+  balances_transferKeepAlive: {
+    title: <h3>Transfer Keep Alive</h3>,
+    description: (
+      <p>Transfer the {"chain's"} native token to a recipient address.</p>
+    ),
+  },
 };
 
 export const TxActionItem = ({
@@ -51,6 +57,8 @@ export const TxActionItem = ({
         return `Compound ${actionData.extra} ${chainCurrency(chainId)}`;
       case 'nominationPools_pendingRewards_withdraw':
         return `Claim ${actionData.extra} ${chainCurrency(chainId)}`;
+      case 'balances_transferKeepAlive':
+        return 'Transfer Keep Alive';
     }
   };
 

--- a/packages/renderer/src/renderer/screens/Home/Send/SendHelpers.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/SendHelpers.tsx
@@ -7,6 +7,7 @@ import * as themeVariables from '../../../theme/variables';
 
 import { useConnections } from '@app/contexts/common/Connections';
 import { useState } from 'react';
+import { PuffLoader } from 'react-spinners';
 import { ChevronDownIcon, ChevronUpIcon } from '@radix-ui/react-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -223,13 +224,23 @@ export const SelectBox = ({
 export const TriggerContent = ({
   label,
   complete,
+  loading = false,
 }: {
   label: string;
   complete: boolean;
+  loading?: boolean;
 }) => (
   <>
     <ChevronDownIcon className="AccordionChevron" aria-hidden />
-    <h4 style={{ flex: 1 }}>{label}</h4>
+    <h4 style={{ flex: 1, display: 'flex', alignItems: 'center', gap: '1rem' }}>
+      <span>{label}</span>
+      <PuffLoader
+        loading={loading}
+        size={16}
+        color={'var(--text-color-secondary)'}
+      />
+    </h4>
+
     <div className="right">
       <FontAwesomeIcon
         style={

--- a/packages/renderer/src/renderer/screens/Home/Send/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/Home/Send/Wrappers.ts
@@ -44,8 +44,8 @@ export const InputWrapper = styled.div`
   }
 `;
 
-export const AddButton = styled.button`
-  background-color: var(--button-pink-background);
+export const ActionButton = styled.button<{ $backgroundColor: string }>`
+  background-color: ${(props) => props.$backgroundColor};
   margin-top: 0.4rem;
 
   display: flex;

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -86,9 +86,6 @@ export const Send: React.FC = () => {
     'section-sender',
   ]);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [estimatedFee, setEstimatedFee] = useState<string>('');
-
   /**
    * Fetch stored addresss from main when component loads.
    */
@@ -653,13 +650,6 @@ export const Send: React.FC = () => {
                   {sendAmount === '0' || sendAmount === '' || !validAmount
                     ? '-'
                     : `${sendAmount} ${chainCurrency(senderNetwork!)}`}
-                </InfoPanel>
-
-                {/** Estimated Fee */}
-                <InfoPanel label={'Estimated Fee:'}>
-                  {estimatedFee === ''
-                    ? '-'
-                    : `${estimatedFee} ${chainCurrency(senderNetwork!)}`}
                 </InfoPanel>
 
                 <FlexRow>

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -172,6 +172,7 @@ export const Send: React.FC = () => {
     // Reset other send fields.
     setReceiver(null);
     setSendAmount('0');
+    setValidAmount(true);
   };
 
   /**

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -13,8 +13,8 @@ import { useEffect, useRef, useState } from 'react';
 import { ellipsisFn, planckToUnit, unitToPlanck } from '@w3ux/utils';
 import { getAddressChainId } from '@app/Utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { AddButton, FlexRow, InputWrapper } from './Wrappers';
+import { faBurst, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { ActionButton, FlexRow, InputWrapper } from './Wrappers';
 import {
   CopyButtonWithTooltip,
   FlexColumn,
@@ -217,6 +217,19 @@ export const Send: React.FC = () => {
         data: JSON.stringify(actionMeta),
       });
     }
+  };
+
+  /**
+   * Handle clicking the reset button.
+   */
+  const handleResetClick = () => {
+    setSender(null);
+    setSenderNetwork(null);
+    setReceiver(null);
+    setSpendable(null);
+    setValidAmount(true);
+    setSendAmount('0');
+    setAccordionValue(['section-sender']);
   };
 
   /**
@@ -633,16 +646,29 @@ export const Send: React.FC = () => {
                     : `${estimatedFee} ${chainCurrency(senderNetwork!)}`}
                 </InfoPanel>
 
-                <AddButton
-                  onClick={async () => await handleProceedClick()}
-                  disabled={proceedDisabled()}
-                >
-                  <FontAwesomeIcon
-                    icon={faChevronRight}
-                    transform={'shrink-4'}
-                  />
-                  <span>Proceed</span>
-                </AddButton>
+                <FlexRow>
+                  <ActionButton
+                    style={{ flex: 1 }}
+                    $backgroundColor={'var(--button-background-secondary)'}
+                    onClick={() => handleResetClick()}
+                    disabled={false}
+                  >
+                    <FontAwesomeIcon icon={faBurst} transform={'shrink-4'} />
+                    <span>Reset</span>
+                  </ActionButton>
+                  <ActionButton
+                    style={{ flex: 3 }}
+                    $backgroundColor={'var(--button-pink-background)'}
+                    onClick={async () => await handleProceedClick()}
+                    disabled={proceedDisabled()}
+                  >
+                    <FontAwesomeIcon
+                      icon={faChevronRight}
+                      transform={'shrink-4'}
+                    />
+                    <span>Proceed</span>
+                  </ActionButton>
+                </FlexRow>
               </FlexColumn>
             </UI.AccordionContent>
           </Accordion.Item>

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -64,8 +64,9 @@ export const Send: React.FC = () => {
   const [sender, setSender] = useState<null | string>(null);
   const [receiver, setReceiver] = useState<null | string>(null);
   const [senderNetwork, setSenderNetwork] = useState<ChainID | null>(null);
-
   const [sendAmount, setSendAmount] = useState<string>('0');
+
+  const [fetchingSpendable, setFetchingSpendable] = useState(false);
   const [spendable, setSpendable] = useState<BigNumber | null>(null);
   const [validAmount, setValidAmount] = useState(true);
 
@@ -222,12 +223,15 @@ export const Send: React.FC = () => {
    * Sender value changed callback.
    */
   const handleSenderChange = async (senderAddress: string) => {
+    setFetchingSpendable(true);
+
     const chainId = getAddressChainId(senderAddress);
     setSender(senderAddress);
     setSenderNetwork(chainId);
 
     const result = await getSpendableBalance(senderAddress, chainId);
     setSpendable(result);
+    setFetchingSpendable(false);
 
     // Reset other send fields.
     setReceiver(null);
@@ -532,6 +536,7 @@ export const Send: React.FC = () => {
             <UI.AccordionTrigger narrow={true}>
               <TriggerContent
                 label="Send Amount"
+                loading={fetchingSpendable}
                 complete={
                   sendAmount !== '0' && sendAmount !== '' && validAmount
                 }
@@ -546,7 +551,7 @@ export const Send: React.FC = () => {
                 >
                   <input
                     type="number"
-                    disabled={!sender || !senderNetwork}
+                    disabled={!sender || !senderNetwork || fetchingSpendable}
                     value={sendAmount}
                     onChange={(e) => handleSendAmountChange(e)}
                     onFocus={() => handleSendAmountFocus()}

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -457,18 +457,18 @@ export const Send: React.FC = () => {
             </UI.AccordionContent>
           </Accordion.Item>
 
-          {/** Receiver Section */}
+          {/** Recipient Section */}
           <Accordion.Item className="AccordionItem" value="section-receiver">
             <UI.AccordionTrigger narrow={true}>
-              <TriggerContent label="Receiver" complete={receiver !== null} />
+              <TriggerContent label="Recipient" complete={receiver !== null} />
             </UI.AccordionTrigger>
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
                 <SelectBox
                   disabled={emptyReceivers}
                   value={receiver || ''}
-                  ariaLabel="Receiver"
-                  placeholder="Select Receiver"
+                  ariaLabel="Recipient"
+                  placeholder="Select Recipient"
                   onValueChange={(val) => setReceiver(val)}
                 >
                   {getReceiverAccounts().map(
@@ -603,7 +603,7 @@ export const Send: React.FC = () => {
                 </InfoPanel>
 
                 {/** Receiver */}
-                <InfoPanel label={'Receiver:'}>
+                <InfoPanel label={'Recipient:'}>
                   {!receiver ? (
                     '-'
                   ) : (

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -13,7 +13,11 @@ import { useEffect, useRef, useState } from 'react';
 import { ellipsisFn, planckToUnit, unitToPlanck } from '@w3ux/utils';
 import { getAddressChainId } from '@app/Utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBurst, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import {
+  faBurst,
+  faCheck,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
 import { ActionButton, FlexRow, InputWrapper } from './Wrappers';
 import {
   CopyButtonWithTooltip,
@@ -69,6 +73,8 @@ export const Send: React.FC = () => {
   const [fetchingSpendable, setFetchingSpendable] = useState(false);
   const [spendable, setSpendable] = useState<BigNumber | null>(null);
   const [validAmount, setValidAmount] = useState(true);
+
+  const [summaryComplete, setSummaryComplete] = useState(false);
 
   const { darkMode } = useConnections();
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
@@ -132,6 +138,13 @@ export const Send: React.FC = () => {
   }, [updateCache]);
 
   /**
+   * Control summary complete flag.
+   */
+  useEffect(() => {
+    setSummaryComplete(false);
+  }, [sender, receiver, sendAmount]);
+
+  /**
    * Progress bar controller.
    */
   useEffect(() => {
@@ -168,6 +181,8 @@ export const Send: React.FC = () => {
     if (!(senderNetwork && sender && receiver)) {
       return;
     }
+
+    setSummaryComplete(true);
 
     // Data for action meta.
     const senderObj = getSenderAccounts().find(
@@ -353,7 +368,8 @@ export const Send: React.FC = () => {
     receiver === null ||
     sendAmount === '0' ||
     sendAmount === '' ||
-    !validAmount;
+    !validAmount ||
+    summaryComplete;
 
   /**
    * Handle clicking a green next step arrow.
@@ -592,7 +608,7 @@ export const Send: React.FC = () => {
           {/** Summary Section */}
           <Accordion.Item className="AccordionItem" value="section-summary">
             <UI.AccordionTrigger narrow={true}>
-              <TriggerContent label="Summary" complete={false} />
+              <TriggerContent label="Summary" complete={summaryComplete} />
             </UI.AccordionTrigger>
             <UI.AccordionContent narrow={true}>
               <FlexColumn>
@@ -663,10 +679,10 @@ export const Send: React.FC = () => {
                     disabled={proceedDisabled()}
                   >
                     <FontAwesomeIcon
-                      icon={faChevronRight}
+                      icon={summaryComplete ? faCheck : faChevronRight}
                       transform={'shrink-4'}
                     />
-                    <span>Proceed</span>
+                    <span>{summaryComplete ? 'Completed' : 'Proceed'}</span>
                   </ActionButton>
                 </FlexRow>
               </FlexColumn>

--- a/packages/renderer/src/utils/AccountUtils.ts
+++ b/packages/renderer/src/utils/AccountUtils.ts
@@ -1,6 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import * as ApiUtils from '@ren/utils/ApiUtils';
 import { AccountsController } from '@ren/controller/AccountsController';
 import BigNumber from 'bignumber.js';
 import {
@@ -24,7 +25,21 @@ import type { AnyData, AnyJson } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { Account } from '@ren/model/Account';
 import type { ApiPromise } from '@polkadot/api';
-import * as ApiUtils from '@ren/utils/ApiUtils';
+
+/**
+ * @name generateUID
+ * @summary Util for generating a UID in the browser.
+ */
+export const generateUID = (): string => {
+  // Generate a random 16-byte array.
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+
+  // Convert to a hexadecimal string.
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join(
+    ''
+  );
+};
 
 /**
  * @name fetchAccountBalances

--- a/packages/types/src/tx.ts
+++ b/packages/types/src/tx.ts
@@ -16,7 +16,8 @@ export type TxStatus =
 
 export type TxActionUid =
   | 'nominationPools_pendingRewards_bond'
-  | 'nominationPools_pendingRewards_withdraw';
+  | 'nominationPools_pendingRewards_withdraw'
+  | 'balances_transferKeepAlive';
 
 export interface ActionMeta {
   // Name of account sending tx.


### PR DESCRIPTION
Fetches a sender account's current spendable balance and improves the send screen UX.

Upon clicking `Proceed`, a new extrinsic item is added to the Extrinsics window for signing.