### PR TITLE
fix: debugging

### DIFF
--- a/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
+++ b/packages/renderer/src/renderer/contexts/action/TxMeta/index.tsx
@@ -110,10 +110,10 @@ export const TxMetaProvider = ({ children }: { children: React.ReactNode }) => {
    */
   useEffect(() => {
     const fetchExtrinsics = async () => {
-      const ser = (await window.myAPI.sendExtrinsicsTaskAsync({
+      const ser = ((await window.myAPI.sendExtrinsicsTaskAsync({
         action: 'extrinsics:getAll',
         data: null,
-      })) as string;
+      })) || '[]') as string;
 
       // Parse the array and dynamic data.
       const parsedA: ExtrinsicInfo[] = JSON.parse(ser);

--- a/packages/renderer/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -33,6 +33,7 @@ export const Accounts = ({
   setBreadcrumb,
   setSection,
   setTypeClicked,
+  setSelectedAccount,
 }: AccountsProps) => {
   const { showDebuggingSubscriptions } = useAppSettings();
   const { setRenderedSubscriptions, setDynamicIntervalTasks } = useManage();
@@ -143,6 +144,8 @@ export const Accounts = ({
     setTypeClicked('account');
     setBreadcrumb(accountName);
     setSection(1);
+
+    setSelectedAccount(address);
   };
 
   /// Set interval subscription tasks state when chain is clicked.

--- a/packages/renderer/src/renderer/screens/Home/Manage/Accounts.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Manage/Accounts.tsx
@@ -144,7 +144,6 @@ export const Accounts = ({
     setTypeClicked('account');
     setBreadcrumb(accountName);
     setSection(1);
-
     setSelectedAccount(address);
   };
 

--- a/packages/renderer/src/renderer/screens/Home/Manage/Permissions.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Manage/Permissions.tsx
@@ -45,6 +45,7 @@ import { ChevronDownIcon } from '@radix-ui/react-icons';
 export const Permissions = ({
   breadcrumb,
   section,
+  selectedAccount,
   typeClicked,
   setSection,
 }: PermissionsProps) => {
@@ -95,6 +96,9 @@ export const Permissions = ({
     new Map<TaskCategory, SubscriptionTask[]>(getCategorised())
   );
 
+  // Mechanism to trigger re-caculating the accordion value AFTER the account state is updated.
+  const [updateAccordionValue, setUpdateAccordionValue] = useState(false);
+
   /// Accordion state.
   const [accordionValueAccounts, setAccordionValueAccounts] = useState<
     string[]
@@ -135,23 +139,31 @@ export const Permissions = ({
     setCategorisedTasks(getCategorised());
     if (section === 1 && renderedSubscriptions.type == '') {
       setSection(0);
+    } else if (typeClicked === 'chain') {
+      setAccordionValueChains(['Chain']);
     }
   }, [renderedSubscriptions]);
 
-  /// Close diasbled subscription groups when loading account or chain subscriptions.
+  /// Trigger updating the accordion value when a new account is selected.
   useEffect(() => {
-    if (typeClicked === 'account') {
-      setAccordionValueAccounts([
-        ...Array.from(categorisedTasks.values())
-          .filter((tasks) =>
-            tasks.length === 0 ? false : !showGroupTooltip(tasks[0])
-          )
-          .map((tasks) => tasks[0].category),
-      ]);
-    } else {
-      setAccordionValueChains(['Chain']);
+    setUpdateAccordionValue(true);
+  }, [selectedAccount]);
+
+  /// Close disabled subscription groups when loading account subscriptions.
+  useEffect(() => {
+    if (updateAccordionValue) {
+      if (typeClicked === 'account') {
+        setAccordionValueAccounts([
+          ...Array.from(categorisedTasks.values())
+            .filter((tasks) =>
+              tasks.length === 0 ? false : !showGroupTooltip(tasks[0])
+            )
+            .map((tasks) => tasks[0].category),
+        ]);
+      }
+      setUpdateAccordionValue(false);
     }
-  }, [categorisedTasks]);
+  }, [updateAccordionValue]);
 
   /// Handle a subscription toggle and update rendered subscription state.
   const handleToggle = async (task: SubscriptionTask) => {

--- a/packages/renderer/src/renderer/screens/Home/Manage/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Manage/index.tsx
@@ -23,6 +23,8 @@ export const Manage = ({ addresses }: ManageProps) => {
   // Whether the user has clicked on an account or chain.
   const [typeClicked, setTypeClicked] = useState<SubscriptionTaskType>('');
 
+  const [selectedAccount, setSelectedAccount] = useState<string | null>(null);
+
   return (
     <div
       style={{
@@ -65,6 +67,7 @@ export const Manage = ({ addresses }: ManageProps) => {
               setBreadcrumb={setBreadcrumb}
               addresses={addresses}
               setTypeClicked={setTypeClicked}
+              setSelectedAccount={setSelectedAccount}
             />
           </Wrapper>
         </div>
@@ -73,6 +76,7 @@ export const Manage = ({ addresses }: ManageProps) => {
           <Permissions
             setSection={setSection}
             section={section}
+            selectedAccount={selectedAccount}
             breadcrumb={breadcrumb}
             typeClicked={typeClicked}
           />

--- a/packages/renderer/src/renderer/screens/Home/Manage/types.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Manage/types.tsx
@@ -18,11 +18,13 @@ export interface AccountsProps {
   setBreadcrumb: (s: string) => void;
   setSection: (n: number) => void;
   setTypeClicked: (t: SubscriptionTaskType) => void;
+  setSelectedAccount: (a: string | null) => void;
 }
 
 export interface PermissionsProps {
   breadcrumb: string;
   section: number;
+  selectedAccount: string | null;
   typeClicked: SubscriptionTaskType;
   setSection: (n: number) => void;
 }


### PR DESCRIPTION
A couple of bug fixes.

- Handle the case when zero extrinsics are fetched from the store when loading the extrinsics window.
- The accordion that renders account subscriptions doesn't re-open when a category switch is clicked. 