### PR TITLE
chore: show disclaimer on initial launch

### DIFF
--- a/packages/main/src/config/main.ts
+++ b/packages/main/src/config/main.ts
@@ -10,6 +10,7 @@ import type { Rectangle, Tray } from 'electron';
 export class Config {
   // Storage keys.
   private static _chainSubscriptionsStorageKey = 'chain_subscriptions';
+  private static _showDisclaimerKey = 'show_disclaimer';
   private static _settingsStorageKey = 'app_settings';
   private static _workspacesStorageKey = 'developer_console_workspaces';
 
@@ -96,6 +97,10 @@ export class Config {
   // Get local storage key for chain subscription tasks.
   static getChainSubscriptionsStorageKey(): string {
     return Config._chainSubscriptionsStorageKey;
+  }
+  // Get local storage key for the disclaimer flag.
+  static getShowDisclaimerStorageKey(): string {
+    return Config._showDisclaimerKey;
   }
 
   // Get local storage key for subscription tasks of a particular address.

--- a/packages/main/src/main.ts
+++ b/packages/main/src/main.ts
@@ -181,6 +181,20 @@ app.whenReady().then(async () => {
   });
 
   /**
+   * Disclaimer
+   */
+  ipcMain.handle('main:disclaimer:show', async () => {
+    const key = ConfigMain.getShowDisclaimerStorageKey();
+
+    if (!store.get(key, false)) {
+      store.set(key, true);
+      return true;
+    } else {
+      return false;
+    }
+  });
+
+  /**
    * Addresses
    */
 

--- a/packages/preload/src/preload.ts
+++ b/packages/preload/src/preload.ts
@@ -105,6 +105,9 @@ export const API: PreloadAPI = {
 
   getOsPlatform: async () => await ipcRenderer.invoke('app:platform:get'),
 
+  getShowDisclaimer: async () =>
+    await ipcRenderer.invoke('main:disclaimer:show'),
+
   copyToClipboard: async (text: string) =>
     await ipcRenderer.invoke('main:clipboard:copy', text),
 

--- a/packages/renderer/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -41,7 +41,7 @@ export const BootstrappingProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [appLoading, setAppLoading] = useState(false);
+  const [appLoading, setAppLoading] = useState(true);
   const [isAborting, setIsAborting] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
 

--- a/packages/renderer/src/renderer/screens/Home/index.tsx
+++ b/packages/renderer/src/renderer/screens/Home/index.tsx
@@ -9,6 +9,7 @@ import { useBootstrapping } from '@app/contexts/main/Bootstrapping';
 import { useCogMenu } from '@app/contexts/main/CogMenu';
 import { useConnections } from '@app/contexts/common/Connections';
 import { useEvents } from '@app/contexts/main/Events';
+import { useHelp } from '@app/contexts/common/Help';
 import { useInitIpcHandlers } from '@app/hooks/useInitIpcHandlers';
 import { useMainMessagePorts } from '@app/hooks/useMainMessagePorts';
 import { Classic } from '@theme-toggles/react';
@@ -47,6 +48,7 @@ export const Home = () => {
   const { getAddresses } = useAddresses();
   const { addEvent, markStaleEvent, removeOutdatedEvents } = useEvents();
   const { darkMode } = useConnections();
+  const { openHelp } = useHelp();
 
   const {
     dockToggled,
@@ -127,13 +129,27 @@ export const Home = () => {
       }
     );
 
-    const initPlatform = async () => {
+    // Async tasks.
+    const initTasks = async () => {
+      // Get OS platform.
       const osPlatform = await window.myAPI.getOsPlatform();
       setPlatform(osPlatform);
     };
 
-    initPlatform();
+    initTasks();
   }, []);
+
+  useEffect(() => {
+    // Show disclaimer on initial launch.
+    const disclaimerTask = async () => {
+      const showDisclaimer = await window.myAPI.getShowDisclaimer();
+      showDisclaimer && openHelp('help:docs:disclaimer');
+    };
+
+    if (!appLoading) {
+      disclaimerTask();
+    }
+  }, [appLoading]);
 
   /// Handle header dock toggle.
   // TODO: Move to file.

--- a/packages/types/src/preload.ts
+++ b/packages/types/src/preload.ts
@@ -18,6 +18,7 @@ import type { PersistedSettings } from './settings';
 export interface PreloadAPI {
   getWindowId: () => string;
   getOsPlatform: () => Promise<string>;
+  getShowDisclaimer: () => Promise<boolean>;
   copyToClipboard: (text: string) => Promise<void>;
 
   rawAccountTask: (task: IpcTask) => Promise<string | void>;


### PR DESCRIPTION
Displays the Polkadot Live disclaimer when the app is launched for the first time.