### PR TITLE
fix: wallet connect namespace

### DIFF
--- a/packages/renderer/src/contexts/main/WalletConnect/index.tsx
+++ b/packages/renderer/src/contexts/main/WalletConnect/index.tsx
@@ -91,7 +91,7 @@ export const WalletConnectProvider = ({
       return [
         `polkadot:${wc.WC_POLKADOT_CAIP_ID}`,
         `polkadot:${wc.WC_KUSAMA_CAIP_ID}`,
-        `polkadot:${wc.WC_WESTEND_CAIP_ID}`,
+        `polkadot:${wc.WC_WESTMINT_CAIP_ID}`,
       ];
     }
   };
@@ -102,14 +102,18 @@ export const WalletConnectProvider = ({
   const getAddressPrefix = (chainId: ChainID) => {
     switch (chainId) {
       case 'Polkadot':
-      case 'Polkadot Asset Hub': {
+      case 'Polkadot Asset Hub':
+      case 'Polkadot People': {
         return 0;
       }
-      case 'Kusama': {
+      case 'Kusama':
+      case 'Kusama Asset Hub':
+      case 'Kusama People': {
         return 2;
       }
       case 'Westend':
-      case 'Westend Asset Hub': {
+      case 'Westend Asset Hub':
+      case 'Westend People': {
         return 42;
       }
     }

--- a/packages/renderer/src/screens/Action/ExtrinsicItemContent.tsx
+++ b/packages/renderer/src/screens/Action/ExtrinsicItemContent.tsx
@@ -68,11 +68,7 @@ export const ExtrinsicItemContent = ({
               {renderSummaryButton()}
               <Signer
                 info={info}
-                valid={
-                  info.actionMeta.source !== 'wallet-connect' &&
-                  !isBuildingExtrinsic &&
-                  info.estimatedFee !== undefined
-                }
+                valid={!isBuildingExtrinsic && info.estimatedFee !== undefined}
               />
             </FlexRow>
           </ResponsiveRow>
@@ -93,11 +89,7 @@ export const ExtrinsicItemContent = ({
               {renderSummaryButton()}
               <Signer
                 info={info}
-                valid={
-                  info.actionMeta.source !== 'wallet-connect' &&
-                  !isBuildingExtrinsic &&
-                  info.estimatedFee !== undefined
-                }
+                valid={!isBuildingExtrinsic && info.estimatedFee !== undefined}
               />
             </FlexRow>
           </ResponsiveRow>
@@ -118,11 +110,7 @@ export const ExtrinsicItemContent = ({
               {renderSummaryButton()}
               <Signer
                 info={info}
-                valid={
-                  info.actionMeta.source !== 'wallet-connect' &&
-                  !isBuildingExtrinsic &&
-                  info.estimatedFee !== undefined
-                }
+                valid={!isBuildingExtrinsic && info.estimatedFee !== undefined}
               />
             </FlexRow>
           </ResponsiveRow>

--- a/packages/renderer/src/screens/Action/index.tsx
+++ b/packages/renderer/src/screens/Action/index.tsx
@@ -23,7 +23,7 @@ import { BarLoader } from 'react-spinners';
 import { DialogExtrinsicSummary } from './Dialogs';
 import { useEffect, useState } from 'react';
 import { PaginationRow } from '../OpenGov/Referenda/Wrappers';
-import { FadeInWrapper, renderToast } from '@polkadot-live/ui/utils';
+import { FadeInWrapper } from '@polkadot-live/ui/utils';
 import type { ExtrinsicInfo, TxStatus } from '@polkadot-live/types/tx';
 import type { TriggerRightIconProps } from './types';
 
@@ -365,17 +365,7 @@ export const Action = () => {
                         isBuilt={info.estimatedFee !== undefined}
                         txStatus={info.txStatus}
                         onDelete={async () => await removeExtrinsic(info)}
-                        onSign={() => {
-                          if (info.actionMeta.source === 'wallet-connect') {
-                            renderToast(
-                              'WalletConnect Currently Disabled',
-                              'wc-disabled',
-                              'error'
-                            );
-                          } else {
-                            initTxDynamicInfo(info.txId);
-                          }
-                        }}
+                        onSign={() => initTxDynamicInfo(info.txId)}
                         onMockSign={() => submitMockTx(info.txId)}
                       />
                     </div>


### PR DESCRIPTION
Request Westend Asset Hub accounts in WalletConnect session namespace to enable signing extrinsics for the chain.