### PR TITLE
fix: batched task query building

### DIFF
--- a/packages/renderer/src/controller/AccountsController.ts
+++ b/packages/renderer/src/controller/AccountsController.ts
@@ -83,9 +83,7 @@ export class AccountsController {
 
         if (account.queryMulti !== null) {
           const tasks: SubscriptionTask[] = JSON.parse(stored);
-          for (const task of tasks) {
-            await TaskOrchestrator.subscribeTask(task, account.queryMulti);
-          }
+          await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
         }
       }
     }
@@ -109,9 +107,7 @@ export class AccountsController {
       );
 
       if (tasks.length && account.queryMulti) {
-        for (const task of tasks) {
-          await TaskOrchestrator.subscribeTask(task, account.queryMulti);
-        }
+        await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
       }
     }
   }
@@ -128,9 +124,7 @@ export class AccountsController {
       for (const account of accounts) {
         if (account.queryMulti) {
           const tasks = account.getSubscriptionTasks() || [];
-          for (const task of tasks) {
-            await TaskOrchestrator.subscribeTask(task, account.queryMulti);
-          }
+          await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
         }
       }
     }
@@ -152,9 +146,7 @@ export class AccountsController {
 
     // Send tasks to query multi wrapper for removal.
     if (tasks && tasks.length && account && account.queryMulti) {
-      for (const task of tasks) {
-        await TaskOrchestrator.subscribeTask(task, account.queryMulti);
-      }
+      await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
 
       // Remove tasks from electron store.
       // TODO: Batch removal of task data in electron store.

--- a/packages/renderer/src/controller/SubscriptionsController.ts
+++ b/packages/renderer/src/controller/SubscriptionsController.ts
@@ -73,9 +73,7 @@ export class SubscriptionsController {
       serialized !== '' ? JSON.parse(serialized) : [];
 
     // Subscribe to tasks.
-    for (const task of tasks) {
-      await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
-    }
+    await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
   }
 
   /**
@@ -90,9 +88,7 @@ export class SubscriptionsController {
 
     // Get subscription task array and subscribe to batched tasks.
     const tasks = this.chainSubscriptions?.getSubscriptionTasks() || [];
-    for (const task of tasks) {
-      await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
-    }
+    await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
   }
 
   /**
@@ -109,9 +105,7 @@ export class SubscriptionsController {
       .getSubscriptionTasks()
       .filter((task) => task.chainId === chainId);
 
-    for (const task of tasks) {
-      await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
-    }
+    await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
   }
 
   /**
@@ -134,9 +128,7 @@ export class SubscriptionsController {
    */
   static async subscribeChainTasks(tasks: SubscriptionTask[]) {
     if (this.chainSubscriptions) {
-      for (const task of tasks) {
-        await TaskOrchestrator.subscribeTask(task, this.chainSubscriptions);
-      }
+      await TaskOrchestrator.subscribeTasks(tasks, this.chainSubscriptions);
     } else {
       throw new Error(
         'Error: SubscriptionsController::subscribeChainTask QueryMultiWrapper null'

--- a/packages/renderer/src/orchestrators/TaskOrchestrator.ts
+++ b/packages/renderer/src/orchestrators/TaskOrchestrator.ts
@@ -29,15 +29,16 @@ export class TaskOrchestrator {
   ) {
     const isOnline: boolean = await getOnlineStatus();
     this.next(task, wrapper);
-    isOnline && (await wrapper.build(task.chainId));
+
+    if (isOnline) {
+      await wrapper.build(task.chainId);
+      await wrapper.run(task.chainId);
+    }
   }
 
   /**
    * @name subscribeTasks
    * @summary Same as `subscribeTask` but for an array of subscription tasks.
-   *
-   * @deprecated The index registry needs to be built synchrously and one subscription
-   * task added at a time.
    */
   static async subscribeTasks(
     tasks: SubscriptionTask[],
@@ -51,6 +52,7 @@ export class TaskOrchestrator {
     // Cache task in its owner account's query multi wrapper.
     for (const task of tasks) {
       this.next(task, wrapper);
+      await wrapper.build(task.chainId);
     }
 
     // Build the tasks if the app is in online mode.
@@ -58,7 +60,7 @@ export class TaskOrchestrator {
     if (isOnline) {
       const chainIds = new Set(tasks.map((t) => t.chainId));
       for (const chainId of chainIds) {
-        isOnline && (await wrapper.build(chainId));
+        await wrapper.run(chainId);
       }
     }
   }

--- a/packages/renderer/src/renderer/contexts/main/Subscriptions/index.tsx
+++ b/packages/renderer/src/renderer/contexts/main/Subscriptions/index.tsx
@@ -197,9 +197,7 @@ export const SubscriptionsProvider = ({
 
         // Subscribe to tasks.
         if (account.queryMulti) {
-          for (const task of tasks) {
-            await TaskOrchestrator.subscribeTask(task, account.queryMulti);
-          }
+          await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
         }
 
         // Analytics.

--- a/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/renderer/hooks/useMainMessagePorts.ts
@@ -168,9 +168,7 @@ export const useMainMessagePorts = () => {
 
         // Subscribe to tasks if app setting enabled.
         if (!fromBackup && account.queryMulti !== null) {
-          for (const task of tasks) {
-            await TaskOrchestrator.subscribeTask(task, account.queryMulti);
-          }
+          await TaskOrchestrator.subscribeTasks(tasks, account.queryMulti);
         }
 
         // Update React subscriptions state.


### PR DESCRIPTION
Separately functions for building an account's query multi argument, and actually running the query multi.

Allows building the full argument  before running the subscription.