### PR TITLE
feat: ongoing referenda iteration

### DIFF
--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/defaults.ts
@@ -6,7 +6,9 @@ import type { PolkassemblyContextInterface } from './types';
 
 export const defaultPolkassemblyContext: PolkassemblyContextInterface = {
   usePolkassemblyApi: true,
+  fetchingMetadata: false,
   getProposal: () => null,
   fetchProposals: () => new Promise(() => {}),
+  setFetchingMetadata: () => {},
   setUsePolkassemblyApi: () => {},
 };

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/defaults.ts
@@ -7,6 +7,7 @@ import type { PolkassemblyContextInterface } from './types';
 export const defaultPolkassemblyContext: PolkassemblyContextInterface = {
   usePolkassemblyApi: true,
   fetchingMetadata: false,
+  clearProposals: () => {},
   getProposal: () => null,
   fetchProposals: () => new Promise(() => {}),
   setFetchingMetadata: () => {},

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import * as defaults from './defaults';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import axios from 'axios';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type {
@@ -34,7 +34,6 @@ export const PolkassemblyProvider = ({
     fetchSetting();
   }, []);
 
-  const proposalsRef = useRef<PolkassemblyProposal[]>([]);
   const [proposalsMap, setProposalsMap] = useState(
     new Map<ChainID, PolkassemblyProposal[]>()
   );
@@ -87,7 +86,6 @@ export const PolkassemblyProvider = ({
 
     // Append fetched proposals to existing cached data.
     setProposalsMap((pv) => pv.set(chainId, [...cached, ...fetched]));
-    proposalsRef.current = [...cached, ...fetched];
   };
 
   // Get polkassembly proposal via referendum id.
@@ -101,11 +99,17 @@ export const PolkassemblyProvider = ({
           .find(({ postId }) => postId === referendumId) || null
       : null;
 
+  // Clear proposal data for a particular chain.
+  const clearProposals = (chainId: ChainID) => {
+    proposalsMap.set(chainId, []);
+  };
+
   return (
     <PolkassemblyContext.Provider
       value={{
         usePolkassemblyApi,
         fetchingMetadata,
+        clearProposals,
         getProposal,
         fetchProposals,
         setFetchingMetadata,

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -23,6 +23,7 @@ export const PolkassemblyProvider = ({
   children: React.ReactNode;
 }) => {
   const [usePolkassemblyApi, setUsePolkassemblyApi] = useState<boolean>(false);
+  const [fetchingMetadata, setFetchingMetadata] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchSetting = async () => {
@@ -53,6 +54,8 @@ export const PolkassemblyProvider = ({
     if (filtered.length === 0) {
       return;
     }
+
+    setFetchingMetadata(true);
 
     // Create Axios instance with base URL to Polkassembly API.
     const axiosApi = axios.create({
@@ -102,8 +105,10 @@ export const PolkassemblyProvider = ({
     <PolkassemblyContext.Provider
       value={{
         usePolkassemblyApi,
+        fetchingMetadata,
         getProposal,
         fetchProposals,
+        setFetchingMetadata,
         setUsePolkassemblyApi,
       }}
     >

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/index.tsx
@@ -6,8 +6,8 @@ import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type {
-  ActiveReferendaInfo,
   PolkassemblyProposal,
+  ReferendaInfo,
 } from '@polkadot-live/types/openGov';
 import type { PolkassemblyContextInterface } from './types';
 
@@ -41,7 +41,7 @@ export const PolkassemblyProvider = ({
   // Fetch proposal data after referenda have been loaded in referenda context.
   const fetchProposals = async (
     chainId: ChainID,
-    referenda: ActiveReferendaInfo[]
+    referenda: ReferendaInfo[]
   ) => {
     // Create Axios instance with base URL to Polkassembly API.
     const axiosApi = axios.create({
@@ -53,9 +53,9 @@ export const PolkassemblyProvider = ({
 
     // Make asynchronous requests to Polkassembly API for each referenda.
     const results = await Promise.all(
-      referenda.map(({ referendaId }) =>
+      referenda.map(({ refId }) =>
         axiosApi.get(
-          `/posts/on-chain-post?postId=${referendaId}&proposalType=referendums_v2`,
+          `/posts/on-chain-post?postId=${refId}&proposalType=referendums_v2`,
           {
             maxBodyLength: Infinity,
             headers: { 'x-network': network },

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -9,6 +9,7 @@ import type {
 
 export interface PolkassemblyContextInterface {
   usePolkassemblyApi: boolean;
+  fetchingMetadata: boolean;
   getProposal: (
     chainId: ChainID,
     referendumId: number
@@ -17,5 +18,6 @@ export interface PolkassemblyContextInterface {
     chainId: ChainID,
     referenda: ReferendaInfo[]
   ) => Promise<void>;
+  setFetchingMetadata: React.Dispatch<React.SetStateAction<boolean>>;
   setUsePolkassemblyApi: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -3,7 +3,7 @@
 
 import type { ChainID } from '@polkadot-live/types/chains';
 import type {
-  ActiveReferendaInfo,
+  ReferendaInfo,
   PolkassemblyProposal,
 } from '@polkadot-live/types/openGov';
 
@@ -15,7 +15,7 @@ export interface PolkassemblyContextInterface {
   ) => PolkassemblyProposal | null;
   fetchProposals: (
     chainId: ChainID,
-    referenda: ActiveReferendaInfo[]
+    referenda: ReferendaInfo[]
   ) => Promise<void>;
   setUsePolkassemblyApi: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/packages/renderer/src/renderer/contexts/openGov/Polkassembly/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Polkassembly/types.ts
@@ -10,6 +10,7 @@ import type {
 export interface PolkassemblyContextInterface {
   usePolkassemblyApi: boolean;
   fetchingMetadata: boolean;
+  clearProposals: (chainId: ChainID) => void;
   getProposal: (
     chainId: ChainID,
     referendumId: number

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -16,7 +16,6 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   setFetchingReferenda: (f) => {},
   getSortedActiveReferenda: (d) => [],
   getTrackFilter: () => null,
-  getCategorisedReferenda: (d) => new Map(),
   updateHasFetchedReferenda: () => {},
   updateTrackFilter: () => {},
 

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -23,6 +23,7 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   activePage: 1,
   activePageCount: 1,
   activePagedReferenda: [],
+  showPageEllipsis: () => false,
   getCurPages: () => [],
   setActivePage: () => {},
   setRefTrigger: () => {},

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/defaults.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/defaults.ts
@@ -19,4 +19,12 @@ export const defaultReferendaContext: ReferendaContextInterface = {
   getCategorisedReferenda: (d) => new Map(),
   updateHasFetchedReferenda: () => {},
   updateTrackFilter: () => {},
+
+  // new
+  activePage: 1,
+  activePageCount: 1,
+  activePagedReferenda: [],
+  getCurPages: () => [],
+  setActivePage: () => {},
+  setRefTrigger: () => {},
 };

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -3,7 +3,14 @@
 
 import * as defaults from './defaults';
 import { Config as ConfigOpenGov } from '@ren/config/processes/openGov';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useConnections } from '@app/contexts/common/Connections';
 import { usePolkassembly } from '../Polkassembly';
 import { setStateWithRef } from '@w3ux/utils';
@@ -93,18 +100,22 @@ export const ReferendaProvider = ({
     return items.slice(start, end);
   };
 
-  // 1, 2 ... n-1, n
-  const getCurPages = (): number[] => {
-    const totalPages = activePageCount;
+  // Get array of current pagination numbers.
+  const getCurPages = useCallback((): number[] => {
+    const count = activePageCount;
+    const cur = activePage;
 
-    if (totalPages <= 4) {
-      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    if (count <= 4) {
+      return Array.from({ length: count }, (_, i) => i + 1);
     } else {
-      const start = [activePage, activePage + 1];
-      const end = [totalPages - 1, totalPages];
-      return [...start, ...end];
+      const start = [1, 2];
+      const end = [count - 1, count];
+      const insert = !start.includes(cur) && !end.includes(cur);
+      return insert ? [...start, cur, ...end] : [...start, ...end];
     }
-  };
+  }, [activePage, activePageCount]);
+
+  const showPageEllipsis = () => getCurPages().length === 5;
 
   // Mechanism to update listed referenda after track filter state set.
   useEffect(() => {
@@ -290,6 +301,7 @@ export const ReferendaProvider = ({
         activePage,
         activePageCount,
         activePagedReferenda,
+        showPageEllipsis,
         getCurPages,
         setActivePage,
         setRefTrigger,

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -4,7 +4,6 @@
 import * as defaults from './defaults';
 import { Config as ConfigOpenGov } from '@ren/config/processes/openGov';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
-import { getOrderedOrigins } from '@app/utils/openGovUtils';
 import { useConnections } from '@app/contexts/common/Connections';
 import { usePolkassembly } from '../Polkassembly';
 import { setStateWithRef } from '@w3ux/utils';
@@ -214,65 +213,6 @@ export const ReferendaProvider = ({
     }
   };
 
-  /// Get categorized referenda, sorted desc or asc in each category.
-  const getCategorisedReferenda = (
-    desc: boolean,
-    otherReferenda?: ReferendaInfo[]
-  ) => {
-    const map = new Map<string, ReferendaInfo[]>();
-
-    // Insert keys into map in the desired order.
-    for (const origin of getOrderedOrigins()) {
-      map.set(origin, []);
-    }
-
-    // Populate map with referenda data.
-    const referenda = referendaMap.get(activeReferendaChainRef.current);
-    const dataSet = otherReferenda || referenda || [];
-
-    for (const ref of dataSet) {
-      if (!ongoingStatuses.includes(ref.refStatus)) {
-        continue;
-      }
-
-      const info = ref.info as RefDeciding;
-      const originData = info.origin;
-      const origin =
-        'system' in originData
-          ? String(originData.system)
-          : String(originData.Origins);
-
-      const state = map.get(origin) || [];
-      state.push(ref);
-      map.set(origin, state);
-    }
-
-    // Sort referenda in each origin according to `desc` argument.
-    for (const [origin, refs] of map.entries()) {
-      const filterFn = (t: ReferendaInfo) => {
-        const info = t.info as RefDeciding;
-        const cur = trackFilter.get(activeReferendaChainRef.current) || null;
-        return cur === null ? true : info.track === cur;
-      };
-
-      map.set(
-        origin,
-        refs
-          .filter(filterFn)
-          .sort((a, b) => (desc ? b.refId - a.refId : a.refId - b.refId))
-      );
-    }
-
-    // Remove keys with no referenda.
-    for (const [origin, infos] of map.entries()) {
-      if (!infos.length) {
-        map.delete(origin);
-      }
-    }
-
-    return map;
-  };
-
   // Update the fetched flag state and ref.
   const updateHasFetchedReferenda = (chainId: ChainID) => {
     if (chainId !== activeReferendaChainId) {
@@ -320,7 +260,6 @@ export const ReferendaProvider = ({
         setReferendaMap,
         setFetchingReferenda,
         getSortedActiveReferenda,
-        getCategorisedReferenda,
         updateHasFetchedReferenda,
         updateTrackFilter,
         // new

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -116,24 +116,39 @@ export const ReferendaProvider = ({
 
   // Fetch referenda for new page.
   useEffect(() => {
-    setActivePagedReferenda(getActiveReferendaPage(activePage));
+    const execute = async () => {
+      const page = getActiveReferendaPage(activePage);
+      await fetchFromPolkassembly(page);
+      setActivePagedReferenda(page);
+    };
+    execute();
   }, [activePage]);
 
   // Triggered when a track filter is selected and when referenda are received.
   useEffect(() => {
-    if (refTrigger) {
-      setActivePageCount(getActivePageCount());
-      setActivePagedReferenda(getActiveReferendaPage(activePage));
-      setRefTrigger(false);
-    }
+    const execute = async () => {
+      if (refTrigger) {
+        const page = getActiveReferendaPage(activePage);
+        await fetchFromPolkassembly(page);
+        setActivePagedReferenda(page);
+        setActivePageCount(getActivePageCount());
+        setRefTrigger(false);
+      }
+    };
+    execute();
   }, [refTrigger]);
 
   // Update paged referenda when new chain selected.
   useEffect(() => {
-    if (referendaMap.has(activeReferendaChainRef.current)) {
-      setActivePageCount(getActivePageCount());
-      setActivePagedReferenda(getActiveReferendaPage(activePage));
-    }
+    const execute = async () => {
+      if (referendaMap.has(activeReferendaChainRef.current)) {
+        const page = getActiveReferendaPage(activePage);
+        await fetchFromPolkassembly(page);
+        setActivePagedReferenda(page);
+        setActivePageCount(getActivePageCount());
+      }
+    };
+    execute();
   }, [activeReferendaChainId]);
 
   // Initiate feching referenda data.
@@ -167,22 +182,19 @@ export const ReferendaProvider = ({
   const receiveReferendaData = async (info: ReferendaInfo[]) => {
     const filtered = info.filter((r) => ongoingStatuses.includes(r.refStatus));
     setReferendaMap((pv) => pv.set(activeReferendaChainRef.current, filtered));
+    setFetchingReferenda(false);
+    setRefTrigger(true);
+  };
 
-    /**
-     * TODO: Fix
-     * Impose limit for fetch data to avoid overhelming Polkassembly API.
-     */
-    // Get Polkassembly enabled setting.
+  // Fetch paged referenda metadata if necessary.
+  const fetchFromPolkassembly = async (referenda: ReferendaInfo[]) => {
     const { appEnablePolkassemblyApi } = await window.myAPI.getAppSettings();
     setUsePolkassemblyApi(appEnablePolkassemblyApi);
 
     // Fetch proposal metadata if Polkassembly enabled.
     if (appEnablePolkassemblyApi) {
-      await fetchProposals(activeReferendaChainRef.current, filtered);
+      await fetchProposals(activeReferendaChainRef.current, referenda);
     }
-
-    setFetchingReferenda(false);
-    setRefTrigger(true);
   };
 
   // Get all referenda sorted by desc or asc.

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -29,8 +29,12 @@ export const ReferendaProvider = ({
   children: React.ReactNode;
 }) => {
   const { getOnlineMode } = useConnections();
-  const { fetchProposals, setUsePolkassemblyApi, setFetchingMetadata } =
-    usePolkassembly();
+  const {
+    clearProposals,
+    fetchProposals,
+    setUsePolkassemblyApi,
+    setFetchingMetadata,
+  } = usePolkassembly();
 
   // Referenda data received from API.
   const [refTrigger, setRefTrigger] = useState(false);
@@ -180,6 +184,7 @@ export const ReferendaProvider = ({
   // Re-fetch referenda, called when user clicks refresh button.
   const refetchReferenda = () => {
     setFetchingReferenda(true);
+    clearProposals(activeReferendaChainId);
     ConfigOpenGov.portOpenGov.postMessage({
       task: 'openGov:referenda:get',
       data: { chainId: activeReferendaChainId },
@@ -191,7 +196,6 @@ export const ReferendaProvider = ({
     const filtered = info.filter((r) => ongoingStatuses.includes(r.refStatus));
     setReferendaMap((pv) => pv.set(activeReferendaChainRef.current, filtered));
     setRefTrigger(true);
-    //setFetchingReferenda(false);
   };
 
   // Fetch paged referenda metadata if necessary.

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/index.tsx
@@ -29,7 +29,8 @@ export const ReferendaProvider = ({
   children: React.ReactNode;
 }) => {
   const { getOnlineMode } = useConnections();
-  const { fetchProposals, setUsePolkassemblyApi } = usePolkassembly();
+  const { fetchProposals, setUsePolkassemblyApi, setFetchingMetadata } =
+    usePolkassembly();
 
   // Referenda data received from API.
   const [refTrigger, setRefTrigger] = useState(false);
@@ -120,6 +121,7 @@ export const ReferendaProvider = ({
       const page = getActiveReferendaPage(activePage);
       await fetchFromPolkassembly(page);
       setActivePagedReferenda(page);
+      setFetchingMetadata(false);
     };
     execute();
   }, [activePage]);
@@ -133,6 +135,11 @@ export const ReferendaProvider = ({
         setActivePagedReferenda(page);
         setActivePageCount(getActivePageCount());
         setRefTrigger(false);
+        setFetchingMetadata(false);
+
+        if (fetchingReferenda) {
+          setFetchingReferenda(false);
+        }
       }
     };
     execute();
@@ -146,6 +153,7 @@ export const ReferendaProvider = ({
         await fetchFromPolkassembly(page);
         setActivePagedReferenda(page);
         setActivePageCount(getActivePageCount());
+        setFetchingMetadata(false);
       }
     };
     execute();
@@ -182,8 +190,8 @@ export const ReferendaProvider = ({
   const receiveReferendaData = async (info: ReferendaInfo[]) => {
     const filtered = info.filter((r) => ongoingStatuses.includes(r.refStatus));
     setReferendaMap((pv) => pv.set(activeReferendaChainRef.current, filtered));
-    setFetchingReferenda(false);
     setRefTrigger(true);
+    //setFetchingReferenda(false);
   };
 
   // Fetch paged referenda metadata if necessary.

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
@@ -27,4 +27,12 @@ export interface ReferendaContextInterface {
   ) => Map<string, ReferendaInfo[]>;
   updateHasFetchedReferenda: (chainId: ChainID) => void;
   updateTrackFilter: (val: string | null) => void;
+
+  // new
+  activePage: number;
+  activePageCount: number;
+  activePagedReferenda: ReferendaInfo[];
+  getCurPages: () => number[];
+  setActivePage: React.Dispatch<React.SetStateAction<number>>;
+  setRefTrigger: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
@@ -2,29 +2,29 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainID } from '@polkadot-live/types/chains';
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 
 export interface ReferendaContextInterface {
   activeReferendaChainId: ChainID;
   fetchingReferenda: boolean;
-  referendaMap: Map<ChainID, ActiveReferendaInfo[]>;
+  referendaMap: Map<ChainID, ReferendaInfo[]>;
   fetchReferendaData: (chainId: ChainID) => void;
   refetchReferenda: () => void;
-  receiveReferendaData: (info: ActiveReferendaInfo[]) => Promise<void>;
+  receiveReferendaData: (info: ReferendaInfo[]) => Promise<void>;
   setReferendaMap: React.Dispatch<
-    React.SetStateAction<Map<ChainID, ActiveReferendaInfo[]>>
+    React.SetStateAction<Map<ChainID, ReferendaInfo[]>>
   >;
   setFetchingReferenda: (flag: boolean) => void;
   getSortedActiveReferenda: (
     desc: boolean,
-    otherReferenda?: ActiveReferendaInfo[]
-  ) => ActiveReferendaInfo[];
+    otherReferenda?: ReferendaInfo[]
+  ) => ReferendaInfo[];
   getReferendaCount: (trackId: string | null) => number;
   getTrackFilter: () => string | null;
   getCategorisedReferenda: (
     desc: boolean,
-    otherReferenda?: ActiveReferendaInfo[]
-  ) => Map<string, ActiveReferendaInfo[]>;
+    otherReferenda?: ReferendaInfo[]
+  ) => Map<string, ReferendaInfo[]>;
   updateHasFetchedReferenda: (chainId: ChainID) => void;
   updateTrackFilter: (val: string | null) => void;
 }

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
@@ -28,6 +28,7 @@ export interface ReferendaContextInterface {
   activePage: number;
   activePageCount: number;
   activePagedReferenda: ReferendaInfo[];
+  showPageEllipsis: () => boolean;
   getCurPages: () => number[];
   setActivePage: React.Dispatch<React.SetStateAction<number>>;
   setRefTrigger: React.Dispatch<React.SetStateAction<boolean>>;

--- a/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/Referenda/types.ts
@@ -21,10 +21,6 @@ export interface ReferendaContextInterface {
   ) => ReferendaInfo[];
   getReferendaCount: (trackId: string | null) => number;
   getTrackFilter: () => string | null;
-  getCategorisedReferenda: (
-    desc: boolean,
-    otherReferenda?: ReferendaInfo[]
-  ) => Map<string, ReferendaInfo[]>;
   updateHasFetchedReferenda: (chainId: ChainID) => void;
   updateTrackFilter: (val: string | null) => void;
 

--- a/packages/renderer/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
@@ -7,7 +7,7 @@ import { createContext, useContext, useState } from 'react';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { IntervalSubscription } from '@polkadot-live/types/subscriptions';
 import type { ReferendaSubscriptionsContextInterface } from './types';
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 
 export const ReferendaSubscriptionsContext =
   createContext<ReferendaSubscriptionsContextInterface>(
@@ -125,17 +125,17 @@ export const ReferendaSubscriptionsProvider = ({
 
   /// Check if a task has been added for a referendum.
   const isSubscribedToTask = (
-    referendum: ActiveReferendaInfo,
+    referendum: ReferendaInfo,
     task: IntervalSubscription
   ) => {
-    const { referendaId } = referendum;
+    const { refId } = referendum;
     const { chainId, action } = task;
 
     if (activeTasksMap.has(chainId)) {
       const chainItems = activeTasksMap.get(chainId)!;
 
-      if (chainItems.has(referendaId)) {
-        const items = chainItems.get(referendaId)!;
+      if (chainItems.has(refId)) {
+        const items = chainItems.get(refId)!;
         if (items.includes(action)) {
           return true;
         }
@@ -148,29 +148,29 @@ export const ReferendaSubscriptionsProvider = ({
   /// Check if a referendum has added subscription tasks.
   const isSubscribedToReferendum = (
     chainId: ChainID,
-    referendum: ActiveReferendaInfo
+    referendum: ReferendaInfo
   ) =>
     activeTasksMap.has(chainId)
-      ? activeTasksMap.get(chainId)!.has(referendum.referendaId)
+      ? activeTasksMap.get(chainId)!.has(referendum.refId)
       : false;
 
   /// Check if referendum has all its subscriptions added.
   const allSubscriptionsAdded = (
     chainId: ChainID,
-    referendum: ActiveReferendaInfo
+    referendum: ReferendaInfo
   ) => {
     if (!activeTasksMap.has(chainId)) {
       return false;
     }
 
     const chainItems = activeTasksMap.get(chainId)!;
-    const { referendaId } = referendum;
+    const { refId } = referendum;
 
-    if (!chainItems.has(referendaId)) {
+    if (!chainItems.has(Number(refId))) {
       return false;
     }
 
-    return chainItems.get(referendaId)!.length === NUM_REFERENDUM_SUBSCRIPTIONS
+    return chainItems.get(refId)!.length === NUM_REFERENDUM_SUBSCRIPTIONS
       ? true
       : false;
   };

--- a/packages/renderer/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/ReferendaSubscriptions/index.tsx
@@ -1,13 +1,12 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { NUM_REFERENDUM_SUBSCRIPTIONS } from '@ren/config/subscriptions/interval';
 import * as defaults from './defaults';
 import { createContext, useContext, useState } from 'react';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { IntervalSubscription } from '@polkadot-live/types/subscriptions';
 import type { ReferendaSubscriptionsContextInterface } from './types';
-import type { ReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo, RefStatus } from '@polkadot-live/types/openGov';
 
 export const ReferendaSubscriptionsContext =
   createContext<ReferendaSubscriptionsContextInterface>(
@@ -165,14 +164,17 @@ export const ReferendaSubscriptionsProvider = ({
 
     const chainItems = activeTasksMap.get(chainId)!;
     const { refId } = referendum;
-
     if (!chainItems.has(Number(refId))) {
       return false;
     }
 
-    return chainItems.get(refId)!.length === NUM_REFERENDUM_SUBSCRIPTIONS
-      ? true
-      : false;
+    const MAX_SUBSCRIPTIONS: number = (
+      ['Preparing', 'Queueing'] as RefStatus[]
+    ).includes(referendum.refStatus)
+      ? 1
+      : 3;
+
+    return chainItems.get(refId)!.length === MAX_SUBSCRIPTIONS ? true : false;
   };
 
   /// Check if any subscriptions have been added for a given chain.

--- a/packages/renderer/src/renderer/contexts/openGov/ReferendaSubscriptions/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/ReferendaSubscriptions/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainID } from '@polkadot-live/types/chains';
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 import type { IntervalSubscription } from '@polkadot-live/types/subscriptions';
 
 export interface ReferendaSubscriptionsContextInterface {
@@ -15,16 +15,16 @@ export interface ReferendaSubscriptionsContextInterface {
   removeReferendaSubscription: (task: IntervalSubscription) => void;
   updateReferendaSubscription: (task: IntervalSubscription) => void;
   isSubscribedToTask: (
-    referendum: ActiveReferendaInfo,
+    referendum: ReferendaInfo,
     task: IntervalSubscription
   ) => boolean;
   isSubscribedToReferendum: (
     chainId: ChainID,
-    referendum: ActiveReferendaInfo
+    referendum: ReferendaInfo
   ) => boolean;
   isNotSubscribedToAny: (chainId: ChainID) => boolean;
   allSubscriptionsAdded: (
     chainId: ChainID,
-    referendum: ActiveReferendaInfo
+    referendum: ReferendaInfo
   ) => boolean;
 }

--- a/packages/renderer/src/renderer/contexts/openGov/TaskHandler/index.tsx
+++ b/packages/renderer/src/renderer/contexts/openGov/TaskHandler/index.tsx
@@ -6,7 +6,7 @@ import { Config as ConfigOpenGov } from '@ren/config/processes/openGov';
 import { createContext, useContext } from 'react';
 import { useReferendaSubscriptions } from '../ReferendaSubscriptions';
 import { renderToast } from '@polkadot-live/ui/utils';
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 import type { IntervalSubscription } from '@polkadot-live/types/subscriptions';
 import type { TaskHandlerContextInterface } from './types';
 
@@ -30,10 +30,10 @@ export const TaskHandlerProvider = ({
   /// Handles adding an interval subscription for a referendum.
   const addIntervalSubscription = (
     task: IntervalSubscription,
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => {
     // Set referendum ID on task.
-    const { referendaId: referendumId } = referendumInfo;
+    const { refId: referendumId } = referendumInfo;
     task.referendumId = referendumId;
 
     // Enable the task by default.
@@ -62,10 +62,10 @@ export const TaskHandlerProvider = ({
   /// Handles removing an interval subscription for a referendum.
   const removeIntervalSubscription = (
     task: IntervalSubscription,
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => {
     // Set referendum ID on task.
-    const { referendaId: referendumId } = referendumInfo;
+    const { refId: referendumId } = referendumInfo;
     task.referendumId = referendumId;
 
     // Remove subscription in referenda subscriptions context.
@@ -91,9 +91,9 @@ export const TaskHandlerProvider = ({
   /// Handles adding all available subscriptions for a referendum.
   const addAllIntervalSubscriptions = (
     tasks: IntervalSubscription[],
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => {
-    const { referendaId: referendumId } = referendumInfo;
+    const { refId: referendumId } = referendumInfo;
 
     // Throw away task if it's already added and set required fields.
     const updated = tasks
@@ -127,9 +127,9 @@ export const TaskHandlerProvider = ({
   /// Handles removing all addde subscriptions for a referendum.
   const removeAllIntervalSubscriptions = (
     tasks: IntervalSubscription[],
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => {
-    const { referendaId: referendumId } = referendumInfo;
+    const { refId: referendumId } = referendumInfo;
 
     // Throw away task if it is not added.
     const updated = tasks

--- a/packages/renderer/src/renderer/contexts/openGov/TaskHandler/types.ts
+++ b/packages/renderer/src/renderer/contexts/openGov/TaskHandler/types.ts
@@ -1,24 +1,24 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 import type { IntervalSubscription } from '@polkadot-live/types/subscriptions';
 
 export interface TaskHandlerContextInterface {
   addIntervalSubscription: (
     task: IntervalSubscription,
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => void;
   removeIntervalSubscription: (
     task: IntervalSubscription,
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => void;
   addAllIntervalSubscriptions: (
     tasks: IntervalSubscription[],
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => void;
   removeAllIntervalSubscriptions: (
     tasks: IntervalSubscription[],
-    referendumInfo: ActiveReferendaInfo
+    referendumInfo: ReferendaInfo
   ) => void;
 }

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -439,7 +439,7 @@ export const useMainMessagePorts = () => {
           // In Queue
           if (human.Ongoing.inQueue === true) {
             const info: OG.RefOngoing = { ...human.Ongoing };
-            allReferenda.push({ refId, refStatus: 'InQueue', info });
+            allReferenda.push({ refId, refStatus: 'Queueing', info });
           }
           // Preparing
           else if (human.Ongoing.deciding === null) {

--- a/packages/renderer/src/renderer/hooks/useOpenGovMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useOpenGovMessagePorts.ts
@@ -8,7 +8,7 @@ import { useTracks } from '@app/contexts/openGov/Tracks';
 import { useReferenda } from '../contexts/openGov/Referenda';
 import { useTreasury } from '../contexts/openGov/Treasury';
 import { useReferendaSubscriptions } from '../contexts/openGov/ReferendaSubscriptions';
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 import type { IntervalSubscription } from '@polkadot-live/types/subscriptions';
 
 export const useOpenGovMessagePorts = () => {
@@ -43,7 +43,7 @@ export const useOpenGovMessagePorts = () => {
             }
             case 'openGov:referenda:receive': {
               const { json } = ev.data.data;
-              const parsed: ActiveReferendaInfo[] = JSON.parse(json);
+              const parsed: ReferendaInfo[] = JSON.parse(json);
               await receiveReferendaData(parsed);
               break;
             }

--- a/packages/renderer/src/renderer/screens/OpenGov/DropdownMenu/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/DropdownMenu/index.tsx
@@ -29,8 +29,8 @@ export const ReferendumDropdownMenu = ({
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
 
   const onPolkassemblyClick = () => {
-    const { referendaId } = referendum;
-    const uriPolkassembly = `https://${chainId}.polkassembly.io/referenda/${referendaId}`;
+    const { refId } = referendum;
+    const uriPolkassembly = `https://${chainId}.polkassembly.io/referenda/${refId}`;
     window.myAPI.openBrowserURL(uriPolkassembly);
     window.myAPI.umamiEvent('link-open', {
       dest: 'polkassembly',
@@ -38,8 +38,8 @@ export const ReferendumDropdownMenu = ({
   };
 
   const onSubsquareClick = () => {
-    const { referendaId } = referendum;
-    const uriSubsquare = `https://${chainId}.subsquare.io/referenda/${referendaId}`;
+    const { refId } = referendum;
+    const uriSubsquare = `https://${chainId}.subsquare.io/referenda/${refId}`;
     window.myAPI.openBrowserURL(uriSubsquare);
     window.myAPI.umamiEvent('link-open', { dest: 'subsquare' });
   };

--- a/packages/renderer/src/renderer/screens/OpenGov/DropdownMenu/types.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/DropdownMenu/types.ts
@@ -3,12 +3,12 @@
 
 import type { ChainID } from '@polkadot-live/types/chains';
 import type {
-  ActiveReferendaInfo,
   PolkassemblyProposal,
+  ReferendaInfo,
 } from '@polkadot-live/types/openGov';
 
 export interface ReferendumDropdownMenuProps {
   chainId: ChainID;
   proposalData: PolkassemblyProposal | null;
-  referendum: ActiveReferendaInfo;
+  referendum: ReferendaInfo;
 }

--- a/packages/renderer/src/renderer/screens/OpenGov/Overview/OverviewExplore.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Overview/OverviewExplore.tsx
@@ -21,7 +21,7 @@ export const OverviewExplore: React.FC<OverviewExploreProps> = ({
 }: OverviewExploreProps) => {
   // Tracks and referenda contexts.
   const { fetchTracksData, updateActiveTracksChain } = useTracks();
-  const { fetchReferendaData } = useReferenda();
+  const { fetchReferendaData, setActivePage } = useReferenda();
 
   // Open origins and tracks information.
   const handleOpenTracks = (chainId: ChainID) => {
@@ -34,6 +34,7 @@ export const OverviewExplore: React.FC<OverviewExploreProps> = ({
   // Open referenda.
   const handleOpenReferenda = (chainId: ChainID) => {
     setSectionContent('referenda');
+    setActivePage(1);
     fetchReferendaData(chainId);
     fetchTracksData(chainId);
     setSection(1);

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -29,9 +29,12 @@ import {
 import { TooltipRx } from '@polkadot-live/ui/components';
 import { FlexRow } from '@polkadot-live/ui/styles';
 import { ReferendumDropdownMenu } from '../DropdownMenu';
-import type { PolkassemblyProposal } from '@polkadot-live/types/openGov';
-import type { ReferendumRowProps } from '../types';
 import { RoundLeftButton, RoundRightButton } from '../DropdownMenu/Wrappers';
+import type {
+  PolkassemblyProposal,
+  RefStatus,
+} from '@polkadot-live/types/openGov';
+import type { ReferendumRowProps } from '../types';
 
 export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const { openHelp } = useHelp();
@@ -59,7 +62,16 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const [expanded, setExpanded] = useState(false);
 
   const getIntervalSubscriptions = () =>
-    allIntervalTasks.filter((t) => t.chainId === chainId);
+    allIntervalTasks
+      .filter((t) => t.chainId === chainId)
+      .filter((t) => {
+        if ((['Preparing', 'Queueing'] as RefStatus[]).includes(refStatus)) {
+          const actions = ['subscribe:interval:openGov:referendumVotes'];
+          return actions.includes(t.action);
+        } else {
+          return true;
+        }
+      });
 
   const getProposalTitle = (data: PolkassemblyProposal) => {
     const { title } = data;
@@ -166,7 +178,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
         transition={{ type: 'spring', duration: 0.25, bounce: 0 }}
       >
         <div className="ContentWrapper">
-          <div className="SubscriptionGrid">
+          <FlexRow className="SubscriptionGrid">
             {/* Render interval tasks from config */}
             {getIntervalSubscriptions().map((t) => (
               <div
@@ -206,7 +218,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
                 </span>
               </div>
             ))}
-          </div>
+          </FlexRow>
         </div>
       </motion.section>
     </ReferendumRowWrapper>

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -78,7 +78,9 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
             <h4>{proposalData ? getProposalTitle(proposalData) : ''}</h4>
             <FlexRow>
               <RefStatusBadge $status={refStatus}>{refStatus}</RefStatusBadge>
-              <h5 className="origin">{renderOrigin(referendum)}</h5>
+              <h5 className="origin text-ellipsis">
+                {renderOrigin(referendum)}
+              </h5>
             </FlexRow>
           </TitleWithOrigin>
         ) : (

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -3,7 +3,11 @@
 
 import * as themeVariables from '../../../theme/variables';
 import { intervalTasks as allIntervalTasks } from '@ren/config/subscriptions/interval';
-import { ReferendumRowWrapper, TitleWithOrigin } from './Wrappers';
+import {
+  ReferendumRowWrapper,
+  RefStatusBadge,
+  TitleWithOrigin,
+} from './Wrappers';
 import { renderOrigin } from '@app/utils/openGovUtils';
 import { useConnections } from '@app/contexts/common/Connections';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -36,7 +40,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
   const isOnline = getOnlineMode();
 
-  const { refId } = referendum;
+  const { refId, refStatus } = referendum;
   const { activeReferendaChainId: chainId } = useReferenda();
   const { isSubscribedToTask, allSubscriptionsAdded } =
     useReferendaSubscriptions();
@@ -67,12 +71,15 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
       <FlexRow>
         <div className="RefID">
           <FontAwesomeIcon icon={faHashtag} transform={'shrink-5'} />
-          {referendum.refId}
+          {refId}
         </div>
         {usePolkassemblyApi ? (
           <TitleWithOrigin>
             <h4>{proposalData ? getProposalTitle(proposalData) : ''}</h4>
-            <h5>{renderOrigin(referendum)}</h5>
+            <FlexRow>
+              <RefStatusBadge $status={refStatus}>{refStatus}</RefStatusBadge>
+              <h5 className="origin">{renderOrigin(referendum)}</h5>
+            </FlexRow>
           </TitleWithOrigin>
         ) : (
           <h4 style={{ flex: 1 }}>{renderOrigin(referendum)}</h4>

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/ReferendumRow.tsx
@@ -36,7 +36,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   const theme = darkMode ? themeVariables.darkTheme : themeVariables.lightThene;
   const isOnline = getOnlineMode();
 
-  const { referendaId } = referendum;
+  const { refId } = referendum;
   const { activeReferendaChainId: chainId } = useReferenda();
   const { isSubscribedToTask, allSubscriptionsAdded } =
     useReferendaSubscriptions();
@@ -49,7 +49,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
   } = useTaskHandler();
 
   const { getProposal, usePolkassemblyApi } = usePolkassembly();
-  const proposalData = getProposal(chainId, referendaId);
+  const proposalData = getProposal(chainId, refId);
 
   // Whether subscriptions are showing.
   const [expanded, setExpanded] = useState(false);
@@ -67,7 +67,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
       <FlexRow>
         <div className="RefID">
           <FontAwesomeIcon icon={faHashtag} transform={'shrink-5'} />
-          {referendum.referendaId}
+          {referendum.refId}
         </div>
         {usePolkassemblyApi ? (
           <TitleWithOrigin>
@@ -161,7 +161,7 @@ export const ReferendumRow = ({ referendum, index }: ReferendumRowProps) => {
             {/* Render interval tasks from config */}
             {getIntervalSubscriptions().map((t) => (
               <div
-                key={`${index}_${referendaId}_${t.action}`}
+                key={`${index}_${refId}_${t.action}`}
                 className="SubscriptionRow"
               >
                 {isSubscribedToTask(referendum, t) ? (

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -124,10 +124,16 @@ export const PaginationRow = styled.div`
   align-items: center;
   user-select: none;
 
+  .ellipsis {
+    color: var(--text-dimmed);
+    margin: 0 0.5rem;
+  }
   .btn {
     background-color: var(--background-surface);
+    border: 1px solid var(--background-surface);
     padding: 0.5rem 1rem;
     transition: background-color 0.2s ease-out;
+    width: 34px;
     cursor: pointer;
 
     &:hover:not(.disable):not(.selected):not(.fetching) {
@@ -137,9 +143,24 @@ export const PaginationRow = styled.div`
       background-color: var(--background-primary-hover);
       color: var(--text-bright);
     }
+    &.middle {
+      border: 1px solid var(--border-subtle);
+    }
     &.disable {
       color: var(--text-dimmed);
       cursor: not-allowed;
+    }
+    &.placeholder {
+      color: var(--text-dimmed);
+      width: 31.75px;
+      align-self: stretch;
+      position: relative;
+      cursor: not-allowed;
+      .icon {
+        position: absolute;
+        bottom: 2px;
+        left: 10px;
+      }
     }
     &.fetching {
       cursor: not-allowed;

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -147,11 +147,9 @@ export const ReferendumRowWrapper = styled.div`
 
       .SubscriptionGrid {
         width: 100%;
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 1rem;
 
         div {
+          flex: 1;
           justify-content: center;
         }
         // Keep for tweaking later.

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -120,7 +120,7 @@ export const NoteWrapper = styled.div`
 
 export const PaginationRow = styled.div`
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
   align-items: center;
   user-select: none;
 

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -3,6 +3,33 @@
 
 import styled from 'styled-components';
 import { mixinHelpIcon } from '@polkadot-live/ui/components';
+import type { RefStatus } from '@polkadot-live/types/openGov';
+
+export const RefStatusBadge = styled.h5<{ $status: RefStatus }>`
+  color: var(--text-color-primary);
+  font-size: 0.92rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.375rem;
+  background-color: ${(props) => {
+    switch (props.$status) {
+      case 'Deciding':
+      case 'Queueing':
+      case 'Preparing':
+        return '#053e94';
+      case 'Approved':
+      case 'Confirming':
+        return '#125715';
+      case 'Cancelled':
+      case 'Killed':
+      case 'Rejected':
+        return '#7f1515';
+      case 'TimedOut':
+        return '#3b3b3b';
+      default:
+        return '#3b3b3b';
+    }
+  }};
+`;
 
 export const TitleWithOrigin = styled.div`
   display: flex;
@@ -19,10 +46,9 @@ export const TitleWithOrigin = styled.div`
     text-overflow: ellipsis;
     font-size: 1.1rem !important;
   }
-  > h5 {
+  .origin {
     color: var(--text-color-secondary);
     margin: 0;
-    font-size: 1rem !important;
   }
 `;
 

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -118,6 +118,32 @@ export const NoteWrapper = styled.div`
   }
 `;
 
+export const PaginationRow = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  user-select: none;
+
+  .btn {
+    background-color: var(--background-surface);
+    padding: 0.5rem 1rem;
+    transition: background-color 0.2s ease-out;
+    cursor: pointer;
+
+    &:hover:not(.disable):not(.selected) {
+      background-color: var(--background-primary-hover);
+    }
+    &.selected {
+      background-color: var(--background-primary-hover);
+      color: var(--text-bright);
+    }
+    &.disable {
+      color: var(--text-dimmed);
+      cursor: not-allowed;
+    }
+  }
+`;
+
 export const ReferendumRowWrapper = styled.div`
   position: relative;
   padding: 1rem 1.25rem;

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -14,8 +14,9 @@ export const RefStatusBadge = styled.h5<{ $status: RefStatus }>`
     switch (props.$status) {
       case 'Deciding':
       case 'Queueing':
-      case 'Preparing':
         return '#053e94';
+      case 'Preparing':
+        return '#294a7c';
       case 'Approved':
       case 'Confirming':
         return '#125715';

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/Wrappers.ts
@@ -130,7 +130,7 @@ export const PaginationRow = styled.div`
     transition: background-color 0.2s ease-out;
     cursor: pointer;
 
-    &:hover:not(.disable):not(.selected) {
+    &:hover:not(.disable):not(.selected):not(.fetching) {
       background-color: var(--background-primary-hover);
     }
     &.selected {
@@ -139,6 +139,9 @@ export const PaginationRow = styled.div`
     }
     &.disable {
       color: var(--text-dimmed);
+      cursor: not-allowed;
+    }
+    &.fetching {
       cursor: not-allowed;
     }
   }

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -151,7 +151,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                     <ItemsColumn>
                       {infos.map((referendum, j) => (
                         <ReferendumRow
-                          key={`${j}_${referendum.referendaId}`}
+                          key={`${j}_${referendum.refId}`}
                           referendum={referendum}
                           index={j}
                         />
@@ -206,7 +206,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                     <ItemsColumn>
                       {infos.map((referendum, j) => (
                         <ReferendumRow
-                          key={`${j}_${referendum.referendaId}`}
+                          key={`${j}_${referendum.refId}`}
                           referendum={referendum}
                           index={j}
                         />
@@ -229,7 +229,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     >
       {getSortedActiveReferenda(newestFirst).map((referendum, i) => (
         <ReferendumRow
-          key={`${i}_${referendum.referendaId}`}
+          key={`${i}_${referendum.refId}`}
           referendum={referendum}
           index={i}
         />
@@ -250,7 +250,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
         {getSortedActiveReferenda(newestFirst, getSubscribedReferenda()).map(
           (referendum, i) => (
             <ReferendumRow
-              key={`${i}_${referendum.referendaId}_subscribed`}
+              key={`${i}_${referendum.refId}_subscribed`}
               referendum={referendum}
               index={i}
             />

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -60,6 +60,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
 
   // Flag to display referenda with active subscriptions.
   const [onlySubscribed, setOnlySubscribed] = useState(false);
+  const [showSubscribedButton] = useState(false);
 
   // Pagination.
   const onActivePageClick = (val: number) => {
@@ -237,18 +238,20 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
                     />
                   </span>
                 </UI.TooltipRx>
-                <UI.TooltipRx theme={theme} text={'Show Subscribed'}>
-                  <span>
-                    <SortControlButton
-                      isActive={onlySubscribed}
-                      isDisabled={fetchingReferenda}
-                      faIcon={faEllipsisVertical}
-                      onClick={() => handleToggleOnlySubscribed()}
-                      fixedWidth={false}
-                      respClass="ReferendaControls"
-                    />
-                  </span>
-                </UI.TooltipRx>
+                {showSubscribedButton && (
+                  <UI.TooltipRx theme={theme} text={'Show Subscribed'}>
+                    <span>
+                      <SortControlButton
+                        isActive={onlySubscribed}
+                        isDisabled={fetchingReferenda}
+                        faIcon={faEllipsisVertical}
+                        onClick={() => handleToggleOnlySubscribed()}
+                        fixedWidth={false}
+                        respClass="ReferendaControls"
+                      />
+                    </span>
+                  </UI.TooltipRx>
+                )}
               </ControlsWrapper>
             </Styles.FlexColumn>
           </section>

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { useConnections } from '@app/contexts/common/Connections';
 import { useEffect, useState } from 'react';
+import { usePolkassembly } from '@app/contexts/openGov/Polkassembly';
 import { useReferenda } from '@app/contexts/openGov/Referenda';
 import { useTracks } from '@app/contexts/openGov/Tracks';
 import { ReferendumRow } from './ReferendumRow';
@@ -27,6 +28,7 @@ import { renderPlaceholders } from '@polkadot-live/ui/utils';
 import { useReferendaSubscriptions } from '@app/contexts/openGov/ReferendaSubscriptions';
 import { ItemsColumn } from '../../Home/Manage/Wrappers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { PuffLoader } from 'react-spinners';
 import type { ReferendaProps } from '../types';
 
 export const Referenda = ({ setSection }: ReferendaProps) => {
@@ -51,6 +53,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     setRefTrigger,
   } = useReferenda();
 
+  const { fetchingMetadata } = usePolkassembly();
   const { fetchingTracks, getOrderedTracks } = useTracks();
   const { isSubscribedToReferendum, isNotSubscribedToAny } =
     useReferendaSubscriptions();
@@ -64,11 +67,12 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
       setActivePage(val);
     }
   };
-  const onPrevActivePageClick = () => {
-    setActivePage((pv) => (pv > 1 ? pv - 1 : pv));
-  };
-  const onNextActivePageClick = () => {
-    setActivePage((pv) => (pv < activePageCount ? pv + 1 : pv));
+  const onPageArrowClick = (dir: 'prev' | 'next') => {
+    if (dir === 'prev') {
+      setActivePage((pv) => (pv > 1 ? pv - 1 : pv));
+    } else {
+      setActivePage((pv) => (pv < activePageCount ? pv + 1 : pv));
+    }
   };
 
   // Get subscribed referenda only.
@@ -102,7 +106,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
         <button
           className={`btn ${activePage === 1 && 'disable'}`}
           disabled={activePage === 1}
-          onClick={() => onPrevActivePageClick()}
+          onClick={() => onPageArrowClick('prev')}
         >
           <FontAwesomeIcon icon={faCaretLeft} />
         </button>
@@ -118,10 +122,14 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
         <button
           className={`btn ${activePage === activePageCount && 'disable'}`}
           disabled={activePage === activePageCount}
-          onClick={() => onNextActivePageClick()}
+          onClick={() => onPageArrowClick('next')}
         >
           <FontAwesomeIcon icon={faCaretRight} />
         </button>
+
+        {fetchingMetadata && (
+          <PuffLoader size={20} color={'var(--text-color-primary)'} />
+        )}
       </PaginationRow>
 
       <ItemsColumn>

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -55,7 +55,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
   const { isSubscribedToReferendum, isNotSubscribedToAny } =
     useReferendaSubscriptions();
 
-  // Sorting controls state.
+  // Flag to display referenda with active subscriptions.
   const [onlySubscribed, setOnlySubscribed] = useState(false);
 
   // Pagination.

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -63,12 +63,14 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
 
   // Pagination.
   const onActivePageClick = (val: number) => {
-    if (activePage !== val) {
+    if (activePage !== val && !fetchingMetadata) {
       setActivePage(val);
     }
   };
   const onPageArrowClick = (dir: 'prev' | 'next') => {
-    if (dir === 'prev') {
+    if (fetchingMetadata) {
+      return;
+    } else if (dir === 'prev') {
       setActivePage((pv) => (pv > 1 ? pv - 1 : pv));
     } else {
       setActivePage((pv) => (pv < activePageCount ? pv + 1 : pv));
@@ -104,7 +106,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     <>
       <PaginationRow>
         <button
-          className={`btn ${activePage === 1 && 'disable'}`}
+          className={`btn ${activePage === 1 && 'disable'} ${fetchingMetadata && 'fetching'}`}
           disabled={activePage === 1}
           onClick={() => onPageArrowClick('prev')}
         >
@@ -114,13 +116,13 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
           <button
             key={i}
             onClick={() => onActivePageClick(i)}
-            className={`btn ${activePage === i && 'selected'}`}
+            className={`btn ${activePage === i && 'selected'} ${fetchingMetadata && 'fetching'}`}
           >
             {i}
           </button>
         ))}
         <button
-          className={`btn ${activePage === activePageCount && 'disable'}`}
+          className={`btn ${activePage === activePageCount && 'disable'} ${fetchingMetadata && 'fetching'}`}
           disabled={activePage === activePageCount}
           onClick={() => onPageArrowClick('next')}
         >

--- a/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
+++ b/packages/renderer/src/renderer/screens/OpenGov/Referenda/index.tsx
@@ -16,6 +16,7 @@ import {
   faArrowsRotate,
   faEllipsisVertical,
   faCaretRight,
+  faEllipsis,
 } from '@fortawesome/free-solid-svg-icons';
 import { useConnections } from '@app/contexts/common/Connections';
 import { useEffect, useState } from 'react';
@@ -48,6 +49,7 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
     activePage,
     activePageCount,
     activePagedReferenda,
+    showPageEllipsis,
     getCurPages,
     setActivePage,
     setRefTrigger,
@@ -113,14 +115,21 @@ export const Referenda = ({ setSection }: ReferendaProps) => {
         >
           <FontAwesomeIcon icon={faCaretLeft} />
         </button>
-        {getCurPages().map((i) => (
-          <button
-            key={i}
-            onClick={() => onActivePageClick(i)}
-            className={`btn ${activePage === i && 'selected'} ${fetchingMetadata && 'fetching'}`}
-          >
-            {i}
-          </button>
+        {getCurPages().map((i, j) => (
+          <Styles.FlexRow key={i} $row={'0.75rem'}>
+            {j === 2 && !showPageEllipsis() && activePageCount > 4 && (
+              <button className={`btn placeholder`}>
+                <FontAwesomeIcon className="icon" icon={faEllipsis} />
+              </button>
+            )}
+            <button
+              onClick={() => onActivePageClick(i)}
+              className={`btn ${activePage === i && 'selected'} ${fetchingMetadata && 'fetching'}
+              ${j === 2 && getCurPages().length === 5 && 'middle'}`}
+            >
+              {i}
+            </button>
+          </Styles.FlexRow>
         ))}
         <button
           className={`btn ${activePage === activePageCount && 'disable'} ${fetchingMetadata && 'fetching'}`}

--- a/packages/renderer/src/renderer/screens/OpenGov/types.ts
+++ b/packages/renderer/src/renderer/screens/OpenGov/types.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { Track } from '@ren/model/Track';
-import type { ActiveReferendaInfo } from '@polkadot-live/types/openGov';
+import type { ReferendaInfo } from '@polkadot-live/types/openGov';
 
 export interface TracksProps {
   setSection: (section: number) => void;
@@ -17,6 +17,6 @@ export interface ReferendaProps {
 }
 
 export interface ReferendumRowProps {
-  referendum: ActiveReferendaInfo;
+  referendum: ReferendaInfo;
   index: number;
 }

--- a/packages/renderer/src/renderer/utils/openGovUtils.ts
+++ b/packages/renderer/src/renderer/utils/openGovUtils.ts
@@ -108,12 +108,12 @@ export const getMinApprovalSupport = async (
   referendumInfo: ReferendaInfo,
   track: Track
 ) => {
-  /**
-   * TODO:
-   * Confirm this function is only needed for Ongoing referenda
-   * Allow all Ongoing status's if it makes sense
-   */
-  if (referendumInfo.refStatus !== 'Deciding') {
+  // Confirm referendum status is valid.
+  if (
+    !(['Deciding', 'Confirming'] as RefStatus[]).includes(
+      referendumInfo.refStatus
+    )
+  ) {
     return null;
   }
 

--- a/packages/renderer/src/renderer/utils/openGovUtils.ts
+++ b/packages/renderer/src/renderer/utils/openGovUtils.ts
@@ -3,7 +3,11 @@
 
 import BigNumber from 'bignumber.js';
 import { Track } from '@ren/model/Track';
-import type { RefDeciding, ReferendaInfo } from '@polkadot-live/types/openGov';
+import type {
+  RefDeciding,
+  ReferendaInfo,
+  RefStatus,
+} from '@polkadot-live/types/openGov';
 import type { AnyData } from '@polkadot-live/types/misc';
 import type { ApiPromise } from '@polkadot/api';
 
@@ -167,12 +171,11 @@ export const getMinApprovalSupport = async (
  * @summary Get referendum origin as string.
  */
 export const renderOrigin = (referendum: ReferendaInfo) => {
-  /**
-   * TODO:
-   * Confirm this function is only needed for Ongoing referenda
-   * Allow all Ongoing status's if it makes sense
-   */
-  if (referendum.refStatus !== 'Deciding') {
+  if (
+    !(
+      ['Queueing', 'Preparing', 'Confirming', 'Deciding'] as RefStatus[]
+    ).includes(referendum.refStatus)
+  ) {
     return 'Unknown';
   }
 

--- a/packages/renderer/src/renderer/utils/openGovUtils.ts
+++ b/packages/renderer/src/renderer/utils/openGovUtils.ts
@@ -235,6 +235,7 @@ export const getSpacedOrigin = (origin: string) => {
 /**
  * @name getOrderedOrigins
  * @summary Get referedum origins in the desired order.
+ * @deprecated
  */
 export const getOrderedOrigins = () => [
   'Root',

--- a/packages/types/src/openGov.ts
+++ b/packages/types/src/openGov.ts
@@ -1,44 +1,101 @@
 // Copyright 2024 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-/**
- * Information received from API for active (ongoing) referenda.
- */
-export interface ActiveReferendaInfo {
-  referendaId: number;
-  Ongoing: {
-    alarm: [string, [string, string]];
-    deciding: {
-      confirming: null | string;
-      since: string;
-    } | null;
-    decisionDeposit: {
-      amount: string;
-      who: string;
-    } | null;
-    enactment: {
-      After: string;
-    };
-    inQueue: boolean;
-    origin: { Origins: string } | { system: string };
-    proposal: {
-      Lookup: {
-        hash: string;
-        len: string;
-      };
-    };
-    submissionDeposit: {
-      amount: string;
-      who: string;
-    };
-    submitted: string;
-    tally: {
-      ayes: string;
-      nays: string;
-      support: string;
-    };
-    track: string;
+export type RefInQueue = RefOngoing; // inQueue: true
+export type RefPreparing = RefOngoing; // deciding: null
+export type RefConfirming = RefOngoing; // deciding.confirming = <string>
+export type RefDeciding = RefOngoing; // deciding.confirming = null;
+
+export type RefStatus =
+  | 'Approved'
+  | 'Cancelled'
+  | 'Confirming'
+  | 'Deciding'
+  | 'InQueue'
+  | 'Killed'
+  | 'Preparing'
+  | 'Rejected'
+  | 'TimedOut';
+
+export interface ReferendaInfo {
+  refId: number;
+  refStatus: RefStatus;
+  info:
+    | RefApproved
+    | RefCancelled
+    | RefConfirming
+    | RefDeciding
+    | RefInQueue
+    | RefKilled
+    | RefPreparing
+    | RefRejected
+    | RefTimedOut;
+}
+
+export interface RefApproved {
+  block: string;
+  who: string | null;
+  amount: string | null;
+}
+
+export interface RefCancelled {
+  block: string;
+  who: string | null;
+  amount: string | null;
+}
+
+export interface RefRejected {
+  block: string;
+  who: string;
+  amount: string;
+}
+
+export interface RefTimedOut {
+  block: string;
+  who: string;
+  amount: string;
+}
+
+export interface RefKilled {
+  block: string;
+}
+
+export interface RefOngoing {
+  alarm: [string, [string, string]];
+  deciding: {
+    confirming: null | string;
+    since: string;
+  } | null;
+  decisionDeposit: {
+    amount: string;
+    who: string;
+  } | null;
+  enactment:
+    | {
+        After: string;
+      }
+    | { At: string };
+  inQueue: boolean;
+  origin: { Origins: string } | { system: string };
+  proposal:
+    | {
+        Lookup: {
+          hash: string;
+          len: string;
+        };
+      }
+    | { Inline: string };
+  submissionDeposit: {
+    amount: string;
+    who: string;
   };
+  submitted: string;
+  tally: {
+    ayes: string;
+    nays: string;
+    support: string;
+  };
+  track: string;
 }
 
 export interface PolkassemblyProposal {

--- a/packages/types/src/openGov.ts
+++ b/packages/types/src/openGov.ts
@@ -11,7 +11,7 @@ export type RefStatus =
   | 'Cancelled'
   | 'Confirming'
   | 'Deciding'
-  | 'InQueue'
+  | 'Queueing'
   | 'Killed'
   | 'Preparing'
   | 'Rejected'


### PR DESCRIPTION
Iteration on the OpenGov referenda infrastructure:

- [x] All Polkadot referenda are fetched and parsed regardless of status.
- [x] Referenda subscription UI set dynamically based on referendum status.
- [x] Pagination implemented to process and cache proposal metadata in batches.
- [x] Loading spinner rendered when fetching proposal metadata via the Polkassembly API.  
- [x] Redundant grouping controls and accordion removed.