### PR TITLE
feat: verify extrinsics before signing

### DIFF
--- a/packages/renderer/src/renderer/contexts/action/TxMeta/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/defaults.ts
@@ -16,6 +16,7 @@ export const defaultTxMeta: TxMetaContextInterface = {
   initTx: () => {},
   initTxDynamicInfo: () => {},
   onFilterChange: () => {},
+  notifyInvalidExtrinsic: () => {},
   setEstimatedFee: () => new Promise(() => {}),
   setTxDynamicInfo: () => {},
   setTxSignature: () => {},

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -275,6 +275,15 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   /**
+   * Render an error notification if an extrinsic is not valid for submission.
+   */
+  const notifyInvalidExtrinsic = (message: string) => {
+    window.myAPI.relayModeFlag('isBuildingExtrinsic', false);
+    const text = `Invalid extrinsic - ${message}`;
+    renderToast(text, `invalid-extrinsic-${String(Date.now())}`, 'error');
+  };
+
+  /**
    * Send a completed and signed extrinsic to main renderer for submission.
    */
   const submitTx = (txId: string) => {
@@ -566,6 +575,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         initTx,
         initTxDynamicInfo,
         onFilterChange,
+        notifyInvalidExtrinsic,
         setEstimatedFee,
         setTxDynamicInfo,
         setTxSignature,

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -228,6 +228,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
 
   /**
    * Requests an extrinsic's dynamic data. Call before submitting an extrinsic.
+   * Confirms the extrinsic is valid and can be submitted, by checking sufficient balances, etc.
    */
   const initTxDynamicInfo = (txId: string) => {
     try {

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/types.ts
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/types.ts
@@ -22,6 +22,7 @@ export interface TxMetaContextInterface {
   initTx: (actionMeta: ActionMeta) => void;
   initTxDynamicInfo: (txId: string) => void;
   onFilterChange: (val: string) => void;
+  notifyInvalidExtrinsic: (message: string) => void;
   setEstimatedFee: (txId: string, estimatedFee: string) => Promise<void>;
   setTxDynamicInfo: (txId: string, dynamicInfo: ExtrinsicDynamicInfo) => void;
   setTxSignature: (txId: string, s: AnyJson) => void;

--- a/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
@@ -14,6 +14,7 @@ export const useActionMessagePorts = () => {
    */
   const {
     initTx,
+    notifyInvalidExtrinsic,
     setEstimatedFee,
     setTxDynamicInfo,
     updateAccountName,
@@ -84,6 +85,15 @@ export const useActionMessagePorts = () => {
   };
 
   /**
+   * @name handleInvalidExtrinsic
+   * @summary Render an error message if an extrinsic is invalid.
+   */
+  const handleInvalidExtrinsic = (ev: MessageEvent) => {
+    const { message }: { message: string } = ev.data.data;
+    notifyInvalidExtrinsic(message);
+  };
+
+  /**
    * @name handleReceivedPort
    * @summary Handle messages sent to the action window..
    */
@@ -115,6 +125,10 @@ export const useActionMessagePorts = () => {
             }
             case 'action:tx:setEstimatedFee': {
               await handleSetEstimatedFee(ev);
+              break;
+            }
+            case 'action:tx:invalid': {
+              handleInvalidExtrinsic(ev);
               break;
             }
             default: {

--- a/packages/renderer/src/renderer/screens/Action/Helpers.tsx
+++ b/packages/renderer/src/renderer/screens/Action/Helpers.tsx
@@ -1,8 +1,9 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { chainCurrency } from '@ren/config/chains';
-import { ellipsisFn } from '@w3ux/utils';
+import BigNumber from 'bignumber.js';
+import { chainCurrency, chainUnits } from '@ren/config/chains';
+import { ellipsisFn, planckToUnit } from '@w3ux/utils';
 import {
   Identicon,
   TooltipRx,
@@ -77,16 +78,18 @@ export const EstimatedFeeBadge = ({
   info: ExtrinsicInfo;
   theme: AnyData;
 }) => {
-  const { chainId } = info.actionMeta;
-  const currency = chainCurrency(chainId);
+  let estimatedFee = '-';
+  let truncEstimatedFee = '-';
 
-  const estimatedFee = info.estimatedFee
-    ? `${info.estimatedFee} ${currency}`
-    : '-';
+  if (info.estimatedFee) {
+    const { chainId } = info.actionMeta;
+    const currency = chainCurrency(chainId);
+    const bnPlanck = new BigNumber(info.estimatedFee);
+    const bnUnit = planckToUnit(bnPlanck, chainUnits(chainId));
 
-  const truncEstimatedFee = info.estimatedFee
-    ? `${truncateDecimalPlaces(info.estimatedFee)} ${currency}`
-    : '-';
+    estimatedFee = `${bnUnit.toString()} ${currency}`;
+    truncEstimatedFee = `${truncateDecimalPlaces(bnUnit.toString())} ${currency}`;
+  }
 
   return (
     <TxInfoBadge icon={faCoins} label={'Estimated Fee'}>

--- a/packages/renderer/src/utils/AccountUtils.ts
+++ b/packages/renderer/src/utils/AccountUtils.ts
@@ -209,6 +209,23 @@ export const fetchNominationPoolDataForAccount = async (account: Account) => {
 };
 
 /**
+ * @name getNominationPoolRewards
+ * @summary Get nomination pool rewards for an arbitrary address.
+ */
+export const getNominationPoolRewards = async (
+  address: string,
+  chainId: ChainID
+) => {
+  const origin = 'getNominationPoolRewards';
+  const { api } = await ApiUtils.getApiInstanceOrThrow(chainId, origin);
+
+  const result: AnyJson =
+    await api.call.nominationPoolsApi.pendingRewards(address);
+
+  return new BigNumber(rmCommas(String(result)));
+};
+
+/**
  * @name setNominationPoolDataForAccount
  * @summary Utility that uses an API instance to get and update an account's nomination
  * pool data.

--- a/packages/renderer/src/utils/AccountUtils.ts
+++ b/packages/renderer/src/utils/AccountUtils.ts
@@ -125,7 +125,7 @@ export const getExistentialDeposit = async (
 export const getSpendableBalance = async (
   address: string,
   chainId: ChainID
-): Promise<BigNumber | null> => {
+): Promise<BigNumber> => {
   const balance = await getBalanceForAccount(address, chainId);
 
   // Spendable balance equation:


### PR DESCRIPTION
## Extrinsics Window

Verifies an extrinsic is still valid when the sign button is clicked.

A error will be shown as a toast notification if an extrinsic is not longer valid. An extrinsic won't be valid if an account has insufficient balance, or if an account's nomination pool rewards have since changed.