### PR TITLE
fix(ci): markdown link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
       - name: Check License Lines
         uses: kt3k/license_checker@v1.0.6
   
-  # NOTE: replace `markdown-link-check` with <https://github.com/UmbrellaDocs/linkspector> when
-  # Github Action is available.
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
@@ -27,7 +25,7 @@ jobs:
         with:
           cache: 'yarn'
       - name: Check Markdown Links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: tcort/github-action-markdown-link-check@v1
         with:
           base-branch: main
           use-quiet-mode: 'yes'

--- a/check-markdown-links-config.json
+++ b/check-markdown-links-config.json
@@ -6,5 +6,10 @@
         "Accept-Encoding": "zstd, br, gzip, deflate"
       }
     }
+  ],
+    "ignorePatterns": [
+    {
+      "pattern": "https://github\\.com/.*/compare/.*\\.\\.\\..*"
+    }
   ]
 }


### PR DESCRIPTION
- Updates the markdown link check GitHub action
- Adds an ignore pattern to disable checking GitHub compare URLs