### PR TITLE
fix(ui): normalise top and bottom spacing around dialogs

### DIFF
--- a/packages/ui/src/styles/dialog.ts
+++ b/packages/ui/src/styles/dialog.ts
@@ -59,7 +59,7 @@ export const DialogContent = styled(Dialog.Content).attrs<{
   left: 50%;
   transform: translate(-50%, -40%);
   width: 90vw;
-  max-height: 85vh;
+  max-height: calc(100vh - 1rem);
   padding: 2.25rem 2rem;
   animation: dialog_contentShow 400ms cubic-bezier(0.16, 1, 0.3, 1);
 


### PR DESCRIPTION
Fix the excessive top and bottom spacing around open dialogs.