### PR TITLE
feat: transfer network amount limits

### DIFF
--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -173,6 +173,11 @@ export const Send: React.FC = () => {
       return;
     }
 
+    // NOTE: Disable Polkadot transfers in alpha releases.
+    if (senderNetwork === 'Polkadot') {
+      return;
+    }
+
     setSummaryComplete(true);
 
     // Data for action meta.
@@ -376,7 +381,13 @@ export const Send: React.FC = () => {
       if (!addresses || addresses.length === 0) {
         continue;
       }
-      result = result.concat(addresses as LocalAddress[]);
+
+      // NOTE: Disable Polkadot transfers in alpha releases.
+      const filtered = (addresses as LocalAddress[]).filter(
+        ({ address }) => getAddressChainId(address) !== 'Polkadot'
+      );
+
+      result = result.concat(filtered);
     }
     return result.sort((a, b) => a.name.localeCompare(b.name));
   };
@@ -414,6 +425,8 @@ export const Send: React.FC = () => {
     receiver === null ||
     sendAmount === '0' ||
     sendAmount === '' ||
+    // NOTE: Disable Polkadot transfers in alpha releases.
+    senderNetwork === 'Polkadot' ||
     !validAmount ||
     summaryComplete;
 

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -19,7 +19,8 @@ import {
   faBurst,
   faCheck,
   faChevronRight,
-  faCircleInfo,
+  faInfoCircle,
+  faWarning,
 } from '@fortawesome/free-solid-svg-icons';
 import { getSpendableBalance } from '@ren/utils/AccountUtils';
 import { getBalanceText } from '@ren/utils/TextUtils';
@@ -483,15 +484,31 @@ export const Send: React.FC = () => {
     <FlexColumn style={{ padding: '2rem 1rem' }}>
       <MainHeading>Send</MainHeading>
 
-      <UI.InfoCard icon={faCircleInfo}>
-        <span style={{ lineHeight: '1.5rem' }}>
-          Send native tokens to a recipient on the same network.
-        </span>
-      </UI.InfoCard>
+      <FlexColumn $rowGap={'0.75rem'}>
+        <UI.InfoCard
+          icon={faWarning}
+          style={{ color: 'var(--accent-warning)' }}
+        >
+          <FlexColumn>
+            <div
+              style={{ lineHeight: '1.5rem', color: 'var(--accent-warning)' }}
+            >
+              This alpha release supports native transfers of up to <b>100</b>{' '}
+              tokens on <b>Kusama</b> and <b>Westend</b> networks.
+            </div>
+          </FlexColumn>
+        </UI.InfoCard>
 
-      <div style={{ marginBottom: '1rem' }}>
-        <ProgressBar value={progress} max={100} />
-      </div>
+        <UI.InfoCard icon={faInfoCircle} style={{ marginTop: '0' }}>
+          <FlexColumn>
+            <div>Send native tokens to a recipient on the same network.</div>
+          </FlexColumn>
+        </UI.InfoCard>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <ProgressBar value={progress} max={100} />
+        </div>
+      </FlexColumn>
 
       <UI.AccordionWrapper $onePart={true}>
         <Accordion.Root

--- a/packages/renderer/src/renderer/screens/Home/Send/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/Send/index.tsx
@@ -48,6 +48,8 @@ import type { ChainID } from '@polkadot-live/types/chains';
 import type { ChangeEvent } from 'react';
 import type { SendAccordionValue } from './types';
 
+const TOKEN_TRANSFER_LIMIT = 100;
+
 export const Send: React.FC = () => {
   /**
    * Addresses fetched from main process.
@@ -335,6 +337,13 @@ export const Send: React.FC = () => {
         return;
       }
 
+      // NOTE: Limit send amount to 100 tokens in alpha releases.
+      if (Number(amount) > TOKEN_TRANSFER_LIMIT) {
+        setSendAmount(amount);
+        setValidAmount(false);
+        return;
+      }
+
       // Check if send amount is less than spendable amount.
       const units = chainUnits(senderNetwork);
       const bnAmountAsPlanck = unitToPlanck(amount, units);
@@ -425,6 +434,8 @@ export const Send: React.FC = () => {
     receiver === null ||
     sendAmount === '0' ||
     sendAmount === '' ||
+    // NOTE: Limit token transfers to 100 tokens in alpha releases.
+    (!isNaN(Number(sendAmount)) && Number(sendAmount) > TOKEN_TRANSFER_LIMIT) ||
     // NOTE: Disable Polkadot transfers in alpha releases.
     senderNetwork === 'Polkadot' ||
     !validAmount ||


### PR DESCRIPTION
Implements native token transfer limits while Polkadot Live is in alpha status:
- Transfer extrinsics supported on **Kusama** and **Westend** networks (Polkadot coming soon)
- Transfer a maximum of **100** native tokens