### PR TITLE
feat: backup extrinsics

### DIFF
--- a/packages/main/src/controller/AddressesController.ts
+++ b/packages/main/src/controller/AddressesController.ts
@@ -52,6 +52,28 @@ export class AddressesController {
   }
 
   /**
+   * @name getAll
+   * @summary Get all stored addresses and serialize as map.
+   */
+  static getAll(): string {
+    const sources: AccountSource[] = [
+      'vault',
+      'ledger',
+      'read-only',
+      'wallet-connect',
+    ];
+
+    const map = new Map<AccountSource, string>();
+    for (const source of sources) {
+      const key = ConfigMain.getStorageKey(source);
+      const addresses = store.has(key) ? this.getFromStore(key) : '[]';
+      map.set(source, addresses);
+    }
+
+    return JSON.stringify(Array.from(map.entries()));
+  }
+
+  /**
    * @name add
    * @summary Set the import flag of an address to `true`.
    */
@@ -157,28 +179,6 @@ export class AddressesController {
     const { source } = task.data;
     const key = ConfigMain.getStorageKey(source);
     return store.has(key) ? this.getFromStore(key) : '[]';
-  }
-
-  /**
-   * @name getAll
-   * @summary Get all stored addresses and serialize as map.
-   */
-  private static getAll(): string {
-    const sources: AccountSource[] = [
-      'vault',
-      'ledger',
-      'read-only',
-      'wallet-connect',
-    ];
-
-    const map = new Map<AccountSource, string>();
-    for (const source of sources) {
-      const key = ConfigMain.getStorageKey(source);
-      const addresses = store.has(key) ? this.getFromStore(key) : '[]';
-      map.set(source, addresses);
-    }
-
-    return JSON.stringify(Array.from(map.entries()));
   }
 
   /**

--- a/packages/main/src/controller/BackupController.ts
+++ b/packages/main/src/controller/BackupController.ts
@@ -5,10 +5,11 @@ import { Config as ConfigMain } from '@/config/main';
 import { dialog } from 'electron';
 import { promises as fsPromises } from 'fs';
 import { AddressesController } from '@/controller/AddressesController';
-import { WindowsController } from './WindowsController';
 import { EventsController } from '@/controller/EventsController';
+import { ExtrinsicsController } from '@/controller/ExtrinsicsController';
 import { IntervalsController } from '@/controller/IntervalsController';
 import { SubscriptionsController } from './SubscriptionsController';
+import { WindowsController } from './WindowsController';
 import { version } from '../../package.json';
 import type { ExportResult, ImportResult } from '@polkadot-live/types/backup';
 
@@ -146,12 +147,14 @@ export class BackupController {
     const map = new Map<string, string>();
     const addresses = AddressesController.getBackupData();
     const events = EventsController.getBackupData();
+    const extrinsics = ExtrinsicsController.getBackupDate();
     const intervals = IntervalsController.getBackupData();
     const accountTasks = SubscriptionsController.getBackupData();
 
     map.set('version', version);
     map.set('addresses', addresses);
     map.set('events', events);
+    map.set('extrinsics', extrinsics);
     map.set('intervals', intervals);
     map.set('accountTasks', accountTasks);
 

--- a/packages/main/src/controller/ExtrinsicsController.ts
+++ b/packages/main/src/controller/ExtrinsicsController.ts
@@ -48,6 +48,7 @@ export class ExtrinsicsController {
   private static update(task: IpcTask) {
     const { serialized }: { serialized: string } = task.data;
     const info: ExtrinsicInfo = JSON.parse(serialized);
+    info.dynamicInfo = undefined;
     const stored = this.getExtrinsicsFromStore();
     const updated = stored.map((i) => (i.txId === info.txId ? { ...info } : i));
     this.persistExtrinsicsToStore(updated);

--- a/packages/main/src/controller/ExtrinsicsController.ts
+++ b/packages/main/src/controller/ExtrinsicsController.ts
@@ -114,4 +114,11 @@ export class ExtrinsicsController {
       JSON.stringify(extrinsics)
     );
   };
+
+  /**
+   * Get all stored extrinsics in serialized form.
+   */
+  static getBackupDate(): string {
+    return (store as Record<string, AnyJson>).get(this.storeKey) as string;
+  }
 }

