### PR TITLE
chore: open wallet connect modal inside import window

### DIFF
--- a/packages/renderer/src/renderer/contexts/import/WalletConnectImport/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnectImport/defaults.ts
@@ -15,5 +15,6 @@ export const defaultWalletConnectImportContext: WalletConnectImportContextInterf
     handleFetch: () => {},
     setWcFetchedAddresses: () => {},
     handleImportProcess: () => new Promise(() => {}),
+    handleOpenCloseWcModal: () => new Promise(() => {}),
     setWcNetworks: () => {},
   };

--- a/packages/renderer/src/renderer/contexts/import/WalletConnectImport/types.ts
+++ b/packages/renderer/src/renderer/contexts/import/WalletConnectImport/types.ts
@@ -17,6 +17,7 @@ export interface WalletConnectImportContextInterface {
   handleImportProcess: (
     setShowImportUi: React.Dispatch<React.SetStateAction<boolean>>
   ) => Promise<void>;
+  handleOpenCloseWcModal: (open: boolean, uri?: string) => Promise<void>;
   setWcNetworks: React.Dispatch<React.SetStateAction<WcSelectNetwork[]>>;
   setWcFetchedAddresses: React.Dispatch<
     React.SetStateAction<WcFetchedAddress[]>

--- a/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useImportMessagePorts.ts
@@ -21,7 +21,8 @@ export const useImportMessagePorts = () => {
   const { handleImportAddressFromBackup } = useImportHandler();
   const { setStatusForAccount } = useAccountStatuses();
   const { handleAddressImport } = useAddresses();
-  const { setWcFetchedAddresses } = useWalletConnectImport();
+  const { setWcFetchedAddresses, handleOpenCloseWcModal } =
+    useWalletConnectImport();
 
   /**
    * @name handleReceivedPort
@@ -59,6 +60,15 @@ export const useImportMessagePorts = () => {
               // Update state for an address.
               const { address, source } = ev.data.data;
               handleAddressImport(source, address);
+              break;
+            }
+            case 'import:wc:modal:open': {
+              const { uri } = ev.data.data;
+              await handleOpenCloseWcModal(true, uri);
+              break;
+            }
+            case 'import:wc:modal:close': {
+              handleOpenCloseWcModal(false);
               break;
             }
             case 'import:wc:set:fetchedAddresses': {


### PR DESCRIPTION
When the user fetches WalletConnect addresses from the import window, the WalletConnect modal is opened over the import screen after the `Connect` button is clicked.

Messaging between the main and import renderers ensures the WalletConnect modal is configured, opened and closed correctly.

Opening the WalletConnect modal within the import window instead of the main window when importing addresses improves UX and keeps the user within a single window.