### PR TITLE
chore: move wallet connect context

### DIFF
--- a/packages/main/src/config/main.ts
+++ b/packages/main/src/config/main.ts
@@ -3,7 +3,11 @@
 
 import { MessageChannelMain } from 'electron';
 import type { AccountSource } from '@polkadot-live/types/accounts';
-import type { PortPair, PortPairID } from '@polkadot-live/types/communication';
+import type {
+  PortPair,
+  PortPairID,
+  WcSyncFlags,
+} from '@polkadot-live/types/communication';
 import type { Rectangle, Tray } from 'electron';
 
 export class Config {
@@ -41,6 +45,11 @@ export class Config {
   private static _importingData = false;
   private static _onlineMode = false;
   private static _isBuildingExtrinsic = false;
+  private static _wcSyncFlags: WcSyncFlags = {
+    wcConnecting: false,
+    wcDisconnecting: false,
+    wcInitialized: false,
+  };
 
   // Return the local storage key for corresponding source addresses.
   static getStorageKey(source: AccountSource): string {
@@ -194,6 +203,14 @@ export class Config {
 
   static set isBuildingExtrinsic(flag: boolean) {
     Config._isBuildingExtrinsic = flag;
+  }
+
+  static get wcSyncFlags(): WcSyncFlags {
+    return Config._wcSyncFlags;
+  }
+
+  static set wcSyncFlags(flags: WcSyncFlags) {
+    Config._wcSyncFlags = flags;
   }
 
   // Setter for app's tray object.

--- a/packages/main/src/config/main.ts
+++ b/packages/main/src/config/main.ts
@@ -49,6 +49,7 @@ export class Config {
     wcConnecting: false,
     wcDisconnecting: false,
     wcInitialized: false,
+    wcSessionRestored: false,
   };
 
   // Return the local storage key for corresponding source addresses.

--- a/packages/main/src/config/main.ts
+++ b/packages/main/src/config/main.ts
@@ -3,11 +3,8 @@
 
 import { MessageChannelMain } from 'electron';
 import type { AccountSource } from '@polkadot-live/types/accounts';
-import type {
-  PortPair,
-  PortPairID,
-  WcSyncFlags,
-} from '@polkadot-live/types/communication';
+import type { PortPair, PortPairID } from '@polkadot-live/types/communication';
+import type { WcSyncFlags } from '@polkadot-live/types/walletConnect';
 import type { Rectangle, Tray } from 'electron';
 
 export class Config {

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -412,6 +412,12 @@ app.whenReady().then(async () => {
         WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
+      case 'wc:session:restored': {
+        const pv = { ...ConfigMain.wcSyncFlags };
+        ConfigMain.wcSyncFlags = { ...pv, wcSessionRestored: flag };
+        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
+        break;
+      }
       default: {
         break;
       }
@@ -440,6 +446,9 @@ app.whenReady().then(async () => {
       }
       case 'wc:initialized': {
         return ConfigMain.wcSyncFlags.wcInitialized;
+      }
+      case 'wc:session:restored': {
+        return ConfigMain.wcSyncFlags.wcSessionRestored;
       }
       default: {
         return false;

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -394,9 +394,21 @@ app.whenReady().then(async () => {
         WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
-      case 'wc:connecting':
-      case 'wc:disconnecting':
+      case 'wc:connecting': {
+        const pv = { ...ConfigMain.wcSyncFlags };
+        ConfigMain.wcSyncFlags = { ...pv, wcConnecting: flag };
+        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
+        break;
+      }
+      case 'wc:disconnecting': {
+        const pv = { ...ConfigMain.wcSyncFlags };
+        ConfigMain.wcSyncFlags = { ...pv, wcDisconnecting: flag };
+        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
+        break;
+      }
       case 'wc:initialized': {
+        const pv = { ...ConfigMain.wcSyncFlags };
+        ConfigMain.wcSyncFlags = { ...pv, wcInitialized: flag };
         WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
@@ -419,6 +431,15 @@ app.whenReady().then(async () => {
       }
       case 'isBuildingExtrinsic': {
         return ConfigMain.isBuildingExtrinsic;
+      }
+      case 'wc:connecting': {
+        return ConfigMain.wcSyncFlags.wcConnecting;
+      }
+      case 'wc:disconnecting': {
+        return ConfigMain.wcSyncFlags.wcDisconnecting;
+      }
+      case 'wc:initialized': {
+        return ConfigMain.wcSyncFlags.wcInitialized;
       }
       default: {
         return false;

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -370,58 +370,50 @@ app.whenReady().then(async () => {
         WindowsController.setWindowsBackgroundColor(
           appDarkMode ? ConfigMain.themeColorDark : ConfigMain.themeColorLight
         );
-
-        // Relay to renderers.
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'isConnected': {
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'isImporting': {
         ConfigMain.importingData = flag;
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'isOnlineMode': {
         ConfigMain.onlineMode = flag;
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'isBuildingExtrinsic': {
         ConfigMain.isBuildingExtrinsic = flag;
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'wc:connecting': {
         const pv = { ...ConfigMain.wcSyncFlags };
         ConfigMain.wcSyncFlags = { ...pv, wcConnecting: flag };
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'wc:disconnecting': {
         const pv = { ...ConfigMain.wcSyncFlags };
         ConfigMain.wcSyncFlags = { ...pv, wcDisconnecting: flag };
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'wc:initialized': {
         const pv = { ...ConfigMain.wcSyncFlags };
         ConfigMain.wcSyncFlags = { ...pv, wcInitialized: flag };
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       case 'wc:session:restored': {
         const pv = { ...ConfigMain.wcSyncFlags };
         ConfigMain.wcSyncFlags = { ...pv, wcSessionRestored: flag };
-        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
       default: {
         break;
       }
     }
+
+    // Relay to renderers.
+    WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
   });
 
   ipcMain.handle('app:modeFlag:get', async (_, syncId: SyncFlag) => {

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -394,6 +394,12 @@ app.whenReady().then(async () => {
         WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
         break;
       }
+      case 'wc:connecting':
+      case 'wc:disconnecting':
+      case 'wc:initialized': {
+        WindowsController.relayIpc('renderer:modeFlag:set', { syncId, flag });
+        break;
+      }
       default: {
         break;
       }

--- a/packages/renderer/src/config/walletConnect.ts
+++ b/packages/renderer/src/config/walletConnect.ts
@@ -1,0 +1,34 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { chainIcon } from '@ren/config/chains';
+import type { WcSelectNetwork } from '@polkadot-live/types/walletConnect';
+
+export const WC_PROJECT_ID = 'ebded8e9ff244ba8b6d173b6c2885d87';
+export const WC_RELAY_URL = 'wss://relay.walletconnect.com';
+
+// CAIPs
+export const WC_POLKADOT_CAIP_ID = '91b171bb158e2d3848fa23a9f1c25182';
+export const WC_KUSAMA_CAIP_ID = 'b0a8d493285c2df73290dfb7e61f870f';
+export const WC_WESTEND_CAIP_ID = 'e143f23803ac50e8f6f8e62695d1ce9e';
+
+export const WcNetworks: WcSelectNetwork[] = [
+  {
+    caipId: WC_POLKADOT_CAIP_ID,
+    ChainIcon: chainIcon('Polkadot'),
+    chainId: 'Polkadot',
+    selected: false,
+  },
+  {
+    caipId: WC_KUSAMA_CAIP_ID,
+    ChainIcon: chainIcon('Kusama'),
+    chainId: 'Kusama',
+    selected: false,
+  },
+  {
+    caipId: WC_WESTEND_CAIP_ID,
+    ChainIcon: chainIcon('Westend'),
+    chainId: 'Westend',
+    selected: false,
+  },
+];

--- a/packages/renderer/src/renderer/Providers.tsx
+++ b/packages/renderer/src/renderer/Providers.tsx
@@ -25,6 +25,7 @@ import { IntervalSubscriptionsProvider } from '@app/contexts/main/IntervalSubscr
 import { IntervalTasksManagerProvider } from '@app/contexts/main/IntervalTasksManager';
 import { DataBackupProvider } from '@app/contexts/main/DataBackup';
 import { CogMenuProvider } from './contexts/main/CogMenu';
+import { WalletConnectProvider as MainWalletConnectProvider } from '@app/contexts/main/WalletConnect';
 
 // Import window contexts.
 import { AccountStatusesProvider as ImportAccountStatusesProvider } from '@app/contexts/import/AccountStatuses';
@@ -34,7 +35,7 @@ import { AddHandlerProvider } from '@app/contexts/import/AddHandler';
 import { RemoveHandlerProvider } from '@app/contexts/import/RemoveHandler';
 import { DeleteHandlerProvider } from '@app/contexts/import/DeleteHandler';
 import { LedgerHardwareProvider } from '@app/contexts/import/LedgerHardware';
-import { WalletConnectProvider } from './contexts/import/WalletConnect';
+import { WalletConnectProvider } from '@app/contexts/import/WalletConnect';
 
 // Settings window contexts.
 import { SettingFlagsProvider } from '@app/contexts/settings/SettingFlags';
@@ -84,7 +85,8 @@ const getProvidersForWindow = () => {
         // Requires setting state from other contexts.
         DataBackupProvider,
         // Requires useBootstrapping and useHelp.
-        CogMenuProvider
+        CogMenuProvider,
+        MainWalletConnectProvider
       )(Theme);
     }
     case 'import': {

--- a/packages/renderer/src/renderer/Providers.tsx
+++ b/packages/renderer/src/renderer/Providers.tsx
@@ -35,7 +35,7 @@ import { AddHandlerProvider } from '@app/contexts/import/AddHandler';
 import { RemoveHandlerProvider } from '@app/contexts/import/RemoveHandler';
 import { DeleteHandlerProvider } from '@app/contexts/import/DeleteHandler';
 import { LedgerHardwareProvider } from '@app/contexts/import/LedgerHardware';
-import { WalletConnectProvider } from '@app/contexts/import/WalletConnect';
+import { WalletConnectImportProvider } from '@app/contexts/import/WalletConnect';
 
 // Settings window contexts.
 import { SettingFlagsProvider } from '@app/contexts/settings/SettingFlags';
@@ -108,7 +108,7 @@ const getProvidersForWindow = () => {
         // Requires useConnections
         LedgerHardwareProvider,
         // Requires useConnections
-        WalletConnectProvider
+        WalletConnectImportProvider
       )(Theme);
     }
     case 'settings': {

--- a/packages/renderer/src/renderer/contexts/common/Connections/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/common/Connections/defaults.ts
@@ -10,6 +10,11 @@ export const defaultConnectionsContext: ConnectionsContextInterface = {
   isOnlineMode: false,
   darkMode: true,
   isBuildingExtrinsic: false,
+  wcSyncFlags: {
+    wcConnecting: false,
+    wcDisconnecting: false,
+    wcInitialized: false,
+  },
   setIsConnected: (b) => {},
   setIsImporting: (b) => {},
   setIsOnlineMode: (b) => {},

--- a/packages/renderer/src/renderer/contexts/common/Connections/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/common/Connections/defaults.ts
@@ -14,6 +14,7 @@ export const defaultConnectionsContext: ConnectionsContextInterface = {
     wcConnecting: false,
     wcDisconnecting: false,
     wcInitialized: false,
+    wcSessionRestored: false,
   },
   setIsConnected: (b) => {},
   setIsImporting: (b) => {},

--- a/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
+++ b/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
@@ -5,7 +5,7 @@ import * as defaults from './defaults';
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ConnectionsContextInterface } from './types';
 import type { IpcRendererEvent } from 'electron';
-import type { SyncFlag } from '@polkadot-live/types/communication';
+import type { SyncFlag, WcSyncFlags } from '@polkadot-live/types/communication';
 
 /**
  * Automatically listens for and sets mode flag state when they are
@@ -40,6 +40,13 @@ export const ConnectionsProvider = ({
 
   // Flag set to `true` when an extrinsic is getting built.
   const [isBuildingExtrinsic, setIsBuildingExtrinsic] = useState(false);
+
+  // WalletConnect flags.
+  const [wcSyncFlags, setWcSyncFlags] = useState<WcSyncFlags>({
+    wcConnecting: false,
+    wcDisconnecting: false,
+    wcInitialized: false,
+  });
 
   useEffect(() => {
     // Synchronize flags in store.
@@ -80,6 +87,18 @@ export const ConnectionsProvider = ({
             setIsBuildingExtrinsic(flag);
             break;
           }
+          case 'wc:connecting': {
+            setWcSyncFlags((pv) => ({ ...pv, wcConnecting: flag }));
+            break;
+          }
+          case 'wc:disconnecting': {
+            setWcSyncFlags((pv) => ({ ...pv, wcDisconnecting: flag }));
+            break;
+          }
+          case 'wc:initialized': {
+            setWcSyncFlags((pv) => ({ ...pv, wcInitialized: flag }));
+            break;
+          }
           default: {
             break;
           }
@@ -103,6 +122,7 @@ export const ConnectionsProvider = ({
         isImporting,
         isOnlineMode,
         isBuildingExtrinsic,
+        wcSyncFlags,
         getOnlineMode,
         setDarkMode,
         setIsConnected,

--- a/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
+++ b/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
@@ -46,6 +46,7 @@ export const ConnectionsProvider = ({
     wcConnecting: false,
     wcDisconnecting: false,
     wcInitialized: false,
+    wcSessionRestored: false,
   });
 
   useEffect(() => {
@@ -65,12 +66,14 @@ export const ConnectionsProvider = ({
         window.myAPI.getModeFlag('wc:connecting'),
         window.myAPI.getModeFlag('wc:disconnecting'),
         window.myAPI.getModeFlag('wc:initialized'),
+        window.myAPI.getModeFlag('wc:session:restored'),
       ]);
 
       setWcSyncFlags({
         wcConnecting: results[0],
         wcDisconnecting: results[1],
         wcInitialized: results[2],
+        wcSessionRestored: results[3],
       });
     };
 
@@ -111,6 +114,10 @@ export const ConnectionsProvider = ({
           }
           case 'wc:initialized': {
             setWcSyncFlags((pv) => ({ ...pv, wcInitialized: flag }));
+            break;
+          }
+          case 'wc:session:restored': {
+            setWcSyncFlags((pv) => ({ ...pv, wcSessionRestored: flag }));
             break;
           }
           default: {

--- a/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
+++ b/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
@@ -55,9 +55,23 @@ export const ConnectionsProvider = ({
       setIsOnlineMode(await window.myAPI.getModeFlag('isOnlineMode'));
       setIsImporting(await window.myAPI.getModeFlag('isImporting'));
       setDarkMode((await window.myAPI.getAppSettings()).appDarkMode);
+
       setIsBuildingExtrinsic(
         await window.myAPI.getModeFlag('isBuildingExtrinsic')
       );
+
+      // Get WalletConnect flags asynchronously.
+      const results = await Promise.all([
+        window.myAPI.getModeFlag('wc:connecting'),
+        window.myAPI.getModeFlag('wc:disconnecting'),
+        window.myAPI.getModeFlag('wc:initialized'),
+      ]);
+
+      setWcSyncFlags({
+        wcConnecting: results[0],
+        wcDisconnecting: results[1],
+        wcInitialized: results[2],
+      });
     };
 
     // Listen for synching events.

--- a/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
+++ b/packages/renderer/src/renderer/contexts/common/Connections/index.tsx
@@ -5,7 +5,8 @@ import * as defaults from './defaults';
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ConnectionsContextInterface } from './types';
 import type { IpcRendererEvent } from 'electron';
-import type { SyncFlag, WcSyncFlags } from '@polkadot-live/types/communication';
+import type { SyncFlag } from '@polkadot-live/types/communication';
+import type { WcSyncFlags } from '@polkadot-live/types/walletConnect';
 
 /**
  * Automatically listens for and sets mode flag state when they are

--- a/packages/renderer/src/renderer/contexts/common/Connections/types.ts
+++ b/packages/renderer/src/renderer/contexts/common/Connections/types.ts
@@ -1,7 +1,7 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { WcSyncFlags } from '@polkadot-live/types/communication';
+import type { WcSyncFlags } from '@polkadot-live/types/walletConnect';
 
 export interface ConnectionsContextInterface {
   isConnected: boolean;

--- a/packages/renderer/src/renderer/contexts/common/Connections/types.ts
+++ b/packages/renderer/src/renderer/contexts/common/Connections/types.ts
@@ -1,12 +1,15 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import type { WcSyncFlags } from '@polkadot-live/types/communication';
+
 export interface ConnectionsContextInterface {
   isConnected: boolean;
   isImporting: boolean;
   isOnlineMode: boolean;
   darkMode: boolean;
   isBuildingExtrinsic: boolean;
+  wcSyncFlags: WcSyncFlags;
   setIsConnected: React.Dispatch<React.SetStateAction<boolean>>;
   setIsImporting: React.Dispatch<React.SetStateAction<boolean>>;
   setIsOnlineMode: React.Dispatch<React.SetStateAction<boolean>>;

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/defaults.ts
@@ -2,18 +2,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
 
-import type { WalletConnectContextInterface } from './types';
+import type { WalletConnectImportContextInterface } from './types';
 
-export const defaultWalletConnectContext: WalletConnectContextInterface = {
-  wcConnecting: false,
-  wcDisconnecting: false,
-  wcFetchedAddresses: [],
-  wcInitialized: false,
-  wcNetworks: [],
-  wcSessionRestored: false,
-  connectWc: () => new Promise(() => {}),
-  disconnectWcSession: () => new Promise(() => {}),
-  fetchAddressesFromExistingSession: () => {},
-  setWcFetchedAddresses: () => {},
-  setWcNetworks: () => {},
-};
+export const defaultWalletConnectImportContext: WalletConnectImportContextInterface =
+  {
+    wcFetchedAddresses: [],
+    wcNetworks: [],
+    handleConnect: () => new Promise(() => {}),
+    handleDisconnect: () => new Promise(() => {}),
+    handleFetch: () => {},
+    setWcFetchedAddresses: () => {},
+    setWcNetworks: () => {},
+  };

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/defaults.ts
@@ -6,11 +6,14 @@ import type { WalletConnectImportContextInterface } from './types';
 
 export const defaultWalletConnectImportContext: WalletConnectImportContextInterface =
   {
+    isImporting: false,
     wcFetchedAddresses: [],
     wcNetworks: [],
+    getSelectedAddresses: () => [],
     handleConnect: () => new Promise(() => {}),
     handleDisconnect: () => new Promise(() => {}),
     handleFetch: () => {},
     setWcFetchedAddresses: () => {},
+    handleImportProcess: () => new Promise(() => {}),
     setWcNetworks: () => {},
   };

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
+import * as wcConfig from '@ren/config/walletConnect';
+
 import { Config as ConfigImport } from '@ren/config/processes/import';
-import { chainIcon } from '@ren/config/chains';
 import { createContext, useContext, useState } from 'react';
 import { ellipsisFn } from '@w3ux/utils';
 import type { WalletConnectImportContextInterface } from './types';
@@ -14,11 +15,6 @@ import type {
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useAddresses } from '@app/contexts/import/Addresses';
 import { useImportHandler } from '@app/contexts/import/ImportHandler';
-
-// TODO: Move constants and network array to config file.
-const WC_POLKADOT_CAIP_ID = '91b171bb158e2d3848fa23a9f1c25182';
-const WC_KUSAMA_CAIP_ID = 'b0a8d493285c2df73290dfb7e61f870f';
-const WC_WESTEND_CAIP_ID = 'e143f23803ac50e8f6f8e62695d1ce9e';
 
 export const WalletConnectImportContext =
   createContext<WalletConnectImportContextInterface>(
@@ -42,26 +38,9 @@ export const WalletConnectImportProvider = ({
   /**
    * WalletConnect networks and their selected state.
    */
-  const [wcNetworks, setWcNetworks] = useState<WcSelectNetwork[]>([
-    {
-      caipId: WC_POLKADOT_CAIP_ID,
-      ChainIcon: chainIcon('Polkadot'),
-      chainId: 'Polkadot',
-      selected: false,
-    },
-    {
-      caipId: WC_KUSAMA_CAIP_ID,
-      ChainIcon: chainIcon('Kusama'),
-      chainId: 'Kusama',
-      selected: false,
-    },
-    {
-      caipId: WC_WESTEND_CAIP_ID,
-      ChainIcon: chainIcon('Westend'),
-      chainId: 'Westend',
-      selected: false,
-    },
-  ]);
+  const [wcNetworks, setWcNetworks] = useState<WcSelectNetwork[]>(
+    wcConfig.WcNetworks
+  );
 
   /**
    * Fetched addresses with WalletConnect.

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
@@ -2,79 +2,35 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
-import UniversalProvider from '@walletconnect/universal-provider';
-import { WalletConnectModal } from '@walletconnect/modal';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
-import { useConnections } from '@app/contexts/common/Connections';
+import { Config as ConfigImport } from '@ren/config/processes/import';
 import { chainIcon } from '@ren/config/chains';
-import { getSdkError } from '@walletconnect/utils';
-import { encodeAddress } from '@polkadot/util-crypto';
-import { getUnixTime } from 'date-fns';
-import { setStateWithRef } from '@w3ux/utils';
-import type { AnyData } from '@polkadot-live/types/misc';
-import type { ChainID } from '@polkadot-live/types/chains';
+import { createContext, useContext, useState } from 'react';
 import type {
-  WalletConnectContextInterface,
+  WalletConnectImportContextInterface,
   WcFetchedAddress,
   WcSelectNetwork,
 } from './types';
 
-const WC_PROJECT_ID = 'ebded8e9ff244ba8b6d173b6c2885d87';
-const WC_RELAY_URL = 'wss://relay.walletconnect.com';
-
+// TODO: Move constants and network array to config file.
 const WC_POLKADOT_CAIP_ID = '91b171bb158e2d3848fa23a9f1c25182';
 const WC_KUSAMA_CAIP_ID = 'b0a8d493285c2df73290dfb7e61f870f';
 const WC_WESTEND_CAIP_ID = 'e143f23803ac50e8f6f8e62695d1ce9e';
 
-/**
- * @todo Keep in import window
- */
-const mapCaipChainId = new Map<string, ChainID>([
-  [WC_POLKADOT_CAIP_ID, 'Polkadot'],
-  [WC_KUSAMA_CAIP_ID, 'Kusama'],
-  [WC_WESTEND_CAIP_ID, 'Westend'],
-]);
-
-export const WalletConnectContext =
-  createContext<WalletConnectContextInterface>(
-    defaults.defaultWalletConnectContext
+export const WalletConnectImportContext =
+  createContext<WalletConnectImportContextInterface>(
+    defaults.defaultWalletConnectImportContext
   );
 
-export const useWalletConnect = () => useContext(WalletConnectContext);
+export const useWalletConnectImport = () =>
+  useContext(WalletConnectImportContext);
 
-export const WalletConnectProvider = ({
+export const WalletConnectImportProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const { getOnlineMode, isConnected, isOnlineMode } = useConnections();
-
-  /**
-   * @todo Make flags relay app flags
-   */
-  const [wcConnecting, setWcConnecting] = useState(false);
-  const [wcDisconnecting, setWcDisconnecting] = useState(false);
-  const [wcInitialized, setWcInitialized] = useState(false);
-
-  const [wcSessionRestored, setWcSessionRestored] = useState(false);
-  const wcSessionRestoredRef = useRef<boolean>(false);
-
-  /**
-   * @todo Move to main renderer
-   */
-  const wcProvider = useRef<UniversalProvider | null>(null);
-  const wcModal = useRef<WalletConnectModal | null>(null);
-  const wcPairingTopic = useRef<string | null>(null);
-
-  const wcMetaRef = useRef<{
-    uri: string | undefined;
-    approval: AnyData;
-  } | null>(null);
-
   /**
    * WalletConnect networks and their selected state.
-   *
-   * @todo Move to main renderer
    */
   const [wcNetworks, setWcNetworks] = useState<WcSelectNetwork[]>([
     {
@@ -99,355 +55,58 @@ export const WalletConnectProvider = ({
 
   /**
    * Fetched addresses with WalletConnect.
-   *
-   * @todo Keep in import renderer
    */
   const [wcFetchedAddresses, setWcFetchedAddresses] = useState<
     WcFetchedAddress[]
   >([]);
 
   /**
-   * Get namespaces of selected networks.
-   *
-   * @todo Move wcNetworks to main renderer
-   * @todo Send selected network ChainIDs to main renderer
+   * Handle connect button click.
    */
-  const getNamespaces = () => {
-    const selectedNetworks = wcNetworks.filter(({ selected }) => selected);
-    if (selectedNetworks.length > 0) {
-      return wcNetworks
-        .filter(({ selected }) => selected)
-        .map(({ caipId }) => `polkadot:${caipId}`);
-    } else {
-      return [
-        `polkadot:${WC_POLKADOT_CAIP_ID}`,
-        `polkadot:${WC_KUSAMA_CAIP_ID}`,
-      ];
-    }
-  };
-
-  /**
-   * Util for getting a chain ID's address prefix for encoding.
-   *
-   * @todo Keep in import window
-   */
-  const getAddressPrefix = (chainId: ChainID) => {
-    switch (chainId) {
-      case 'Polkadot': {
-        return 0;
-      }
-      case 'Kusama': {
-        return 2;
-      }
-      case 'Westend': {
-        return 42;
-      }
-    }
-  };
-
-  /**
-   * Util for setting fetched addresses state.
-   *
-   * @todo Send fetched addresses to import window via port message
-   */
-  const setFetchedAddresses = (namespaces: AnyData) => {
-    /** Get the accounts from the session. */
-    const wcAccounts = Object.values(namespaces)
-      .map((namespace: AnyData) => namespace.accounts)
-      .flat();
-
-    /** Grab account addresses and their CAIP ID. */
-    const accounts: { address: string; caipId: string }[] = wcAccounts.map(
-      (wcAccount) => ({
-        address: wcAccount.split(':')[2],
-        caipId: wcAccount.split(':')[1],
-      })
+  const handleConnect = async () => {
+    const selectedNetworks = wcNetworks.filter(
+      ({ selected }) => selected === true
     );
 
-    setWcFetchedAddresses(() =>
-      accounts.map(({ address, caipId }) => {
-        const chainId = mapCaipChainId.get(caipId)!;
-        const pref = getAddressPrefix(chainId);
-
-        return {
-          chainId,
-          encoded: encodeAddress(address, pref),
-          substrate: address,
-          selected: false,
-        };
-      })
-    );
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:wc:connect',
+      data: { networks: JSON.stringify(selectedNetworks) },
+    });
   };
 
   /**
-   * Init provider and modal.
-   *
-   * @todo Move to main renderer
+   * Handle disconnect button click.
    */
-  const initProvider = async () => {
-    if (!wcProvider.current) {
-      // Instantiate provider.
-      const provider = await UniversalProvider.init({
-        projectId: WC_PROJECT_ID,
-        relayUrl: WC_RELAY_URL,
-        // TODO: metadata
-      });
-
-      // Listen for WalletConnect events
-      // 'session_create', 'session_delete', 'session_update', 'connect', 'disconnect'
-      provider.on('session_delete', async (session: AnyData) => {
-        console.log('Session deleted:', session);
-        await disconnectWcSession();
-      });
-
-      wcProvider.current = provider;
-    }
-
-    // Instantiate a standalone modal using the dapp's WalletConnect projectId.
-    if (!wcModal.current) {
-      const modal = new WalletConnectModal({
-        enableExplorer: false,
-        explorerRecommendedWalletIds: 'NONE',
-        explorerExcludedWalletIds: 'ALL',
-        projectId: WC_PROJECT_ID,
-      });
-
-      wcModal.current = modal;
-    }
-
-    console.log('> WalletConnect Initialized');
-    setWcInitialized(true);
+  const handleDisconnect = async () => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:wc:disconnect',
+      data: null,
+    });
   };
 
   /**
-   * Get connection params for WalletConnect session.
-   *
-   * Requires up to 3 different chain namespaces (polkadot, kusama and westend).
-   * The supported methods, chains, and events can all be defined by the dapp
-   * team based on the requirements of the dapp.
-   *
-   * @todo Move to main renderer
+   * Handle fetch button click.
    */
-  const getConnectionParams = () => ({
-    requiredNamespaces: {
-      polkadot: {
-        // Sign the relevant data (either an unsigned transaction or message) and return the signature.
-        methods: ['polkadot_signTransaction', 'polkadot_signMessage'],
-        chains: getNamespaces(),
-        events: ['chainChanged", "accountsChanged'],
-      },
-    },
-  });
-
-  /**
-   * Create or restore a WalletConnect session.
-   *
-   * @todo Move to main renderer
-   * @todo Send existing session flag to import window to sync UI
-   */
-  const createSession = async () => {
-    try {
-      if (!wcInitialized) {
-        return;
-      }
-
-      // If an existing session exists, cache the pairing topic.
-      const pairingTopic = wcProvider.current!.session?.pairingTopic;
-      wcPairingTopic.current = pairingTopic || null;
-      console.log('> Pairing topic:', pairingTopic);
-
-      // If no session exists, create a new one.
-      if (!wcProvider.current?.session) {
-        console.log('> No existing session found, creating a new one.');
-
-        const { uri, approval } = await wcProvider.current!.client.connect(
-          getConnectionParams()
-        );
-
-        wcMetaRef.current = { uri, approval };
-      } else {
-        setStateWithRef(true, setWcSessionRestored, wcSessionRestoredRef);
-      }
-    } catch (error: AnyData) {
-      console.error('initWc: An unexpected error occurred:', error);
-    }
+  const handleFetch = () => {
+    ConfigImport.portImport.postMessage({
+      task: 'renderer:wc:fetch',
+      data: null,
+    });
   };
-
-  /**
-   * Restore an existing session. Called when `Connect` UI button clicked.
-   * Note: Will prompt wallet to approve addresses.
-   *
-   * @todo Move to main renderer
-   */
-  const restoreOrConnectSession = async () => {
-    /** Create new session if there's no session to restore. */
-    if (!wcSessionRestoredRef.current) {
-      /** Re-connect to get a new uri and approval function */
-      console.log('> Re-create session uri and approval.');
-      await createSession();
-
-      /** Open modal. */
-      if (wcMetaRef.current?.uri) {
-        wcModal.current!.openModal({ uri: wcMetaRef.current.uri });
-      }
-
-      return true;
-    } else {
-      /** NOTE: This branch is currently not run based on the UI. */
-      const expiry = wcProvider.current!.session!.expiry;
-      const nowUnix = getUnixTime(new Date());
-
-      /** Existing session not expired. */
-      if (nowUnix <= expiry) {
-        console.log('> Restored session');
-
-        return false;
-      } else {
-        console.log('> Session expired. Creating a new one.');
-
-        /** Existing session expired. */
-        await disconnectWcSession();
-
-        /** Create a new session. */
-        await createSession();
-
-        /** Open modal. */
-        if (wcMetaRef.current?.uri) {
-          wcModal.current!.openModal({ uri: wcMetaRef.current.uri });
-        }
-
-        return true;
-      }
-    }
-  };
-
-  /**
-   * Set addresses from existing session. Called with `Fetch` UI button clicked.
-   *
-   * @todo Move to main renderer
-   */
-  const fetchAddressesFromExistingSession = () => {
-    /** Fetch accounts from restored session. */
-    const namespaces = wcProvider.current?.session?.namespaces;
-    if (!namespaces) {
-      console.log('> Unable to get namespaces of restored session.');
-      return;
-    }
-
-    /** Set received WalletConnect address state. */
-    setFetchedAddresses(namespaces);
-  };
-
-  /**
-   * Establish a session or use an existing session to fetch addresses.
-   *
-   * @todo Move to main renderer
-   * @todo Send fetched addresses to import window via port message
-   * @todo UI allows calling this function only when creating a new session. Can be simplified
-   */
-  const connectWc = async () => {
-    try {
-      if (!wcInitialized) {
-        return;
-      }
-
-      /** Restore existing session or create a new one. */
-      setWcConnecting(true);
-      const modalOpen = await restoreOrConnectSession();
-      setWcConnecting(false);
-
-      if (!modalOpen) {
-        /** Fetch accounts from restored session. */
-        fetchAddressesFromExistingSession();
-      } else {
-        /** Await session approval from the wallet app. */
-        const walletConnectSession = await wcMetaRef.current!.approval();
-
-        /** Close modal if we're creating a new session. */
-        console.log('> Close modal.');
-        if (wcMetaRef.current?.uri) {
-          wcModal.current!.closeModal();
-        }
-
-        /** Set received WalletConnect address state. */
-        setFetchedAddresses(walletConnectSession.namespaces);
-        setStateWithRef(true, setWcSessionRestored, wcSessionRestoredRef);
-      }
-    } catch (error: AnyData) {
-      console.error('initWc: An unexpected error occurred:', error);
-    }
-  };
-
-  /**
-   * Disconnect from the current session.
-   *
-   * @todo Move to main renderer
-   */
-  const disconnectWcSession = async () => {
-    if (!wcProvider.current) {
-      return;
-    }
-
-    setWcDisconnecting(true);
-    const topic = wcProvider.current.session?.topic;
-    if (topic) {
-      await wcProvider.current.client.disconnect({
-        topic,
-        reason: getSdkError('USER_DISCONNECTED'),
-      });
-
-      delete wcProvider.current.session;
-    }
-
-    wcPairingTopic.current = null;
-    wcMetaRef.current = null;
-    setStateWithRef(false, setWcSessionRestored, wcSessionRestoredRef);
-    setWcDisconnecting(false);
-  };
-
-  /**
-   * Initialize the WalletConnect provider on initial render.
-   *
-   * @todo Move to main renderer
-   */
-  useEffect(() => {
-    if (getOnlineMode() && !wcProvider.current) {
-      console.log('> Init wallet connect provider (Mount).');
-      initProvider();
-    }
-  }, []);
-
-  useEffect(() => {
-    if (getOnlineMode() && !wcProvider.current) {
-      console.log('> Init wallet connect provider (Online).');
-      initProvider();
-    }
-  }, [isConnected, isOnlineMode]);
-
-  useEffect(() => {
-    if (wcInitialized) {
-      console.log('> Create session if one does not already exist.');
-      createSession();
-    }
-  }, [wcInitialized]);
 
   return (
-    <WalletConnectContext.Provider
+    <WalletConnectImportContext.Provider
       value={{
-        connectWc,
-        disconnectWcSession,
-        fetchAddressesFromExistingSession,
-        setWcFetchedAddresses,
-        setWcNetworks,
-        wcConnecting,
-        wcDisconnecting,
         wcFetchedAddresses,
-        wcInitialized,
         wcNetworks,
-        wcSessionRestored,
+        handleConnect,
+        handleDisconnect,
+        handleFetch,
+        setWcNetworks,
+        setWcFetchedAddresses,
       }}
     >
       {children}
-    </WalletConnectContext.Provider>
+    </WalletConnectImportContext.Provider>
   );
 };

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
@@ -5,11 +5,11 @@ import * as defaults from './defaults';
 import { Config as ConfigImport } from '@ren/config/processes/import';
 import { chainIcon } from '@ren/config/chains';
 import { createContext, useContext, useState } from 'react';
+import type { WalletConnectImportContextInterface } from './types';
 import type {
-  WalletConnectImportContextInterface,
   WcFetchedAddress,
   WcSelectNetwork,
-} from './types';
+} from '@polkadot-live/types/walletConnect';
 
 // TODO: Move constants and network array to config file.
 const WC_POLKADOT_CAIP_ID = '91b171bb158e2d3848fa23a9f1c25182';

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/index.tsx
@@ -46,6 +46,9 @@ export const WalletConnectProvider = ({
 }) => {
   const { getOnlineMode, isConnected, isOnlineMode } = useConnections();
 
+  /**
+   * @todo Make flags relay app flags
+   */
   const [wcConnecting, setWcConnecting] = useState(false);
   const [wcDisconnecting, setWcDisconnecting] = useState(false);
   const [wcInitialized, setWcInitialized] = useState(false);
@@ -53,6 +56,9 @@ export const WalletConnectProvider = ({
   const [wcSessionRestored, setWcSessionRestored] = useState(false);
   const wcSessionRestoredRef = useRef<boolean>(false);
 
+  /**
+   * @todo Move to main renderer
+   */
   const wcProvider = useRef<UniversalProvider | null>(null);
   const wcModal = useRef<WalletConnectModal | null>(null);
   const wcPairingTopic = useRef<string | null>(null);
@@ -64,6 +70,8 @@ export const WalletConnectProvider = ({
 
   /**
    * WalletConnect networks and their selected state.
+   *
+   * @todo Move to main renderer
    */
   const [wcNetworks, setWcNetworks] = useState<WcSelectNetwork[]>([
     {
@@ -88,6 +96,8 @@ export const WalletConnectProvider = ({
 
   /**
    * Fetched addresses with WalletConnect.
+   *
+   * @todo Keep in import renderer
    */
   const [wcFetchedAddresses, setWcFetchedAddresses] = useState<
     WcFetchedAddress[]
@@ -95,6 +105,9 @@ export const WalletConnectProvider = ({
 
   /**
    * Get namespaces of selected networks.
+   *
+   * @todo Move wcNetworks to main renderer
+   * @todo Send selected network ChainIDs to main renderer
    */
   const getNamespaces = () => {
     const selectedNetworks = wcNetworks.filter(({ selected }) => selected);
@@ -112,6 +125,8 @@ export const WalletConnectProvider = ({
 
   /**
    * Util for getting a chain ID's address prefix for encoding.
+   *
+   * @todo Move to main renderer
    */
   const getAddressPrefix = (chainId: ChainID) => {
     switch (chainId) {
@@ -129,6 +144,9 @@ export const WalletConnectProvider = ({
 
   /**
    * Util for setting fetched addresses state.
+   *
+   * @todo Move to main renderer
+   * @todo Send fetched addresses to import window via port message
    */
   const setFetchedAddresses = (namespaces: AnyData) => {
     /** Get the accounts from the session. */
@@ -161,6 +179,8 @@ export const WalletConnectProvider = ({
 
   /**
    * Init provider and modal.
+   *
+   * @todo Move to main renderer
    */
   const initProvider = async () => {
     if (!wcProvider.current) {
@@ -181,8 +201,8 @@ export const WalletConnectProvider = ({
       wcProvider.current = provider;
     }
 
+    // Instantiate a standalone modal using the dapp's WalletConnect projectId.
     if (!wcModal.current) {
-      // Create a standalone modal using the dapp's WalletConnect projectId.
       const modal = new WalletConnectModal({
         enableExplorer: false,
         explorerRecommendedWalletIds: 'NONE',
@@ -203,6 +223,8 @@ export const WalletConnectProvider = ({
    * Requires up to 3 different chain namespaces (polkadot, kusama and westend).
    * The supported methods, chains, and events can all be defined by the dapp
    * team based on the requirements of the dapp.
+   *
+   * @todo Move to main renderer
    */
   const getConnectionParams = () => ({
     requiredNamespaces: {
@@ -217,6 +239,9 @@ export const WalletConnectProvider = ({
 
   /**
    * Create or restore a WalletConnect session.
+   *
+   * @todo Move to main renderer
+   * @todo Send existing session flag to import window to sync UI
    */
   const createSession = async () => {
     try {
@@ -249,6 +274,8 @@ export const WalletConnectProvider = ({
   /**
    * Restore an existing session. Called when `Connect` UI button clicked.
    * Note: Will prompt wallet to approve addresses.
+   *
+   * @todo Move to main renderer
    */
   const restoreOrConnectSession = async () => {
     /** Create new session if there's no session to restore. */
@@ -294,6 +321,8 @@ export const WalletConnectProvider = ({
 
   /**
    * Set addresses from existing session. Called with `Fetch` UI button clicked.
+   *
+   * @todo Move to main renderer
    */
   const fetchAddressesFromExistingSession = () => {
     /** Fetch accounts from restored session. */
@@ -308,10 +337,11 @@ export const WalletConnectProvider = ({
   };
 
   /**
-   * Instantiate a universal provider using the projectId.
+   * Establish a session or use an existing session to fetch addresses.
    *
-   * NOTE: UI allows calling this function only when creating a new
-   * session. Can be simplified.
+   * @todo Move to main renderer
+   * @todo Send fetched addresses to import window via port message
+   * @todo UI allows calling this function only when creating a new session. Can be simplified
    */
   const connectWc = async () => {
     try {
@@ -348,6 +378,8 @@ export const WalletConnectProvider = ({
 
   /**
    * Disconnect from the current session.
+   *
+   * @todo Move to main renderer
    */
   const disconnectWcSession = async () => {
     if (!wcProvider.current) {
@@ -373,6 +405,8 @@ export const WalletConnectProvider = ({
 
   /**
    * Initialize the WalletConnect provider on initial render.
+   *
+   * @todo Move to main renderer
    */
   useEffect(() => {
     if (getOnlineMode() && !wcProvider.current) {

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/types.ts
@@ -7,11 +7,16 @@ import type {
 } from '@polkadot-live/types/walletConnect';
 
 export interface WalletConnectImportContextInterface {
+  isImporting: boolean;
   wcFetchedAddresses: WcFetchedAddress[];
   wcNetworks: WcSelectNetwork[];
+  getSelectedAddresses: () => WcFetchedAddress[];
   handleConnect: () => Promise<void>;
   handleDisconnect: () => Promise<void>;
   handleFetch: () => void;
+  handleImportProcess: (
+    setShowImportUi: React.Dispatch<React.SetStateAction<boolean>>
+  ) => Promise<void>;
   setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
   setWcFetchedAddresses: React.Dispatch<
     React.SetStateAction<WcFetchedAddress[]>

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/types.ts
@@ -1,8 +1,10 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyData } from '@polkadot-live/types/misc';
-import type { ChainID } from '@polkadot-live/types/chains';
+import type {
+  WcFetchedAddress,
+  WcSelectNetwork,
+} from '@polkadot-live/types/walletConnect';
 
 export interface WalletConnectImportContextInterface {
   wcFetchedAddresses: WcFetchedAddress[];
@@ -14,21 +16,4 @@ export interface WalletConnectImportContextInterface {
   setWcFetchedAddresses: React.Dispatch<
     React.SetStateAction<WcFetchedAddress[]>
   >;
-}
-
-/**
- * @todo Move to types package or import window
- */
-export interface WcSelectNetwork {
-  caipId: string;
-  ChainIcon: AnyData;
-  chainId: ChainID;
-  selected: boolean;
-}
-
-export interface WcFetchedAddress {
-  chainId: ChainID;
-  encoded: string;
-  substrate: string;
-  selected: boolean;
 }

--- a/packages/renderer/src/renderer/contexts/import/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnect/types.ts
@@ -4,22 +4,21 @@
 import type { AnyData } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
 
-export interface WalletConnectContextInterface {
-  wcConnecting: boolean;
-  wcDisconnecting: boolean;
+export interface WalletConnectImportContextInterface {
   wcFetchedAddresses: WcFetchedAddress[];
-  wcInitialized: boolean;
   wcNetworks: WcSelectNetwork[];
-  wcSessionRestored: boolean;
-  connectWc: () => Promise<void>;
-  disconnectWcSession: () => Promise<void>;
-  fetchAddressesFromExistingSession: () => void;
+  handleConnect: () => Promise<void>;
+  handleDisconnect: () => Promise<void>;
+  handleFetch: () => void;
+  setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
   setWcFetchedAddresses: React.Dispatch<
     React.SetStateAction<WcFetchedAddress[]>
   >;
-  setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
 }
 
+/**
+ * @todo Move to types package or import window
+ */
 export interface WcSelectNetwork {
   caipId: string;
   ChainIcon: AnyData;

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/defaults.ts
@@ -1,0 +1,19 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function */
+
+import type { WalletConnectContextInterface } from './types';
+
+export const defaultWalletConnectContext: WalletConnectContextInterface = {
+  wcConnecting: false,
+  wcDisconnecting: false,
+  //wcFetchedAddresses: [],
+  wcInitialized: false,
+  wcNetworks: [],
+  wcSessionRestored: false,
+  connectWc: () => new Promise(() => {}),
+  disconnectWcSession: () => new Promise(() => {}),
+  fetchAddressesFromExistingSession: () => {},
+  //setWcFetchedAddresses: () => {},
+  setWcNetworks: () => {},
+};

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/defaults.ts
@@ -5,10 +5,8 @@
 import type { WalletConnectContextInterface } from './types';
 
 export const defaultWalletConnectContext: WalletConnectContextInterface = {
-  wcNetworks: [],
   wcSessionRestored: false,
   connectWc: () => new Promise(() => {}),
   disconnectWcSession: () => new Promise(() => {}),
   fetchAddressesFromExistingSession: () => {},
-  setWcNetworks: () => {},
 };

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/defaults.ts
@@ -5,15 +5,10 @@
 import type { WalletConnectContextInterface } from './types';
 
 export const defaultWalletConnectContext: WalletConnectContextInterface = {
-  wcConnecting: false,
-  wcDisconnecting: false,
-  //wcFetchedAddresses: [],
-  wcInitialized: false,
   wcNetworks: [],
   wcSessionRestored: false,
   connectWc: () => new Promise(() => {}),
   disconnectWcSession: () => new Promise(() => {}),
   fetchAddressesFromExistingSession: () => {},
-  //setWcFetchedAddresses: () => {},
   setWcNetworks: () => {},
 };

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
@@ -12,11 +12,11 @@ import { getSdkError } from '@walletconnect/utils';
 import { getUnixTime } from 'date-fns';
 import type { AnyData } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
+import type { WalletConnectContextInterface } from './types';
 import type {
-  WalletConnectContextInterface,
   WcFetchedAddress,
   WcSelectNetwork,
-} from './types';
+} from '@polkadot-live/types/walletConnect';
 
 const WC_PROJECT_ID = 'ebded8e9ff244ba8b6d173b6c2885d87';
 const WC_RELAY_URL = 'wss://relay.walletconnect.com';
@@ -199,8 +199,6 @@ export const WalletConnectProvider = ({
 
   /**
    * Create or restore a WalletConnect session.
-   *
-   * @todo Send existing session flag to import window to sync UI
    */
   const createSession = async () => {
     try {

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
@@ -40,14 +40,12 @@ export const WalletConnectProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const { getOnlineMode, isConnected, isOnlineMode } = useConnections();
-
-  /**
-   * @todo Make flags relay app flags
-   */
-  const [wcConnecting, setWcConnecting] = useState(false);
-  const [wcDisconnecting, setWcDisconnecting] = useState(false);
-  const [wcInitialized, setWcInitialized] = useState(false);
+  const {
+    getOnlineMode,
+    isConnected,
+    isOnlineMode,
+    wcSyncFlags: { wcInitialized },
+  } = useConnections();
 
   const [wcSessionRestored, setWcSessionRestored] = useState(false);
   const wcSessionRestoredRef = useRef<boolean>(false);
@@ -175,7 +173,9 @@ export const WalletConnectProvider = ({
     }
 
     console.log('> WalletConnect Initialized');
-    setWcInitialized(true);
+
+    //setWcInitialized(true);
+    window.myAPI.relayModeFlag('wc:initialized', true);
   };
 
   /**
@@ -303,9 +303,9 @@ export const WalletConnectProvider = ({
       }
 
       /** Restore existing session or create a new one. */
-      setWcConnecting(true);
+      window.myAPI.relayModeFlag('wc:connecting', true);
       const modalOpen = await restoreOrConnectSession();
-      setWcConnecting(false);
+      window.myAPI.relayModeFlag('wc:connecting', false);
 
       if (!modalOpen) {
         /** Fetch accounts from restored session. */
@@ -337,7 +337,7 @@ export const WalletConnectProvider = ({
       return;
     }
 
-    setWcDisconnecting(true);
+    window.myAPI.relayModeFlag('wc:disconnecting', true);
     const topic = wcProvider.current.session?.topic;
     if (topic) {
       await wcProvider.current.client.disconnect({
@@ -351,7 +351,7 @@ export const WalletConnectProvider = ({
     wcPairingTopic.current = null;
     wcMetaRef.current = null;
     setStateWithRef(false, setWcSessionRestored, wcSessionRestoredRef);
-    setWcDisconnecting(false);
+    window.myAPI.relayModeFlag('wc:disconnecting', false);
   };
 
   /**
@@ -384,12 +384,7 @@ export const WalletConnectProvider = ({
         connectWc,
         disconnectWcSession,
         fetchAddressesFromExistingSession,
-        //setWcFetchedAddresses,
         setWcNetworks,
-        wcConnecting,
-        wcDisconnecting,
-        //wcFetchedAddresses,
-        wcInitialized,
         wcNetworks,
         wcSessionRestored,
       }}

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
+import * as wcConfig from '@ren/config/walletConnect';
+
 import { Config as ConfigRenderer } from '@ren/config/processes/renderer';
 import UniversalProvider from '@walletconnect/universal-provider';
 import { WalletConnectModal } from '@walletconnect/modal';
@@ -18,19 +20,10 @@ import type {
   WcSelectNetwork,
 } from '@polkadot-live/types/walletConnect';
 
-const WC_PROJECT_ID = 'ebded8e9ff244ba8b6d173b6c2885d87';
-const WC_RELAY_URL = 'wss://relay.walletconnect.com';
-
-// TODO: Move constants and network array to config file.
-const WC_POLKADOT_CAIP_ID = '91b171bb158e2d3848fa23a9f1c25182';
-const WC_KUSAMA_CAIP_ID = 'b0a8d493285c2df73290dfb7e61f870f';
-const WC_WESTEND_CAIP_ID = 'e143f23803ac50e8f6f8e62695d1ce9e';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapCaipChainId = new Map<string, ChainID>([
-  [WC_POLKADOT_CAIP_ID, 'Polkadot'],
-  [WC_KUSAMA_CAIP_ID, 'Kusama'],
-  [WC_WESTEND_CAIP_ID, 'Westend'],
+  [wcConfig.WC_POLKADOT_CAIP_ID, 'Polkadot'],
+  [wcConfig.WC_KUSAMA_CAIP_ID, 'Kusama'],
+  [wcConfig.WC_WESTEND_CAIP_ID, 'Westend'],
 ]);
 
 export const WalletConnectContext =
@@ -80,8 +73,8 @@ export const WalletConnectProvider = ({
         .map(({ caipId }) => `polkadot:${caipId}`);
     } else {
       return [
-        `polkadot:${WC_POLKADOT_CAIP_ID}`,
-        `polkadot:${WC_KUSAMA_CAIP_ID}`,
+        `polkadot:${wcConfig.WC_POLKADOT_CAIP_ID}`,
+        `polkadot:${wcConfig.WC_KUSAMA_CAIP_ID}`,
       ];
     }
   };
@@ -148,8 +141,8 @@ export const WalletConnectProvider = ({
     if (!wcProvider.current) {
       // Instantiate provider.
       const provider = await UniversalProvider.init({
-        projectId: WC_PROJECT_ID,
-        relayUrl: WC_RELAY_URL,
+        projectId: wcConfig.WC_PROJECT_ID,
+        relayUrl: wcConfig.WC_RELAY_URL,
         // TODO: metadata
       });
 
@@ -169,7 +162,7 @@ export const WalletConnectProvider = ({
         enableExplorer: false,
         explorerRecommendedWalletIds: 'NONE',
         explorerExcludedWalletIds: 'ALL',
-        projectId: WC_PROJECT_ID,
+        projectId: wcConfig.WC_PROJECT_ID,
       });
 
       wcModal.current = modal;

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
@@ -281,8 +281,16 @@ export const WalletConnectProvider = ({
     /** Fetch accounts from restored session. */
     const namespaces = wcProvider.current?.session?.namespaces;
     if (!namespaces) {
-      // TODO: Send error notification in import window.
-      console.log('> Unable to get namespaces of restored session.');
+      // Render toast error notification in import window.
+      ConfigRenderer.portToImport?.postMessage({
+        task: 'import:toast:show',
+        data: {
+          message: 'Session Error - Establish a new session',
+          toastId: `wc-error-${String(Date.now())}`,
+          toastType: 'error',
+        },
+      });
+
       return;
     }
 

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/index.tsx
@@ -8,16 +8,11 @@ import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { useConnections } from '@app/contexts/common/Connections';
 import { chainIcon } from '@ren/config/chains';
 import { getSdkError } from '@walletconnect/utils';
-import { encodeAddress } from '@polkadot/util-crypto';
 import { getUnixTime } from 'date-fns';
 import { setStateWithRef } from '@w3ux/utils';
 import type { AnyData } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
-import type {
-  WalletConnectContextInterface,
-  WcFetchedAddress,
-  WcSelectNetwork,
-} from './types';
+import type { WalletConnectContextInterface, WcSelectNetwork } from './types';
 
 const WC_PROJECT_ID = 'ebded8e9ff244ba8b6d173b6c2885d87';
 const WC_RELAY_URL = 'wss://relay.walletconnect.com';
@@ -26,9 +21,7 @@ const WC_POLKADOT_CAIP_ID = '91b171bb158e2d3848fa23a9f1c25182';
 const WC_KUSAMA_CAIP_ID = 'b0a8d493285c2df73290dfb7e61f870f';
 const WC_WESTEND_CAIP_ID = 'e143f23803ac50e8f6f8e62695d1ce9e';
 
-/**
- * @todo Keep in import window
- */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapCaipChainId = new Map<string, ChainID>([
   [WC_POLKADOT_CAIP_ID, 'Polkadot'],
   [WC_KUSAMA_CAIP_ID, 'Kusama'],
@@ -59,9 +52,6 @@ export const WalletConnectProvider = ({
   const [wcSessionRestored, setWcSessionRestored] = useState(false);
   const wcSessionRestoredRef = useRef<boolean>(false);
 
-  /**
-   * @todo Move to main renderer
-   */
   const wcProvider = useRef<UniversalProvider | null>(null);
   const wcModal = useRef<WalletConnectModal | null>(null);
   const wcPairingTopic = useRef<string | null>(null);
@@ -73,8 +63,6 @@ export const WalletConnectProvider = ({
 
   /**
    * WalletConnect networks and their selected state.
-   *
-   * @todo Move to main renderer
    */
   const [wcNetworks, setWcNetworks] = useState<WcSelectNetwork[]>([
     {
@@ -98,19 +86,7 @@ export const WalletConnectProvider = ({
   ]);
 
   /**
-   * Fetched addresses with WalletConnect.
-   *
-   * @todo Keep in import renderer
-   */
-  const [wcFetchedAddresses, setWcFetchedAddresses] = useState<
-    WcFetchedAddress[]
-  >([]);
-
-  /**
    * Get namespaces of selected networks.
-   *
-   * @todo Move wcNetworks to main renderer
-   * @todo Send selected network ChainIDs to main renderer
    */
   const getNamespaces = () => {
     const selectedNetworks = wcNetworks.filter(({ selected }) => selected);
@@ -123,25 +99,6 @@ export const WalletConnectProvider = ({
         `polkadot:${WC_POLKADOT_CAIP_ID}`,
         `polkadot:${WC_KUSAMA_CAIP_ID}`,
       ];
-    }
-  };
-
-  /**
-   * Util for getting a chain ID's address prefix for encoding.
-   *
-   * @todo Keep in import window
-   */
-  const getAddressPrefix = (chainId: ChainID) => {
-    switch (chainId) {
-      case 'Polkadot': {
-        return 0;
-      }
-      case 'Kusama': {
-        return 2;
-      }
-      case 'Westend': {
-        return 42;
-      }
     }
   };
 
@@ -164,25 +121,27 @@ export const WalletConnectProvider = ({
       })
     );
 
-    setWcFetchedAddresses(() =>
-      accounts.map(({ address, caipId }) => {
-        const chainId = mapCaipChainId.get(caipId)!;
-        const pref = getAddressPrefix(chainId);
-
-        return {
-          chainId,
-          encoded: encodeAddress(address, pref),
-          substrate: address,
-          selected: false,
-        };
-      })
+    console.log(
+      `TODO: Send ${accounts.length} fetched accounts to import window`
     );
+
+    //setWcFetchedAddresses(() =>
+    //  accounts.map(({ address, caipId }) => {
+    //    const chainId = mapCaipChainId.get(caipId)!;
+    //    const pref = getAddressPrefix(chainId);
+
+    //    return {
+    //      chainId,
+    //      encoded: encodeAddress(address, pref),
+    //      substrate: address,
+    //      selected: false,
+    //    };
+    //  })
+    //);
   };
 
   /**
    * Init provider and modal.
-   *
-   * @todo Move to main renderer
    */
   const initProvider = async () => {
     if (!wcProvider.current) {
@@ -225,8 +184,6 @@ export const WalletConnectProvider = ({
    * Requires up to 3 different chain namespaces (polkadot, kusama and westend).
    * The supported methods, chains, and events can all be defined by the dapp
    * team based on the requirements of the dapp.
-   *
-   * @todo Move to main renderer
    */
   const getConnectionParams = () => ({
     requiredNamespaces: {
@@ -242,7 +199,6 @@ export const WalletConnectProvider = ({
   /**
    * Create or restore a WalletConnect session.
    *
-   * @todo Move to main renderer
    * @todo Send existing session flag to import window to sync UI
    */
   const createSession = async () => {
@@ -276,8 +232,6 @@ export const WalletConnectProvider = ({
   /**
    * Restore an existing session. Called when `Connect` UI button clicked.
    * Note: Will prompt wallet to approve addresses.
-   *
-   * @todo Move to main renderer
    */
   const restoreOrConnectSession = async () => {
     /** Create new session if there's no session to restore. */
@@ -293,7 +247,7 @@ export const WalletConnectProvider = ({
 
       return true;
     } else {
-      /** NOTE: This branch is currently not run based on the UI. */
+      /** NOTE: This branch is currently not run based on the import UI. */
       const expiry = wcProvider.current!.session!.expiry;
       const nowUnix = getUnixTime(new Date());
 
@@ -323,8 +277,6 @@ export const WalletConnectProvider = ({
 
   /**
    * Set addresses from existing session. Called with `Fetch` UI button clicked.
-   *
-   * @todo Move to main renderer
    */
   const fetchAddressesFromExistingSession = () => {
     /** Fetch accounts from restored session. */
@@ -341,7 +293,6 @@ export const WalletConnectProvider = ({
   /**
    * Establish a session or use an existing session to fetch addresses.
    *
-   * @todo Move to main renderer
    * @todo Send fetched addresses to import window via port message
    * @todo UI allows calling this function only when creating a new session. Can be simplified
    */
@@ -380,8 +331,6 @@ export const WalletConnectProvider = ({
 
   /**
    * Disconnect from the current session.
-   *
-   * @todo Move to main renderer
    */
   const disconnectWcSession = async () => {
     if (!wcProvider.current) {
@@ -407,8 +356,6 @@ export const WalletConnectProvider = ({
 
   /**
    * Initialize the WalletConnect provider on initial render.
-   *
-   * @todo Move to main renderer
    */
   useEffect(() => {
     if (getOnlineMode() && !wcProvider.current) {
@@ -437,11 +384,11 @@ export const WalletConnectProvider = ({
         connectWc,
         disconnectWcSession,
         fetchAddressesFromExistingSession,
-        setWcFetchedAddresses,
+        //setWcFetchedAddresses,
         setWcNetworks,
         wcConnecting,
         wcDisconnecting,
-        wcFetchedAddresses,
+        //wcFetchedAddresses,
         wcInitialized,
         wcNetworks,
         wcSessionRestored,

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
@@ -1,29 +1,11 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { AnyData } from '@polkadot-live/types/misc';
-import type { ChainID } from '@polkadot-live/types/chains';
+import type { WcSelectNetwork } from '@polkadot-live/types/walletConnect';
 
 export interface WalletConnectContextInterface {
   wcSessionRestored: boolean;
   connectWc: (wcNetworks: WcSelectNetwork[]) => Promise<void>;
   disconnectWcSession: () => Promise<void>;
   fetchAddressesFromExistingSession: () => void;
-}
-
-/**
- * @todo Move to types package or import window
- */
-export interface WcSelectNetwork {
-  caipId: string;
-  ChainIcon: AnyData;
-  chainId: ChainID;
-  selected: boolean;
-}
-
-export interface WcFetchedAddress {
-  chainId: ChainID;
-  encoded: string;
-  substrate: string;
-  selected: boolean;
 }

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
@@ -1,0 +1,38 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AnyData } from '@polkadot-live/types/misc';
+import type { ChainID } from '@polkadot-live/types/chains';
+
+export interface WalletConnectContextInterface {
+  wcConnecting: boolean;
+  wcDisconnecting: boolean;
+  //wcFetchedAddresses: WcFetchedAddress[];
+  wcInitialized: boolean;
+  wcNetworks: WcSelectNetwork[];
+  wcSessionRestored: boolean;
+  connectWc: () => Promise<void>;
+  disconnectWcSession: () => Promise<void>;
+  fetchAddressesFromExistingSession: () => void;
+  //setWcFetchedAddresses: React.Dispatch<
+  //  React.SetStateAction<WcFetchedAddress[]>
+  //>;
+  setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
+}
+
+export interface WcSelectNetwork {
+  caipId: string;
+  ChainIcon: AnyData;
+  chainId: ChainID;
+  selected: boolean;
+}
+
+/**
+ * @todo Move to types package or import window
+ */
+export interface WcFetchedAddress {
+  chainId: ChainID;
+  encoded: string;
+  substrate: string;
+  selected: boolean;
+}

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
@@ -5,14 +5,15 @@ import type { AnyData } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
 
 export interface WalletConnectContextInterface {
-  wcNetworks: WcSelectNetwork[];
   wcSessionRestored: boolean;
-  connectWc: () => Promise<void>;
+  connectWc: (wcNetworks: WcSelectNetwork[]) => Promise<void>;
   disconnectWcSession: () => Promise<void>;
   fetchAddressesFromExistingSession: () => void;
-  setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
 }
 
+/**
+ * @todo Move to types package or import window
+ */
 export interface WcSelectNetwork {
   caipId: string;
   ChainIcon: AnyData;
@@ -20,9 +21,6 @@ export interface WcSelectNetwork {
   selected: boolean;
 }
 
-/**
- * @todo Move to types package or import window
- */
 export interface WcFetchedAddress {
   chainId: ChainID;
   encoded: string;

--- a/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
+++ b/packages/renderer/src/renderer/contexts/main/WalletConnect/types.ts
@@ -5,18 +5,11 @@ import type { AnyData } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
 
 export interface WalletConnectContextInterface {
-  wcConnecting: boolean;
-  wcDisconnecting: boolean;
-  //wcFetchedAddresses: WcFetchedAddress[];
-  wcInitialized: boolean;
   wcNetworks: WcSelectNetwork[];
   wcSessionRestored: boolean;
   connectWc: () => Promise<void>;
   disconnectWcSession: () => Promise<void>;
   fetchAddressesFromExistingSession: () => void;
-  //setWcFetchedAddresses: React.Dispatch<
-  //  React.SetStateAction<WcFetchedAddress[]>
-  //>;
   setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
 }
 

--- a/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
@@ -7,12 +7,14 @@ import { Config as ConfigImport } from '@ren/config/processes/import';
 import { useAddresses } from '@app/contexts/import/Addresses';
 import { useImportHandler } from '@app/contexts/import/ImportHandler';
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
+import { useWalletConnectImport } from '@app/contexts/import/WalletConnect';
 import { useEffect } from 'react';
 import type {
   AccountSource,
   LedgerLocalAddress,
   LocalAddress,
 } from '@polkadot-live/types/accounts';
+import type { WcFetchedAddress } from '@app/contexts/import/WalletConnect/types';
 
 // TODO: Move to WalletConnect file.
 const WC_EVENT_ORIGIN = 'https://verify.walletconnect.org';
@@ -21,6 +23,7 @@ export const useImportMessagePorts = () => {
   const { handleImportAddressFromBackup } = useImportHandler();
   const { setStatusForAccount } = useAccountStatuses();
   const { handleAddressImport } = useAddresses();
+  const { setWcFetchedAddresses } = useWalletConnectImport();
 
   /**
    * @name handleReceivedPort
@@ -66,6 +69,13 @@ export const useImportMessagePorts = () => {
               // Update state for an address.
               const { address, source } = ev.data.data;
               handleAddressImport(source, address);
+              break;
+            }
+            case 'import:wc:set:fetchedAddresses': {
+              const parsed: WcFetchedAddress[] = JSON.parse(
+                ev.data.data.fetchedAddresses
+              );
+              setWcFetchedAddresses(parsed);
               break;
             }
             default: {

--- a/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
@@ -17,9 +17,6 @@ import type {
 } from '@polkadot-live/types/accounts';
 import type { WcFetchedAddress } from '@polkadot-live/types/walletConnect';
 
-// TODO: Move to WalletConnect file.
-const WC_EVENT_ORIGIN = 'https://verify.walletconnect.org';
-
 export const useImportMessagePorts = () => {
   const { handleImportAddressFromBackup } = useImportHandler();
   const { setStatusForAccount } = useAccountStatuses();
@@ -31,14 +28,6 @@ export const useImportMessagePorts = () => {
    * @summary Handle messages sent to the import window.
    */
   const handleReceivedPort = (e: MessageEvent) => {
-    // TODO: May need to handle WalletConnect messages here.
-    // For now, don't do any further processing if message is from WalletConnect.
-    if (e.origin === WC_EVENT_ORIGIN) {
-      console.log('> WalletConnect event received:');
-      console.log(e);
-      return;
-    }
-
     console.log(`received port: ${e.data.target}`);
 
     switch (e.data.target) {

--- a/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
@@ -14,7 +14,7 @@ import type {
   LedgerLocalAddress,
   LocalAddress,
 } from '@polkadot-live/types/accounts';
-import type { WcFetchedAddress } from '@app/contexts/import/WalletConnect/types';
+import type { WcFetchedAddress } from '@polkadot-live/types/walletConnect';
 
 // TODO: Move to WalletConnect file.
 const WC_EVENT_ORIGIN = 'https://verify.walletconnect.org';

--- a/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
@@ -9,6 +9,7 @@ import { useImportHandler } from '@app/contexts/import/ImportHandler';
 import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useWalletConnectImport } from '@app/contexts/import/WalletConnect';
 import { useEffect } from 'react';
+import { renderToast } from '@polkadot-live/ui/utils';
 import type {
   AccountSource,
   LedgerLocalAddress,
@@ -76,6 +77,11 @@ export const useImportMessagePorts = () => {
                 ev.data.data.fetchedAddresses
               );
               setWcFetchedAddresses(parsed);
+              break;
+            }
+            case 'import:toast:show': {
+              const { message, toastId, toastType } = ev.data.data;
+              renderToast(message, toastId, toastType);
               break;
             }
             default: {

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -47,6 +47,9 @@ import type {
 } from '@polkadot-live/types/subscriptions';
 import { getAddressChainId } from '../Utils';
 
+// TODO: Move to WalletConnect file.
+const WC_EVENT_ORIGIN = 'https://verify.walletconnect.org';
+
 export const useMainMessagePorts = () => {
   /// Main renderer contexts.
   const { importAddress, removeAddress, setAddresses } = useAddresses();
@@ -629,6 +632,14 @@ export const useMainMessagePorts = () => {
    */
   const handleReceivedPort = async (e: MessageEvent) => {
     console.log(`received port: ${e.data.target}`);
+
+    // TODO: May need to handle WalletConnect messages here.
+    // For now, don't do any further processing if message is from WalletConnect.
+    if (e.origin === WC_EVENT_ORIGIN) {
+      console.log('> WalletConnect event received:');
+      console.log(e);
+      return;
+    }
 
     switch (e.data.target) {
       case 'main-import:main': {

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -658,8 +658,6 @@ export const useMainMessagePorts = () => {
    * sets up message handlers accordingly.
    */
   const handleReceivedPort = async (e: MessageEvent) => {
-    console.log(`received port: ${e.data.target}`);
-
     // TODO: May need to handle WalletConnect messages here.
     // For now, don't do any further processing if message is from WalletConnect.
     if (e.origin === WC_EVENT_ORIGIN) {
@@ -667,6 +665,8 @@ export const useMainMessagePorts = () => {
       console.log(e);
       return;
     }
+
+    console.log(`received port: ${e.data.target}`);
 
     switch (e.data.target) {
       case 'main-import:main': {

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -23,6 +23,7 @@ import { planckToUnit, rmCommas } from '@w3ux/utils';
 import { SubscriptionsController } from '@ren/controller/SubscriptionsController';
 import { IntervalsController } from '@ren/controller/IntervalsController';
 import { TaskOrchestrator } from '@ren/orchestrators/TaskOrchestrator';
+import { getAddressChainId } from '../Utils';
 
 /// Main window contexts.
 import { useAddresses } from '@app/contexts/main/Addresses';
@@ -46,8 +47,7 @@ import type {
   IntervalSubscription,
   SubscriptionTask,
 } from '@polkadot-live/types/subscriptions';
-import type { WcSelectNetwork } from '@app/contexts/import/WalletConnect/types';
-import { getAddressChainId } from '../Utils';
+import type { WcSelectNetwork } from '@polkadot-live/types/walletConnect';
 
 // TODO: Move to WalletConnect file.
 const WC_EVENT_ORIGIN = 'https://verify.walletconnect.org';

--- a/packages/renderer/src/renderer/screens/Import/WalletConnect/Import/index.tsx
+++ b/packages/renderer/src/renderer/screens/Import/WalletConnect/Import/index.tsx
@@ -39,9 +39,14 @@ import {
 import type { ImportProps } from './types';
 
 export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
+  const {
+    darkMode,
+    getOnlineMode,
+    wcSyncFlags: { wcConnecting, wcDisconnecting, wcInitialized },
+  } = useConnections();
+
   const { insertAccountStatus } = useAccountStatuses();
   const { isAlreadyImported, wcAddresses } = useAddresses();
-  const { darkMode, getOnlineMode } = useConnections();
   const { handleImportAddress } = useImportHandler();
 
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
@@ -51,10 +56,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
     fetchAddressesFromExistingSession,
     setWcFetchedAddresses,
     setWcNetworks,
-    wcConnecting,
-    wcDisconnecting,
     wcFetchedAddresses,
-    wcInitialized,
     wcNetworks,
     wcSessionRestored,
   } = useWalletConnect();

--- a/packages/renderer/src/renderer/screens/Import/WalletConnect/Import/index.tsx
+++ b/packages/renderer/src/renderer/screens/Import/WalletConnect/Import/index.tsx
@@ -27,7 +27,7 @@ import { useAccountStatuses } from '@app/contexts/import/AccountStatuses';
 import { useAddresses } from '@app/contexts/import/Addresses';
 import { useConnections } from '@app/contexts/common/Connections';
 import { useImportHandler } from '@app/contexts/import/ImportHandler';
-import { useWalletConnect } from '@app/contexts/import/WalletConnect';
+import { useWalletConnectImport } from '@app/contexts/import/WalletConnect';
 import { useEffect, useState } from 'react';
 import { ellipsisFn } from '@w3ux/utils';
 import { WcFlexRow, WcSessionButton } from './Wrappers';
@@ -42,7 +42,12 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
   const {
     darkMode,
     getOnlineMode,
-    wcSyncFlags: { wcConnecting, wcDisconnecting, wcInitialized },
+    wcSyncFlags: {
+      wcConnecting,
+      wcDisconnecting,
+      wcInitialized,
+      wcSessionRestored,
+    },
   } = useConnections();
 
   const { insertAccountStatus } = useAccountStatuses();
@@ -51,15 +56,14 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
 
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
   const {
-    connectWc,
-    disconnectWcSession,
-    fetchAddressesFromExistingSession,
-    setWcFetchedAddresses,
-    setWcNetworks,
     wcFetchedAddresses,
     wcNetworks,
-    wcSessionRestored,
-  } = useWalletConnect();
+    handleConnect,
+    handleDisconnect,
+    handleFetch,
+    setWcFetchedAddresses,
+    setWcNetworks,
+  } = useWalletConnectImport();
 
   const [isImporting, setIsImporting] = useState(false);
   const [accordionActiveIndices, setAccordionActiveIndices] = useState<
@@ -68,13 +72,6 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
 
   const getSelectedNetworkCount = () =>
     wcNetworks.filter(({ selected }) => selected).length;
-
-  /**
-   * Handle connect button click.
-   */
-  const handleConnect = async () => {
-    await connectWc();
-  };
 
   /**
    * Handle address checkbox click.
@@ -241,7 +238,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                           wcConnecting ||
                           wcDisconnecting
                         }
-                        onClick={async () => await disconnectWcSession()}
+                        onClick={async () => await handleDisconnect()}
                       >
                         Disconnect
                       </WcSessionButton>
@@ -254,7 +251,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                           wcDisconnecting
                         }
                         onClick={() => {
-                          fetchAddressesFromExistingSession();
+                          handleFetch();
                           setAccordionActiveIndices([1]);
                         }}
                       >

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,6 +20,7 @@
     "./settings": "./src/settings.ts",
     "./subscriptions": "./src/subscriptions.ts",
     "./tx": "./src/tx.ts",
+    "./walletConnect": "./src/walletConnect.ts",
     "./chains": "./src/chains/index.ts",
     "./chains/polkadot": "./src/chains/polkadot.ts",
     "./developerConsole/workspaces": "./src/developerConsole/workspaces.ts"

--- a/packages/types/src/communication.ts
+++ b/packages/types/src/communication.ts
@@ -95,10 +95,3 @@ export interface IpcTask {
     | 'websockets:server:stop';
   data: AnyData;
 }
-
-export interface WcSyncFlags {
-  wcConnecting: boolean;
-  wcDisconnecting: boolean;
-  wcInitialized: boolean;
-  wcSessionRestored: boolean;
-}

--- a/packages/types/src/communication.ts
+++ b/packages/types/src/communication.ts
@@ -12,7 +12,8 @@ export type SyncFlag =
   // WalletConnect
   | 'wc:connecting'
   | 'wc:disconnecting'
-  | 'wc:initialized';
+  | 'wc:initialized'
+  | 'wc:session:restored';
 
 export interface RelayPortTask {
   windowId: string;
@@ -99,4 +100,5 @@ export interface WcSyncFlags {
   wcConnecting: boolean;
   wcDisconnecting: boolean;
   wcInitialized: boolean;
+  wcSessionRestored: boolean;
 }

--- a/packages/types/src/communication.ts
+++ b/packages/types/src/communication.ts
@@ -8,7 +8,11 @@ export type SyncFlag =
   | 'isBuildingExtrinsic'
   | 'isConnected'
   | 'isImporting'
-  | 'isOnlineMode';
+  | 'isOnlineMode'
+  // WalletConnect
+  | 'wc:connecting'
+  | 'wc:disconnecting'
+  | 'wc:initialized';
 
 export interface RelayPortTask {
   windowId: string;
@@ -89,4 +93,10 @@ export interface IpcTask {
     | 'websockets:server:start'
     | 'websockets:server:stop';
   data: AnyData;
+}
+
+export interface WcSyncFlags {
+  wcConnecting: boolean;
+  wcDisconnecting: boolean;
+  wcInitialized: boolean;
 }

--- a/packages/types/src/walletConnect.ts
+++ b/packages/types/src/walletConnect.ts
@@ -1,0 +1,26 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { AnyData } from './misc';
+import type { ChainID } from './chains';
+
+export interface WcSyncFlags {
+  wcConnecting: boolean;
+  wcDisconnecting: boolean;
+  wcInitialized: boolean;
+  wcSessionRestored: boolean;
+}
+
+export interface WcSelectNetwork {
+  caipId: string;
+  ChainIcon: AnyData;
+  chainId: ChainID;
+  selected: boolean;
+}
+
+export interface WcFetchedAddress {
+  chainId: ChainID;
+  encoded: string;
+  substrate: string;
+  selected: boolean;
+}


### PR DESCRIPTION
In preparation for signing extrinsics with the WalletConnect protocol, the WalletConnect provider and session have been moved to a new context in the main renderer.

The import window's WalletConnect context communicates with the main renderer's new context to facilitate fetching addresses via a WalletConnect session.

## Other improvements

- WalletConnect state flags re-implemented as relay flags which are accessible to the whole application
- WalletConnect import logic lifted to contexts and separated from markup
- WalletConnect constant data moved to a config file