--- a/packages/main/src/controller/ExtrinsicsController.ts
+++ b/packages/main/src/controller/ExtrinsicsController.ts
@@ -72,7 +72,7 @@ export class ExtrinsicsController {
     const addressNameMap = ImportUtils.getAddressNameMap();
 
     // Get stored extrinsics and sync account names with import data.
-    let stored = this.getExtrinsicsFromStore().map((info) => {
+    const stored = this.getExtrinsicsFromStore().map((info) => {
       const { action, accountName, from } = info.actionMeta;
 
       // Update transfer extrinsic data if necessary.
@@ -97,15 +97,13 @@ export class ExtrinsicsController {
       return info;
     });
 
-    for (const a of received) {
-      const avoid = stored.find((b) => !ImportUtils.compareExtrinsics(a, b));
-      if (!avoid) {
-        stored = stored.concat([a]);
-      }
-    }
+    // Append unique imported extrinsics.
+    const append: ExtrinsicInfo[] = received.filter(
+      (a) => !stored.find((b) => ImportUtils.compareExtrinsics(a, b))
+    );
 
-    this.persistExtrinsicsToStore(stored);
-    return JSON.stringify(stored);
+    this.persistExtrinsicsToStore([...stored, ...append]);
+    return JSON.stringify([...stored, ...append]);
   }
 
   /**

--- a/packages/main/src/utils/ImportUtils.ts
+++ b/packages/main/src/utils/ImportUtils.ts
@@ -7,7 +7,7 @@ import type {
   LedgerLocalAddress,
   LocalAddress,
 } from '@polkadot-live/types/accounts';
-import type { ExtrinsicInfo } from '@polkadot-live/types/tx';
+import type { ExtrinsicInfo, TxActionUid } from '@polkadot-live/types/tx';
 
 /**
  * @name getAddressNameMap
@@ -46,20 +46,21 @@ export const getAddressNameMap = () => {
 };
 
 /**
- * @name doImportExtrinsic
+ * @name compareExtrinsics
  * @summary Checks if two extrinsics are deemed different when importing.
+ * @returns `true` if extrinsics are the same, `false` otherwise.
  */
 export const compareExtrinsics = (a: ExtrinsicInfo, b: ExtrinsicInfo) => {
   const { action: aAction, from: aFrom } = a.actionMeta;
   const { action: bAction, from: bFrom } = b.actionMeta;
-  const whiteListed = 'balances_transferKeepAlive';
+  const whiteListed: TxActionUid = 'balances_transferKeepAlive';
 
-  // Allow duplicate balance extrinsics.
   return a.txId === b.txId
-    ? false
-    : aFrom === bFrom && aAction === bAction && aAction !== whiteListed
-      ? a.txStatus === 'finalized'
-        ? true
-        : false
-      : true;
+    ? true
+    : aFrom === bFrom &&
+        aAction === bAction &&
+        aAction !== whiteListed &&
+        a.txStatus !== 'finalized'
+      ? true
+      : false;
 };

--- a/packages/main/src/utils/ImportUtils.ts
+++ b/packages/main/src/utils/ImportUtils.ts
@@ -1,0 +1,65 @@
+// Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { AddressesController } from '@/controller/AddressesController';
+import type {
+  AccountSource,
+  LedgerLocalAddress,
+  LocalAddress,
+} from '@polkadot-live/types/accounts';
+import type { ExtrinsicInfo } from '@polkadot-live/types/tx';
+
+/**
+ * @name getAddressNameMap
+ * @summary Get map with address as key and name as value.
+ */
+export const getAddressNameMap = () => {
+  const addressNameMap = new Map<string, string>();
+  const s_addresses = AddressesController.getAll();
+  const p_addresses = new Map<AccountSource, string>(JSON.parse(s_addresses));
+
+  for (const [source, ser] of p_addresses.entries()) {
+    switch (source) {
+      case 'vault':
+      case 'read-only':
+      case 'wallet-connect': {
+        const parsed: LocalAddress[] = JSON.parse(ser);
+        for (const { address, name } of parsed) {
+          addressNameMap.set(address, name);
+        }
+        continue;
+      }
+      case 'ledger': {
+        const parsed: LedgerLocalAddress[] = JSON.parse(ser);
+        for (const { address, name } of parsed) {
+          addressNameMap.set(address, name);
+        }
+        continue;
+      }
+      default: {
+        continue;
+      }
+    }
+  }
+
+  return addressNameMap;
+};
+
+/**
+ * @name doImportExtrinsic
+ * @summary Checks if two extrinsics are deemed different when importing.
+ */
+export const compareExtrinsics = (a: ExtrinsicInfo, b: ExtrinsicInfo) => {
+  const { action: aAction, from: aFrom } = a.actionMeta;
+  const { action: bAction, from: bFrom } = b.actionMeta;
+  const whiteListed = 'balances_transferKeepAlive';
+
+  // Allow duplicate balance extrinsics.
+  return a.txId === b.txId
+    ? false
+    : aFrom === bFrom && aAction === bAction && aAction !== whiteListed
+      ? a.txStatus === 'finalized'
+        ? true
+        : false
+      : true;
+};

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/defaults.ts
@@ -24,7 +24,7 @@ export const defaultTxMeta: TxMetaContextInterface = {
   setTxSignature: () => {},
   submitTx: () => {},
   submitMockTx: () => {},
-  updateAccountName: () => {},
+  updateAccountName: () => new Promise(() => {}),
   updateTxStatus: () => new Promise(() => {}),
   removeExtrinsic: () => new Promise(() => {}),
 };

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/defaults.ts
@@ -14,6 +14,7 @@ export const defaultTxMeta: TxMetaContextInterface = {
   getGenesisHash: () => null,
   getTxPayload: () => null,
   handleOpenCloseWcModal: () => new Promise(() => {}),
+  importExtrinsics: () => {},
   initTx: () => {},
   initTxDynamicInfo: () => {},
   onFilterChange: () => {},

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -235,7 +235,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
    */
   const initEstimatedFee = (txId: string) => {
     try {
-      const info = extrinsics.get(txId);
+      const info = extrinsicsRef.current.get(txId);
       if (!info) {
         throw new Error('Error: Extrinsic not found.');
       }
@@ -288,7 +288,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
    */
   const initTxDynamicInfo = (txId: string) => {
     try {
-      const info = extrinsics.get(txId);
+      const info = extrinsicsRef.current.get(txId);
       if (!info) {
         throw new Error('Error: Extrinsic not found.');
       }

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -515,6 +515,7 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         continue;
       }
 
+      // TODO: Update transfer extrinsic data with new name.
       extrinsicsRef.current.set(txId, {
         ...info,
         actionMeta: { ...info.actionMeta, accountName: newName },
@@ -571,32 +572,13 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
    */
   const importExtrinsics = (serialized: string) => {
     const parsed: ExtrinsicInfo[] = JSON.parse(serialized);
+    const map = new Map<string, ExtrinsicInfo>();
 
-    // Checks if two extrinsics are deemed the same.
-    const doImport = (a: ExtrinsicInfo, b: ExtrinsicInfo) => {
-      const { action: aAction, from: aFrom } = a.actionMeta;
-      const { action: bAction, from: bFrom } = b.actionMeta;
-      const whiteListed = 'balances_transferKeepAlive';
-
-      // Allow duplicate balance extrinsics.
-      return a.txId === b.txId
-        ? false
-        : aFrom === bFrom && aAction === bAction && aAction !== whiteListed
-          ? a.txStatus === 'finalized'
-            ? true
-            : false
-          : true;
-    };
-
-    let infoArr: ExtrinsicInfo[] = Array.from(extrinsicsRef.current.values());
     for (const info of parsed) {
-      const avoid = infoArr.find((b) => !doImport(info, b));
-      if (!avoid) {
-        infoArr = infoArr.concat([info]);
-        extrinsicsRef.current.set(info.txId, info);
-      }
+      map.set(info.txId, info);
     }
 
+    extrinsicsRef.current = map;
     setUpdateCache(true);
   };
 

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -17,6 +17,7 @@ import type { TxMetaContextInterface } from './types';
 import type {
   ActionMeta,
   AddressInfo,
+  ExTransferKeepAliveData,
   ExtrinsicDynamicInfo,
   ExtrinsicInfo,
   TxStatus,
@@ -85,6 +86,26 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   /**
+   * Parse serialized extrinsic data to object.
+   * Must be called before caching a received extrinsic item.
+   */
+  const parseExtrinsicData = (meta: ActionMeta) => {
+    const { action, data } = meta;
+    switch (action) {
+      case 'balances_transferKeepAlive': {
+        if (typeof data === 'string') {
+          const p_data: ExTransferKeepAliveData = JSON.parse(data);
+          meta.data = p_data;
+        }
+        return;
+      }
+      default: {
+        return;
+      }
+    }
+  };
+
+  /**
    * Fetch stored extrinsics when window loads.
    */
   useEffect(() => {
@@ -94,19 +115,27 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
         data: null,
       })) as string;
 
-      // Parse the array and set data in the extrinsics map ref.
-      const parsed: ExtrinsicInfo[] = JSON.parse(ser);
+      // Parse the array and dynamic data.
+      const parsedA: ExtrinsicInfo[] = JSON.parse(ser);
+      const parsedB = parsedA.map((info) => {
+        parseExtrinsicData(info.actionMeta);
+        return info;
+      });
 
-      for (const info of parsed) {
-        // Set status to `submitted-unknown` if app was closed before tx was finalized.
+      // Set status to `submitted-unknown` if app was closed before tx was finalized.
+      for (const info of parsedB) {
         if (info.txStatus === 'submitted' || info.txStatus === 'in_block') {
           info.txStatus = 'submitted-unkown';
 
           await window.myAPI.sendExtrinsicsTaskAsync({
-            action: 'extrinsics:persist',
-            data: { serialized: JSON.stringify(info) },
+            action: 'extrinsics:update',
+            data: {
+              serialized: JSON.stringify({ ...info, dynamicInfo: undefined }),
+            },
           });
         }
+
+        // Cache data in extrinsics ref.
         extrinsicsRef.current.set(info.txId, { ...info });
       }
 
@@ -155,6 +184,9 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
       setStateWithRef(actionMeta.from, setSelectedFilter, selectedFilterRef);
     }
 
+    // Parse data property correctly before storing state.
+    parseExtrinsicData(actionMeta);
+
     // Check if this extrinsic has already been initialized.
     const alreadyExists = Array.from(extrinsicsRef.current.values())
       .map((obj) => ({
@@ -174,7 +206,6 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
     if (alreadyExists !== undefined) {
       // Relay building extrinsic flag to app.
       window.myAPI.relayModeFlag('isBuildingExtrinsic', false);
-
       renderToast(
         'Extrinsic already added.',
         `toast-already-exists-${String(Date.now())}`,
@@ -508,25 +539,48 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
   /**
    * Update an account name assocated with an address.
    */
-  const updateAccountName = (address: string, newName: string) => {
+  const updateAccountName = async (address: string, accountName: string) => {
     // Update extrinsics state in actionMeta.
     for (const [txId, info] of Array.from(extrinsicsRef.current.entries())) {
-      if (info.actionMeta.from !== address) {
-        continue;
+      let updateStore = false;
+
+      if (info.actionMeta.action === 'balances_transferKeepAlive') {
+        // Check signer and recipient account names.
+        const data: ExTransferKeepAliveData = info.actionMeta.data;
+        const updateSigner = info.actionMeta.from === address;
+        const updateRecipient = data.recipientAddress === address;
+
+        if (updateSigner) {
+          info.actionMeta.accountName = accountName;
+        }
+        if (updateRecipient) {
+          info.actionMeta.data.recipientAccountName = accountName;
+        }
+        if (updateSigner || updateRecipient) {
+          extrinsicsRef.current.set(txId, { ...info });
+          updateStore = true;
+        }
+      } else if (info.actionMeta.from === address) {
+        // Update signer account name.
+        info.actionMeta.accountName = accountName;
+        extrinsicsRef.current.set(txId, { ...info });
+        updateStore = true;
       }
 
-      // TODO: Update transfer extrinsic data with new name.
-      extrinsicsRef.current.set(txId, {
-        ...info,
-        actionMeta: { ...info.actionMeta, accountName: newName },
-      });
+      // Update data in store.
+      if (updateStore) {
+        await window.myAPI.sendExtrinsicsTaskAsync({
+          action: 'extrinsics:update',
+          data: { serialized: JSON.stringify(info) },
+        });
+      }
     }
 
     // Update addresses info state.
     setAddressesInfo((prev) => {
       const updated = prev.map((i) => {
         if (i.address === address) {
-          return { ...i, accountName: newName };
+          return { ...i, accountName };
         } else {
           return { ...i };
         }
@@ -575,6 +629,8 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
     const map = new Map<string, ExtrinsicInfo>();
 
     for (const info of parsed) {
+      // Parse extrinsic dynamic data before caching state.
+      parseExtrinsicData(info.actionMeta);
       map.set(info.txId, info);
     }
 

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/types.ts
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/types.ts
@@ -20,6 +20,7 @@ export interface TxMetaContextInterface {
   getGenesisHash: (txUid: string) => AnyJson | null;
   getTxPayload: (txUid: string) => Uint8Array | null;
   handleOpenCloseWcModal: (open: boolean, uri?: string) => Promise<void>;
+  importExtrinsics: (serialized: string) => void;
   initTx: (actionMeta: ActionMeta) => void;
   initTxDynamicInfo: (txId: string) => void;
   onFilterChange: (val: string) => void;

--- a/packages/renderer/src/renderer/contexts/action/TxMeta/types.ts
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/types.ts
@@ -30,7 +30,7 @@ export interface TxMetaContextInterface {
   setTxSignature: (txId: string, s: AnyJson) => void;
   submitTx: (txId: string) => void;
   submitMockTx: (txId: string) => void;
-  updateAccountName: (address: string, newName: string) => void;
+  updateAccountName: (address: string, accountName: string) => Promise<void>;
   updateTxStatus: (txId: string, txStatus: TxStatus) => Promise<void>;
   removeExtrinsic: (info: ExtrinsicInfo) => Promise<void>;
 }

--- a/packages/renderer/src/renderer/contexts/main/DataBackup/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/DataBackup/index.tsx
@@ -125,10 +125,10 @@ export const DataBackupProvider = ({
           // Import serialized data.
           const { serialized: s } = response.data;
           await importAddressData(s, handleImportAddress, handleRemoveAddress);
-          await importExtrinsicsData(s);
           await importEventData(s);
           await importIntervalData(s);
           await importAccountTaskData(s);
+          await importExtrinsicsData(s);
 
           postToSettings('settings:render:toast', {
             success: response.result,
@@ -245,14 +245,14 @@ export const DataBackupProvider = ({
       return;
     }
 
-    // Persist new extrinsics to store in main process.
-    await window.myAPI.sendExtrinsicsTaskAsync({
+    const s_extrinsics_synced = (await window.myAPI.sendExtrinsicsTaskAsync({
       action: 'extrinsics:import',
       data: { serialized: s_extrinsics },
-    });
+    })) as string;
 
-    // Update extrinsics state in extrinsics window.
-    postToExtrinsics('action:tx:import', { serialized: s_extrinsics });
+    postToExtrinsics('action:tx:import', {
+      serialized: s_extrinsics_synced,
+    });
   };
 
   /// Extract event data from an imported text file and send to application.

--- a/packages/renderer/src/renderer/contexts/main/DataBackup/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/DataBackup/index.tsx
@@ -10,6 +10,7 @@ import { SubscriptionsController } from '@ren/controller/SubscriptionsController
 import { getAddressChainId } from '@app/Utils';
 import {
   getFromBackupFile,
+  postToExtrinsics,
   postToImport,
   postToOpenGov,
   postToSettings,
@@ -124,6 +125,7 @@ export const DataBackupProvider = ({
           // Import serialized data.
           const { serialized: s } = response.data;
           await importAddressData(s, handleImportAddress, handleRemoveAddress);
+          await importExtrinsicsData(s);
           await importEventData(s);
           await importIntervalData(s);
           await importAccountTaskData(s);
@@ -234,6 +236,23 @@ export const DataBackupProvider = ({
       // Update account list state.
       setAddresses(AccountsController.getAllFlattenedAccountData());
     }
+  };
+
+  /// Extract extrinsics data from an imported text file and send to application.
+  const importExtrinsicsData = async (serialized: string): Promise<void> => {
+    const s_extrinsics = getFromBackupFile('extrinsics', serialized);
+    if (!s_extrinsics) {
+      return;
+    }
+
+    // Persist new extrinsics to store in main process.
+    await window.myAPI.sendExtrinsicsTaskAsync({
+      action: 'extrinsics:import',
+      data: { serialized: s_extrinsics },
+    });
+
+    // TODO: Set extrinsics state in extrinsics window.
+    postToExtrinsics('action:tx:import', { serialized: s_extrinsics });
   };
 
   /// Extract event data from an imported text file and send to application.

--- a/packages/renderer/src/renderer/contexts/main/DataBackup/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/DataBackup/index.tsx
@@ -251,7 +251,7 @@ export const DataBackupProvider = ({
       data: { serialized: s_extrinsics },
     });
 
-    // TODO: Set extrinsics state in extrinsics window.
+    // Update extrinsics state in extrinsics window.
     postToExtrinsics('action:tx:import', { serialized: s_extrinsics });
   };
 

--- a/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
@@ -16,6 +16,7 @@ export const useActionMessagePorts = () => {
    */
   const {
     handleOpenCloseWcModal,
+    importExtrinsics,
     initTx,
     notifyInvalidExtrinsic,
     setEstimatedFee,
@@ -33,6 +34,15 @@ export const useActionMessagePorts = () => {
   const handleInitAction = (ev: MessageEvent) => {
     const data: ActionMeta = JSON.parse(ev.data.data);
     initTx(data);
+  };
+
+  /**
+   * @name handleTxImport
+   * @summary Import extrinsics data from a backup file.
+   */
+  const handleTxImport = (ev: MessageEvent) => {
+    const { serialized } = ev.data.data;
+    importExtrinsics(serialized);
   };
 
   /**
@@ -117,8 +127,7 @@ export const useActionMessagePorts = () => {
               break;
             }
             case 'action:tx:import': {
-              // TODO: Import from backup file data.
-              console.log('> Import from backup...');
+              handleTxImport(ev);
               break;
             }
             case 'action:tx:report:data': {

--- a/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
@@ -49,7 +49,7 @@ export const useActionMessagePorts = () => {
    * @name handleAccountRename
    * @summary Update extrinsics and address state to reflect an updated account name.
    */
-  const handleAccountRename = (ev: MessageEvent) => {
+  const handleAccountRename = async (ev: MessageEvent) => {
     interface Target {
       address: string;
       chainId: ChainID;
@@ -57,7 +57,7 @@ export const useActionMessagePorts = () => {
     }
 
     const { address, newName }: Target = ev.data.data;
-    updateAccountName(address, newName);
+    await updateAccountName(address, newName);
   };
 
   /**
@@ -139,7 +139,7 @@ export const useActionMessagePorts = () => {
               break;
             }
             case 'action:account:rename': {
-              handleAccountRename(ev);
+              await handleAccountRename(ev);
               break;
             }
             case 'action:tx:setEstimatedFee': {

--- a/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useActionMessagePorts.ts
@@ -116,6 +116,11 @@ export const useActionMessagePorts = () => {
               handleInitAction(ev);
               break;
             }
+            case 'action:tx:import': {
+              // TODO: Import from backup file data.
+              console.log('> Import from backup...');
+              break;
+            }
             case 'action:tx:report:data': {
               handleTxReportData(ev);
               break;

--- a/packages/renderer/src/renderer/screens/Action/ExtrinsicItemContent.tsx
+++ b/packages/renderer/src/renderer/screens/Action/ExtrinsicItemContent.tsx
@@ -33,7 +33,7 @@ export const ExtrinsicItemContent = ({
 }: ExtrinsicItemContentProps): React.ReactNode => {
   const { isBuildingExtrinsic, darkMode } = useConnections();
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
-  const { chainId, data: serData } = info.actionMeta;
+  const { chainId, data } = info.actionMeta;
 
   switch (info.actionMeta.action) {
     case 'balances_transferKeepAlive': {
@@ -41,7 +41,7 @@ export const ExtrinsicItemContent = ({
         sendAmount: planck,
         recipientAccountName,
         recipientAddress,
-      }: ExTransferKeepAliveData = JSON.parse(serData);
+      }: ExTransferKeepAliveData = data;
 
       const units = chainUnits(chainId);
       const bnPlanck = new BigNumber(planck);
@@ -105,7 +105,7 @@ export const ExtrinsicItemContent = ({
       );
     }
     case 'nominationPools_pendingRewards_bond': {
-      const bnPendingRewardsPlanck = new BigNumber(serData.extra);
+      const bnPendingRewardsPlanck = new BigNumber(data.extra);
       const bnUnit = planckToUnit(bnPendingRewardsPlanck, chainUnits(chainId));
       const fmtAmount = (
         <b>{`${bnUnit.toString()} ${chainCurrency(chainId)}`}</b>
@@ -130,7 +130,7 @@ export const ExtrinsicItemContent = ({
       );
     }
     case 'nominationPools_pendingRewards_withdraw': {
-      const bnPendingRewardsPlanck = new BigNumber(serData.extra);
+      const bnPendingRewardsPlanck = new BigNumber(data.extra);
       const bnUnit = planckToUnit(bnPendingRewardsPlanck, chainUnits(chainId));
       const fmtAmount = (
         <b>{`${bnUnit.toString()} ${chainCurrency(chainId)}`}</b>

--- a/packages/renderer/src/renderer/screens/Action/Helpers.tsx
+++ b/packages/renderer/src/renderer/screens/Action/Helpers.tsx
@@ -41,8 +41,8 @@ export const getExtrinsicTitle = (info: ExtrinsicInfo) => {
 
   switch (action) {
     case 'balances_transferKeepAlive': {
-      const { chainId, data: serData } = info.actionMeta;
-      const { sendAmount }: ExTransferKeepAliveData = JSON.parse(serData);
+      const { chainId, data } = info.actionMeta;
+      const { sendAmount }: ExTransferKeepAliveData = data;
       const bnPlanck = new BigNumber(sendAmount);
       const bnUnit = planckToUnit(bnPlanck, chainUnits(chainId));
 

--- a/packages/renderer/src/renderer/utils/ImportUtils.ts
+++ b/packages/renderer/src/renderer/utils/ImportUtils.ts
@@ -152,6 +152,14 @@ export const getFromBackupFile = (
 };
 
 /**
+ * @name postToExtrinsics
+ * @summary Utility to post a message to the extrinsics window.
+ * (main renderer)
+ */
+export const postToExtrinsics = (task: string, dataObj: AnyData) => {
+  ConfigRenderer.portToAction?.postMessage({ task, data: dataObj });
+};
+/**
  * @name postToImport
  * @summary Utility to post a message to the import window.
  * (main renderer)

--- a/packages/types/src/communication.ts
+++ b/packages/types/src/communication.ts
@@ -67,6 +67,7 @@ export interface IpcTask {
     | 'events:import'
     // Extrinsics
     | 'extrinsics:getAll'
+    | 'extrinsics:import'
     | 'extrinsics:persist'
     | 'extrinsics:remove'
     | 'extrinsics:update'


### PR DESCRIPTION
Implementation of exporting extrinsics data to a backup file, and importing extrinsics backup data back into Polkdaot Live.

Account renames are synced with dynamic transaction data with cached account names.