### PR TITLE
fix(metadata): ensure Uint8Array input to MerkleizedMetadata

### DIFF
--- a/packages/core/src/controllers/ExtrinsicsController.ts
+++ b/packages/core/src/controllers/ExtrinsicsController.ts
@@ -24,6 +24,7 @@ import type {
 } from '@polkadot-live/types/tx';
 import type { SignerPayloadRaw } from 'dedot/types';
 import * as $ from '@dedot/shape';
+import { $Metadata } from 'dedot/codecs';
 
 const TOKEN_TRANSFER_LIMIT = '100';
 
@@ -197,11 +198,11 @@ export class ExtrinsicsController {
 
       // Build and cache payload.
       const { tx } = cached;
-      let rawPayload: SignerPayloadRaw;
+      let rawPayload: SignerPayloadRaw | null = null;
 
       if (source === 'ledger') {
         const { units, unit } = ChainList.get(chainId)!;
-        const metadata = api.metadata;
+        const metadata = $Metadata.tryEncode(api.metadata);
         const merkleizer = new MerkleizedMetadata(metadata, {
           decimals: units,
           tokenSymbol: unit,

--- a/packages/renderer/src/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/hooks/useActionMessagePorts.ts
@@ -85,7 +85,13 @@ export const useActionMessagePorts = () => {
    * @summary Set tx data in actions window sent from extrinsics controller.
    */
   const handleTxReportData = (ev: MessageEvent) => {
-    const { accountNonce, genesisHash, txId, txPayload } = ev.data.data;
+    interface Target {
+      accountNonce: number;
+      genesisHash: `0x${string}`;
+      txId: string;
+      txPayload: Uint8Array;
+    }
+    const { accountNonce, genesisHash, txId, txPayload }: Target = ev.data.data;
 
     setTxDynamicInfo(txId, {
       accountNonce: String(accountNonce),

--- a/packages/renderer/src/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/hooks/useMainMessagePorts.ts
@@ -354,6 +354,7 @@ export const useMainMessagePorts = () => {
     const info: ExtrinsicInfo = JSON.parse(serialized);
     ExtrinsicsController.submit(info);
   };
+
   /**
    * @name handleTxMockSubmit
    * @summary Mock an extrinsic submission for UI testing.

--- a/packages/types/src/tx.ts
+++ b/packages/types/src/tx.ts
@@ -75,7 +75,7 @@ export interface AddressInfo {
 
 export interface ExtrinsicDynamicInfo {
   accountNonce: string;
-  genesisHash: Uint8Array;
+  genesisHash: `0x${string}`;
   txPayload: Uint8Array;
   txSignature?: `0x${string}`;
 }


### PR DESCRIPTION
The following code currently works in the development build but throws a `TypeError` exception in the production build:

```ts
const metadata = api.metadata;
const merkleizer = new MerkleizedMetadata(metadata, { decimals, tokenSymbol });
```

The production build expects the `metadata` argument to be of type `Uint8Array`. The following code is currently in place to ensure this:

```ts
import { $Metadata } from 'dedot/codecs';
const metadata = $Metadata.tryEncode(api.metadata);
const merkleizer = new MerkleizedMetadata(metadata, { decimals, tokenSymbol });
```