### PR TITLE
fix: debugging iteration

### DIFF
--- a/packages/renderer/src/controller/SubscriptionsController.ts
+++ b/packages/renderer/src/controller/SubscriptionsController.ts
@@ -73,7 +73,9 @@ export class SubscriptionsController {
       serialized !== '' ? JSON.parse(serialized) : [];
 
     // Subscribe to tasks.
-    await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
+    for (const task of tasks) {
+      await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
+    }
   }
 
   /**
@@ -88,9 +90,8 @@ export class SubscriptionsController {
 
     // Get subscription task array and subscribe to batched tasks.
     const tasks = this.chainSubscriptions?.getSubscriptionTasks() || [];
-
-    if (tasks.length) {
-      await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
+    for (const task of tasks) {
+      await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
     }
   }
 
@@ -108,8 +109,9 @@ export class SubscriptionsController {
       .getSubscriptionTasks()
       .filter((task) => task.chainId === chainId);
 
-    tasks.length &&
-      (await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions));
+    for (const task of tasks) {
+      await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
+    }
   }
 
   /**
@@ -132,7 +134,9 @@ export class SubscriptionsController {
    */
   static async subscribeChainTasks(tasks: SubscriptionTask[]) {
     if (this.chainSubscriptions) {
-      await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
+      for (const task of tasks) {
+        await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
+      }
     } else {
       throw new Error(
         'Error: SubscriptionsController::subscribeChainTask QueryMultiWrapper null'

--- a/packages/renderer/src/model/QueryMultiWrapper.ts
+++ b/packages/renderer/src/model/QueryMultiWrapper.ts
@@ -135,8 +135,8 @@ export class QueryMultiWrapper {
    */
   private async handleCallback(entry: ApiCallEntry, dataArr: AnyData) {
     const { action, justBuilt } = entry.task;
-    const subData = dataArr[entry.task.dataIndex!];
-    const sf = this.postCallbackSyncFlags;
+    const data = dataArr[entry.task.dataIndex!];
+    const flags = this.postCallbackSyncFlags;
 
     // Exit early if the task was just built (toggled on).
     if (justBuilt) {
@@ -146,47 +146,47 @@ export class QueryMultiWrapper {
 
     switch (action) {
       case 'subscribe:chain:timestamp': {
-        Callbacks.callback_query_timestamp_now(subData, entry, this);
+        Callbacks.callback_query_timestamp_now(data, entry, this);
         break;
       }
       case 'subscribe:chain:currentSlot': {
-        Callbacks.callback_query_babe_currentSlot(subData, entry, this);
+        Callbacks.callback_query_babe_currentSlot(data, entry, this);
         break;
       }
       case 'subscribe:account:balance:free': {
-        await Callbacks.callback_account_balance_free(subData, entry, sf);
+        await Callbacks.callback_account_balance_free(data, entry, flags);
         break;
       }
       case 'subscribe:account:balance:frozen': {
-        await Callbacks.callback_account_balance_frozen(subData, entry, sf);
+        await Callbacks.callback_account_balance_frozen(data, entry, flags);
         break;
       }
       case 'subscribe:account:balance:reserved': {
-        await Callbacks.callback_account_balance_reserved(subData, entry, sf);
+        await Callbacks.callback_account_balance_reserved(data, entry, flags);
         break;
       }
       case 'subscribe:account:balance:spendable': {
-        await Callbacks.callback_account_balance_spendable(subData, entry, sf);
+        await Callbacks.callback_account_balance_spendable(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominationPools:rewards': {
-        await Callbacks.callback_nomination_pool_rewards(entry, sf);
+        await Callbacks.callback_nomination_pool_rewards(entry, flags);
         break;
       }
       case 'subscribe:account:nominationPools:state': {
-        await Callbacks.callback_nomination_pool_state(subData, entry, sf);
+        await Callbacks.callback_nomination_pool_state(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominationPools:renamed': {
-        await Callbacks.callback_nomination_pool_renamed(subData, entry, sf);
+        await Callbacks.callback_nomination_pool_renamed(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominationPools:roles': {
-        await Callbacks.callback_nomination_pool_roles(subData, entry, sf);
+        await Callbacks.callback_nomination_pool_roles(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominationPools:commission': {
-        await Callbacks.callback_nomination_pool_commission(subData, entry, sf);
+        await Callbacks.callback_nomination_pool_commission(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominating:pendingPayouts': {
@@ -194,15 +194,15 @@ export class QueryMultiWrapper {
         break;
       }
       case 'subscribe:account:nominating:exposure': {
-        await Callbacks.callback_nominating_exposure(subData, entry, sf);
+        await Callbacks.callback_nominating_exposure(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominating:commission': {
-        await Callbacks.callback_nominating_commission(subData, entry, sf);
+        await Callbacks.callback_nominating_commission(data, entry, flags);
         break;
       }
       case 'subscribe:account:nominating:nominations': {
-        await Callbacks.callback_nominating_nominations(subData, entry, sf);
+        await Callbacks.callback_nominating_nominations(data, entry, flags);
         break;
       }
     }
@@ -267,29 +267,21 @@ export class QueryMultiWrapper {
     if (account) {
       // Sync account balance.
       if (this.postCallbackSyncFlags.syncAccountBalance) {
-        const balance = await getBalanceForAccount(
-          api,
-          account.address,
-          account.chain,
-          false
-        );
+        const { address, chain } = account;
+        const balance = await getBalanceForAccount(api, address, chain, false);
         account.balance = balance;
       }
 
       // Sync account nominating data.
       if (this.postCallbackSyncFlags.syncAccountNominating) {
         const result = await getAccountNominatingData(api, account);
-        if (result) {
-          account.nominatingData = result;
-        }
+        result && (account.nominatingData = result);
       }
 
       // Sync account nomination pool data.
       if (this.postCallbackSyncFlags.syncAccountNominationPool) {
         const result = await getNominationPoolDataForAccount(account);
-        if (result) {
-          account.nominationPoolData = result;
-        }
+        result && (account.nominationPoolData = result);
       }
 
       // Set updated account data in the appropriate entries.

--- a/packages/renderer/src/model/QueryMultiWrapper.ts
+++ b/packages/renderer/src/model/QueryMultiWrapper.ts
@@ -3,17 +3,28 @@
 
 import * as Utils from '@ren/utils/CommonUtils';
 import { AccountId32 } from 'dedot/codecs';
+import { AccountsController } from '@ren/controller/AccountsController';
 import { APIsController } from '@ren/controller/dedot/APIsController';
 import { Callbacks } from '@app/callbacks';
 import { MainDebug } from '@ren/utils/DebugUtils';
-import type { ChainID } from '@polkadot-live/types/chains';
+import { getAccountNominatingData } from '@ren/renderer/callbacks/nominating';
+import {
+  getBalanceForAccount,
+  getNominationPoolDataForAccount,
+} from '@ren/utils/AccountUtils';
+
 import type { AnyData, AnyFunction } from '@polkadot-live/types/misc';
+import type { Account } from './Account';
+import type { ChainID } from '@polkadot-live/types/chains';
+import type { FlattenedAccountData } from 'packages/types/src';
+import type { QueryWithParams } from 'dedot/types';
+import type { RelayDedotClient } from '@polkadot-live/types/apis';
 import type {
   SubscriptionTask,
   QueryMultiEntry,
   ApiCallEntry,
+  PostCallbackSyncFlags,
 } from '@polkadot-live/types/subscriptions';
-import type { QueryWithParams } from 'dedot/types';
 
 const debug = MainDebug.extend('QueryMultiWrapper');
 
@@ -22,6 +33,15 @@ export class QueryMultiWrapper {
    * API call entries (subscription tasks) are keyed by their chain ID.
    */
   private subscriptions = new Map<ChainID, QueryMultiEntry>();
+
+  /**
+   * Flag what data needs syncing after executing callbacks.
+   */
+  postCallbackSyncFlags: PostCallbackSyncFlags = {
+    syncAccountBalance: false,
+    syncAccountNominationPool: false,
+    syncAccountNominating: false,
+  };
 
   /**
    * @name requiresApiInstanceForChain
@@ -116,6 +136,7 @@ export class QueryMultiWrapper {
   private async handleCallback(entry: ApiCallEntry, dataArr: AnyData) {
     const { action, justBuilt } = entry.task;
     const subData = dataArr[entry.task.dataIndex!];
+    const sf = this.postCallbackSyncFlags;
 
     // Exit early if the task was just built (toggled on).
     if (justBuilt) {
@@ -133,39 +154,39 @@ export class QueryMultiWrapper {
         break;
       }
       case 'subscribe:account:balance:free': {
-        await Callbacks.callback_account_balance_free(subData, entry);
+        await Callbacks.callback_account_balance_free(subData, entry, sf);
         break;
       }
       case 'subscribe:account:balance:frozen': {
-        await Callbacks.callback_account_balance_frozen(subData, entry);
+        await Callbacks.callback_account_balance_frozen(subData, entry, sf);
         break;
       }
       case 'subscribe:account:balance:reserved': {
-        await Callbacks.callback_account_balance_reserved(subData, entry);
+        await Callbacks.callback_account_balance_reserved(subData, entry, sf);
         break;
       }
       case 'subscribe:account:balance:spendable': {
-        await Callbacks.callback_account_balance_spendable(subData, entry);
+        await Callbacks.callback_account_balance_spendable(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominationPools:rewards': {
-        await Callbacks.callback_nomination_pool_rewards(entry);
+        await Callbacks.callback_nomination_pool_rewards(entry, sf);
         break;
       }
       case 'subscribe:account:nominationPools:state': {
-        await Callbacks.callback_nomination_pool_state(subData, entry);
+        await Callbacks.callback_nomination_pool_state(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominationPools:renamed': {
-        await Callbacks.callback_nomination_pool_renamed(subData, entry);
+        await Callbacks.callback_nomination_pool_renamed(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominationPools:roles': {
-        await Callbacks.callback_nomination_pool_roles(subData, entry);
+        await Callbacks.callback_nomination_pool_roles(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominationPools:commission': {
-        await Callbacks.callback_nomination_pool_commission(subData, entry);
+        await Callbacks.callback_nomination_pool_commission(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominating:pendingPayouts': {
@@ -173,15 +194,15 @@ export class QueryMultiWrapper {
         break;
       }
       case 'subscribe:account:nominating:exposure': {
-        await Callbacks.callback_nominating_exposure(subData, entry);
+        await Callbacks.callback_nominating_exposure(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominating:commission': {
-        await Callbacks.callback_nominating_commission(subData, entry);
+        await Callbacks.callback_nominating_commission(subData, entry, sf);
         break;
       }
       case 'subscribe:account:nominating:nominations': {
-        await Callbacks.callback_nominating_nominations(subData, entry);
+        await Callbacks.callback_nominating_nominations(subData, entry, sf);
         break;
       }
     }
@@ -212,6 +233,9 @@ export class QueryMultiWrapper {
         for (const entry of callEntries) {
           await this.handleCallback(entry, data);
         }
+
+        // Update managed state after all callbacks processed.
+        await this.postCallback(api, chainId, callEntries);
       });
 
       // Replace the entry's unsub function
@@ -221,6 +245,87 @@ export class QueryMultiWrapper {
       // TODO: UI notification
     }
   }
+
+  /**
+   * @name postCallback
+   * @summary Update managed state after processing all callbacks.
+   */
+  private postCallback = async (
+    api: RelayDedotClient,
+    chainId: ChainID,
+    callEntries: ApiCallEntry[]
+  ) => {
+    // Get the task's associated account.
+    const firstEntry = callEntries.at(0);
+    let account: Account | undefined = undefined;
+    if (firstEntry !== undefined) {
+      const { task } = firstEntry;
+      const address = task.account ? task.account.address : null;
+      address && (account = AccountsController.get(chainId, address));
+    }
+
+    if (account) {
+      // Sync account balance.
+      if (this.postCallbackSyncFlags.syncAccountBalance) {
+        const balance = await getBalanceForAccount(
+          api,
+          account.address,
+          account.chain,
+          false
+        );
+        account.balance = balance;
+      }
+
+      // Sync account nominating data.
+      if (this.postCallbackSyncFlags.syncAccountNominating) {
+        const result = await getAccountNominatingData(api, account);
+        if (result) {
+          account.nominatingData = result;
+        }
+      }
+
+      // Sync account nomination pool data.
+      if (this.postCallbackSyncFlags.syncAccountNominationPool) {
+        const result = await getNominationPoolDataForAccount(account);
+        if (result) {
+          account.nominationPoolData = result;
+        }
+      }
+
+      // Set updated account data in the appropriate entries.
+      for (const entry of callEntries) {
+        if (entry.task.account) {
+          entry.task.account = account.flatten();
+        }
+      }
+
+      // Update managed account data.
+      await AccountsController.set(account.chain, account);
+
+      // Reset flags.
+      this.postCallbackSyncFlags = {
+        syncAccountBalance: false,
+        syncAccountNominating: false,
+        syncAccountNominationPool: false,
+      };
+    }
+  };
+
+  /**
+   * @name updateEntryAccountData
+   * @summary Updated cached flattened account data after processing a one-shot.
+   */
+  updateEntryAccountData = (
+    chainId: ChainID,
+    flattened: FlattenedAccountData
+  ) => {
+    const { callEntries } = this.subscriptions.get(chainId)!;
+    for (const entry of callEntries) {
+      if (entry.task.account) {
+        entry.task.account = flattened;
+      }
+    }
+  };
 
   /**
    * @name insert

--- a/packages/renderer/src/orchestrators/TaskOrchestrator.ts
+++ b/packages/renderer/src/orchestrators/TaskOrchestrator.ts
@@ -35,6 +35,9 @@ export class TaskOrchestrator {
   /**
    * @name subscribeTasks
    * @summary Same as `subscribeTask` but for an array of subscription tasks.
+   *
+   * @deprecated The index registry needs to be built synchrously and one subscription
+   * task added at a time.
    */
   static async subscribeTasks(
     tasks: SubscriptionTask[],

--- a/packages/renderer/src/renderer/callbacks/index.ts
+++ b/packages/renderer/src/renderer/callbacks/index.ts
@@ -13,7 +13,10 @@ import {
 } from './nominating';
 import { NotificationsController } from '@ren/controller/NotificationsController';
 import { u8aToString, u8aUnwrapBytes } from '@polkadot/util';
-import type { ApiCallEntry } from '@polkadot-live/types/subscriptions';
+import type {
+  ApiCallEntry,
+  PostCallbackSyncFlags,
+} from '@polkadot-live/types/subscriptions';
 import type { AnyData } from '@polkadot-live/types/misc';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { EventCallback } from '@polkadot-live/types/reporter';
@@ -25,6 +28,7 @@ import type {
 import type {
   PalletBalancesAccountData,
   PalletNominationPoolsBondedPoolInner,
+  PalletStakingActiveEraInfo,
 } from '@dedot/chaintypes/substrate';
 
 export class Callbacks {
@@ -119,6 +123,7 @@ export class Callbacks {
   static async callback_account_balance_free(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -133,9 +138,7 @@ export class Callbacks {
       }
 
       // Get the received balance.
-      const nonce = data.nonce as number;
       const balance = data.data as PalletBalancesAccountData;
-
       const reserved = balance.reserved;
       const free = balance.free - reserved;
       const b = account.balance;
@@ -148,10 +151,7 @@ export class Callbacks {
 
       // Update account data if balance has changed.
       if (!isSame) {
-        account.balance.free = free;
-        account.balance.nonce = BigInt(nonce);
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountBalance = true;
       }
 
       // Create event and parse into same format as persisted events.
@@ -183,6 +183,7 @@ export class Callbacks {
   static async callback_account_balance_frozen(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -197,7 +198,6 @@ export class Callbacks {
       }
 
       // Get the received frozen balance.
-      const nonce = data.nonce as number;
       const balance = data.data as PalletBalancesAccountData;
       const frozen = balance.frozen;
       const b = account.balance;
@@ -210,10 +210,7 @@ export class Callbacks {
 
       // Update account data if balance has changed.
       if (!isSame) {
-        account.balance.frozen = frozen;
-        account.balance.nonce = BigInt(nonce);
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountBalance = true;
       }
 
       // Create event and parse into same format as persisted events.
@@ -245,6 +242,7 @@ export class Callbacks {
   static async callback_account_balance_reserved(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -259,7 +257,6 @@ export class Callbacks {
       }
 
       // Get the received reserved balance.
-      const nonce = data.nonce as number;
       const balance = data.data as PalletBalancesAccountData;
       const reserved = balance.reserved;
       const b = account.balance;
@@ -272,10 +269,7 @@ export class Callbacks {
 
       // Update account data if balance has changed.
       if (!isSame) {
-        account.balance.reserved = reserved;
-        account.balance.nonce = BigInt(nonce);
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountBalance = true;
       }
 
       // Create an event and parse into same format as persisted event.
@@ -306,6 +300,7 @@ export class Callbacks {
   static async callback_account_balance_spendable(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -325,7 +320,6 @@ export class Callbacks {
        */
       const api = await this.getApiOrThrow(account.chain);
       const ed = api.consts.balances.existentialDeposit;
-      const nonce = data.nonce as number;
       const balance = data.data as PalletBalancesAccountData;
 
       const free = balance.free;
@@ -350,9 +344,7 @@ export class Callbacks {
 
       // Update account nonce if balance has changed.
       if (!isSame) {
-        account.balance.nonce = BigInt(nonce);
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountBalance = true;
       }
 
       // Create an event and parse into same format as persisted event.
@@ -391,6 +383,7 @@ export class Callbacks {
    */
   static async callback_nomination_pool_rewards(
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -412,9 +405,7 @@ export class Callbacks {
 
       // Update account and entry data.
       if (!isSame) {
-        account.nominationPoolData!.poolPendingRewards = pending.toString();
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountNominationPool = true;
       }
 
       // Get event and notification.
@@ -444,6 +435,7 @@ export class Callbacks {
   static async callback_nomination_pool_state(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -461,9 +453,7 @@ export class Callbacks {
 
       // Update account and entry data.
       if (!isSame) {
-        account.nominationPoolData!.poolState = state;
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountNominationPool = true;
       }
 
       // Get notification.
@@ -497,6 +487,7 @@ export class Callbacks {
   static async callback_nomination_pool_renamed(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -513,9 +504,7 @@ export class Callbacks {
 
       // Update account and entry data.
       if (!isSame) {
-        account.nominationPoolData!.poolName = poolName;
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountNominationPool = true;
       }
 
       // Get notification.
@@ -549,6 +538,7 @@ export class Callbacks {
   static async callback_nomination_pool_roles(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -582,10 +572,7 @@ export class Callbacks {
 
       // Update account and entry data.
       if (!isSame) {
-        // eslint-disable-next-line prettier/prettier
-        account.nominationPoolData!.poolRoles = { ...roles };
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountNominationPool = true;
       }
 
       // Get notification.
@@ -619,6 +606,7 @@ export class Callbacks {
   static async callback_nomination_pool_commission(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
@@ -658,9 +646,7 @@ export class Callbacks {
 
       // Update account and entry data.
       if (!isSame) {
-        account.nominationPoolData!.poolCommission = cur;
-        await AccountsController.set(account.chain, account);
-        entry.task.account = account.flatten();
+        syncFlags.syncAccountNominationPool = true;
       }
 
       // Get notification.
@@ -744,13 +730,12 @@ export class Callbacks {
   static async callback_nominating_exposure(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
-      // eslint-disable-next-line prettier/prettier
-      const era: number = parseInt(
-        (data.toHuman().index as string).replace(/,/g, '')
-      );
+      const casted = data as PalletStakingActiveEraInfo;
+      const era: number = casted.index;
       const account = checkAccountWithProperties(entry, ['nominatingData']);
       const alreadyKnown = account.nominatingData!.lastCheckedEra >= era;
 
@@ -765,12 +750,9 @@ export class Callbacks {
 
       // Update account nominating data.
       const maybeNominatingData = await getAccountNominatingData(api, account);
-      maybeNominatingData
-        ? (account.nominatingData = { ...maybeNominatingData })
-        : (account.nominatingData = null);
-
-      await AccountsController.set(account.chain, account);
-      entry.task.account = account.flatten();
+      if (maybeNominatingData) {
+        syncFlags.syncAccountNominating = true;
+      }
 
       // Return if exposure has not changed.
       const exposed = maybeNominatingData ? maybeNominatingData.exposed : false;
@@ -813,13 +795,12 @@ export class Callbacks {
   static async callback_nominating_commission(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
-      // eslint-disable-next-line prettier/prettier
-      const era: number = parseInt(
-        (data.toHuman().index as string).replace(/,/g, '')
-      );
+      const casted = data as PalletStakingActiveEraInfo;
+      const era: number = casted.index;
       const account = checkAccountWithProperties(entry, ['nominatingData']);
       const alreadyKnown = account.nominatingData!.lastCheckedEra >= era;
 
@@ -837,12 +818,9 @@ export class Callbacks {
 
       // Update account nominating data.
       const maybeNominatingData = await getAccountNominatingData(api, account);
-      maybeNominatingData
-        ? (account.nominatingData = { ...maybeNominatingData })
-        : (account.nominatingData = null);
-
-      await AccountsController.set(account.chain, account);
-      entry.task.account = account.flatten();
+      if (maybeNominatingData) {
+        syncFlags.syncAccountNominating = true;
+      }
 
       // Return if commissions haven't changed.
       if (maybeNominatingData) {
@@ -893,13 +871,12 @@ export class Callbacks {
   static async callback_nominating_nominations(
     data: AnyData,
     entry: ApiCallEntry,
+    syncFlags: PostCallbackSyncFlags,
     isOneShot = false
   ): Promise<boolean> {
     try {
-      // eslint-disable-next-line prettier/prettier
-      const era: number = parseInt(
-        (data.toHuman().index as string).replace(/,/g, '')
-      );
+      const casted = data as PalletStakingActiveEraInfo;
+      const era: number = casted.index;
       const account = checkAccountWithProperties(entry, ['nominatingData']);
       const alreadyKnown = account.nominatingData!.lastCheckedEra >= era;
 
@@ -917,12 +894,9 @@ export class Callbacks {
 
       // Update account nominating data.
       const maybeNominatingData = await getAccountNominatingData(api, account);
-      maybeNominatingData
-        ? (account.nominatingData = { ...maybeNominatingData })
-        : (account.nominatingData = null);
-
-      await AccountsController.set(account.chain, account);
-      entry.task.account = account.flatten();
+      if (maybeNominatingData) {
+        syncFlags.syncAccountNominating = true;
+      }
 
       // Return if nominations haven't changed.
       if (maybeNominatingData) {

--- a/packages/renderer/src/renderer/callbacks/index.ts
+++ b/packages/renderer/src/renderer/callbacks/index.ts
@@ -544,7 +544,7 @@ export class Callbacks {
    * @name callback_nomination_pool_roles
    * @summary Callback for 'subscribe:account:nominationPools:roles'
    *
-   * When a nomination pool's name changes, dispatch an event and notificaiton.
+   * When a nomination pool's roles changes, dispatch an event and notificaiton.
    */
   static async callback_nomination_pool_roles(
     data: AnyData,

--- a/packages/renderer/src/renderer/callbacks/index.ts
+++ b/packages/renderer/src/renderer/callbacks/index.ts
@@ -750,14 +750,16 @@ export class Callbacks {
 
       // Update account nominating data.
       const maybeNominatingData = await getAccountNominatingData(api, account);
-      if (maybeNominatingData) {
-        syncFlags.syncAccountNominating = true;
-      }
 
       // Return if exposure has not changed.
       const exposed = maybeNominatingData ? maybeNominatingData.exposed : false;
       if (!isOneShot && prevExposed === exposed) {
         return true;
+      }
+
+      // Update account nominating data in post process.
+      if (prevExposed !== exposed) {
+        syncFlags.syncAccountNominating = true;
       }
 
       // Get notification.
@@ -818,9 +820,6 @@ export class Callbacks {
 
       // Update account nominating data.
       const maybeNominatingData = await getAccountNominatingData(api, account);
-      if (maybeNominatingData) {
-        syncFlags.syncAccountNominating = true;
-      }
 
       // Return if commissions haven't changed.
       if (maybeNominatingData) {
@@ -829,6 +828,7 @@ export class Callbacks {
 
         if (!areEqual) {
           hasChanged = true;
+          syncFlags.syncAccountNominating = true;
         } else if (!isOneShot && areEqual) {
           return true;
         }
@@ -894,9 +894,6 @@ export class Callbacks {
 
       // Update account nominating data.
       const maybeNominatingData = await getAccountNominatingData(api, account);
-      if (maybeNominatingData) {
-        syncFlags.syncAccountNominating = true;
-      }
 
       // Return if nominations haven't changed.
       if (maybeNominatingData) {
@@ -905,6 +902,7 @@ export class Callbacks {
 
         if (!areEqual) {
           hasChanged = true;
+          syncFlags.syncAccountNominating = true;
         } else if (!isOneShot && areEqual) {
           return true;
         }

--- a/packages/renderer/src/renderer/contexts/main/Bootstrapping/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/Bootstrapping/index.tsx
@@ -75,17 +75,24 @@ export const BootstrappingProvider = ({
 
   /// Step 3: Connect necessary API instances.
   const connectAPIs = async () => {
-    const chainIds = Array.from(AccountsController.accounts.keys());
-    await Promise.all(chainIds.map((c) => APIsController.connectApi(c)));
+    const isConnected: boolean = await Utils.getOnlineStatus();
+    if (isConnected) {
+      const chainIds = Array.from(AccountsController.accounts.keys());
+      await Promise.all(chainIds.map((c) => APIsController.connectApi(c)));
+    }
   };
 
   /// Step 4: Fetch current account data.
-  const fetchAccountData = async () =>
-    await Promise.all([
-      AccountUtils.fetchAccountBalances(),
-      AccountUtils.fetchAccountNominationPoolData(),
-      AccountUtils.fetchAccountNominatingData(),
-    ]);
+  const fetchAccountData = async () => {
+    const isConnected: boolean = await Utils.getOnlineStatus();
+    if (isConnected) {
+      await Promise.all([
+        AccountUtils.fetchAccountBalances(),
+        AccountUtils.fetchAccountNominationPoolData(),
+        AccountUtils.fetchAccountNominatingData(),
+      ]);
+    }
+  };
 
   /// Step 5: Initiate subscriptions.
   const initSubscriptions = async () => {
@@ -156,7 +163,7 @@ export const BootstrappingProvider = ({
         if (index === 4) {
           // Always initialize intervals controller.
           await task();
-        } else if (!refAborted.current && isConnected) {
+        } else if (!refAborted.current) {
           await task();
         }
       }

--- a/packages/renderer/src/renderer/contexts/main/Subscriptions/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/Subscriptions/index.tsx
@@ -196,8 +196,11 @@ export const SubscriptionsProvider = ({
         }
 
         // Subscribe to tasks.
-        account.queryMulti &&
-          (await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti));
+        if (account.queryMulti) {
+          for (const task of tasks) {
+            await TaskOrchestrator.subscribeTask(task, account.queryMulti);
+          }
+        }
 
         // Analytics.
         const event = `subscriptions-account-category-${targetStatus === 'enable' ? 'off' : 'on'}`;

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -167,9 +167,11 @@ export const useMainMessagePorts = () => {
         }
 
         // Subscribe to tasks if app setting enabled.
-        !fromBackup &&
-          ConfigRenderer.enableAutomaticSubscriptions &&
-          (await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti));
+        if (!fromBackup && account.queryMulti !== null) {
+          for (const task of tasks) {
+            await TaskOrchestrator.subscribeTask(task, account.queryMulti);
+          }
+        }
 
         // Update React subscriptions state.
         SubscriptionsController.syncAccountSubscriptionsState();

--- a/packages/renderer/src/utils/AccountUtils.ts
+++ b/packages/renderer/src/utils/AccountUtils.ts
@@ -51,29 +51,21 @@ export const processOneShotPostCallback = async (
 ) => {
   // Sync account balance.
   if (syncFlags.syncAccountBalance) {
-    const balance = await getBalanceForAccount(
-      api,
-      account.address,
-      account.chain,
-      false
-    );
+    const { address, chain } = account;
+    const balance = await getBalanceForAccount(api, address, chain, false);
     account.balance = balance;
   }
 
   // Sync account nominating data.
   if (syncFlags.syncAccountNominating) {
     const result = await getAccountNominatingData(api, account);
-    if (result) {
-      account.nominatingData = result;
-    }
+    result && (account.nominatingData = result);
   }
 
   // Sync account nomination pool data.
   if (syncFlags.syncAccountNominationPool) {
     const result = await getNominationPoolDataForAccount(account);
-    if (result) {
-      account.nominationPoolData = result;
-    }
+    result && (account.nominationPoolData = result);
   }
 
   // Update managed account data.

--- a/packages/renderer/src/utils/AccountUtils.ts
+++ b/packages/renderer/src/utils/AccountUtils.ts
@@ -108,7 +108,7 @@ export const fetchAccountBalances = async () => {
  * @summary Fetch balance data for a single account.
  */
 export const fetchBalanceForAccount = async (account: Account) => {
-  if (!['Polkadot', 'Kusama', 'Westend'].includes(account.chain)) {
+  if (!Array.from(ChainList.keys()).includes(account.chain)) {
     return;
   }
 
@@ -206,7 +206,7 @@ export const fetchNominatingDataForAccount = async (account: Account) => {
  */
 export const setNominatingDataForAccount = async (account: Account) => {
   // Only allow nominating data on specific chains.
-  if (!['Polkadot', 'Kusama', 'Westend'].includes(account.chain)) {
+  if (!Array.from(ChainList.keys()).includes(account.chain)) {
     return;
   }
 

--- a/packages/renderer/src/utils/AccountUtils.ts
+++ b/packages/renderer/src/utils/AccountUtils.ts
@@ -262,7 +262,7 @@ export const getNominationPoolRewards = async (
  * pool data.
  */
 const setNominationPoolDataForAccount = async (account: Account) => {
-  if (!['Polkadot', 'Kusama', 'Westend'].includes(account.chain)) {
+  if (!Array.from(ChainList.keys()).includes(account.chain)) {
     return;
   }
 
@@ -295,11 +295,12 @@ const setNominationPoolDataForAccount = async (account: Account) => {
   const { depositor, root, nominator, bouncer } = npResult.roles;
   const { changeRate, current, max, throttleFrom } = npResult.commission;
 
+  const prefix = api.consts.system.ss58Prefix;
   const poolRoles: NominationPoolRoles = {
-    depositor: depositor.raw,
-    root: root?.raw || undefined,
-    nominator: nominator?.raw || undefined,
-    bouncer: bouncer?.raw || undefined,
+    depositor: depositor.address(prefix),
+    root: root ? root.address(prefix) : undefined,
+    nominator: nominator ? nominator.address(prefix) : undefined,
+    bouncer: bouncer ? bouncer.address(prefix) : undefined,
   };
 
   const poolCommission: NominationPoolCommission = {

--- a/packages/types/src/subscriptions.ts
+++ b/packages/types/src/subscriptions.ts
@@ -39,6 +39,12 @@ export interface IntervalSubscription {
   justBuilt?: boolean;
 }
 
+export interface PostCallbackSyncFlags {
+  syncAccountBalance: boolean;
+  syncAccountNominationPool: boolean;
+  syncAccountNominating: boolean;
+}
+
 export type SubscriptionNextStatus = 'enable' | 'disable';
 
 export interface SubscriptionTask {


### PR DESCRIPTION
- [x] Fix nomination pool roles data
  Role addresses are encoded before being cached for use in the application, and can be compared correctly in the subscription callback. 

- [x] Fix data index registry
  The batch `subscribeTasks` method has been temporarily deprecated because of the data index registry being incorrectly built for query multi handling. Subscriptions are currently built one-by-one. This code should be optimised in a future PR. 

- [x] Fix offline app initialisation
  The main window initialises imported accounts and subscriptions correctly when the app starts offline.

- [x] Fix post subscription callback processing
  Managed account data is updated after all subscription callbacks have finished processing. Managed state was previously being updated within the callback itself, potentially invalidating subsequent callbacks that should have been processed.