### PR TITLE
feat(extrinsics): store and track transaction hash

### DIFF
--- a/packages/core/src/controllers/ExtrinsicsController.ts
+++ b/packages/core/src/controllers/ExtrinsicsController.ts
@@ -421,13 +421,14 @@ export class ExtrinsicsController {
   ) => {
     const {
       txId,
+      txHash,
       actionMeta: { eventUid, chainId },
     } = info;
 
     // Report status in actions window.
     ConfigRenderer.portToAction?.postMessage({
       task: 'action:tx:report:status',
-      data: { status, txId },
+      data: txHash ? { status, txId, txHash } : { status, txId },
     });
 
     if (eventUid) {

--- a/packages/core/src/controllers/ExtrinsicsController.ts
+++ b/packages/core/src/controllers/ExtrinsicsController.ts
@@ -365,7 +365,7 @@ export class ExtrinsicsController {
         extra: extra!.data,
       });
 
-      const unsub = await tx.send(async ({ status }) => {
+      const unsub = await tx.send(async ({ status, txHash }) => {
         switch (status.type) {
           case 'Broadcasting': {
             this.postTxStatus('submitted', info);
@@ -390,6 +390,7 @@ export class ExtrinsicsController {
             break;
           }
           case 'Finalized': {
+            info.txHash = txHash;
             this.postTxStatus('finalized', info);
 
             if (!(await this.silenceOsNotifications())) {

--- a/packages/renderer/src/contexts/action/TxMeta/defaults.ts
+++ b/packages/renderer/src/contexts/action/TxMeta/defaults.ts
@@ -29,6 +29,7 @@ export const defaultTxMeta: TxMetaContextInterface = {
   setFilterOption: () => {},
   setPage: () => {},
   setTxDynamicInfo: () => {},
+  setTxHash: () => {},
   setTxSignature: () => {},
   submitTx: () => {},
   submitMockTx: () => {},

--- a/packages/renderer/src/contexts/action/TxMeta/types.ts
+++ b/packages/renderer/src/contexts/action/TxMeta/types.ts
@@ -37,6 +37,7 @@ export interface TxMetaContextInterface {
   setFilterOption: (filter: TxStatus, selected: boolean) => void;
   setPage: (page: number) => void;
   setTxDynamicInfo: (txId: string, dynamicInfo: ExtrinsicDynamicInfo) => void;
+  setTxHash: (txId: string, txHash: `0x${string}`) => void;
   setTxSignature: (txId: string, s: AnyJson) => void;
   submitTx: (txId: string) => void;
   submitMockTx: (txId: string) => void;

--- a/packages/renderer/src/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/hooks/useActionMessagePorts.ts
@@ -10,7 +10,7 @@ import {
 } from '@ren/contexts/action';
 import { useOverlay } from '@polkadot-live/ui/contexts';
 import { renderToast } from '@polkadot-live/ui/utils';
-import type { ActionMeta } from '@polkadot-live/types/tx';
+import type { ActionMeta, TxStatus } from '@polkadot-live/types/tx';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { LedgerErrorMeta } from '@polkadot-live/types/ledger';
 
@@ -26,6 +26,7 @@ export const useActionMessagePorts = () => {
     setEstimatedFee,
     setTxDynamicInfo,
     updateAccountName,
+    setTxHash,
     updateTxStatus,
   } = useTxMeta();
 
@@ -107,7 +108,15 @@ export const useActionMessagePorts = () => {
    * @summary Update the status for a transaction.
    */
   const handleSetTxStatus = async (ev: MessageEvent) => {
-    const { txId, status } = ev.data.data;
+    const { txId, status }: { txId: string; status: TxStatus } = ev.data.data;
+
+    // Handle transaction hash.
+    if (status === 'finalized') {
+      const { txHash }: { txHash: `0x${string}` } = ev.data.data;
+      setTxHash(txId, txHash);
+    }
+
+    // Also updates store with transaction hash.
     await updateTxStatus(txId, status);
   };
 

--- a/packages/types/src/tx.ts
+++ b/packages/types/src/tx.ts
@@ -93,10 +93,12 @@ export interface ExtrinsicInfo {
   timestamp: number;
   // Data set dynamically before submitting the extrinsic.
   dynamicInfo?: ExtrinsicDynamicInfo;
+  // Tx hash set after extrinsic finalized.
+  txHash?: `0x${string}`;
 }
 
 /**
- * Specific data send with a transfer extrinsic.
+ * Specific data sent with a transfer extrinsic.
  */
 export interface ExTransferKeepAliveData {
   recipientAddress: string;


### PR DESCRIPTION
Cache and persist the transaction hash when a submitted extrinsic is finalised on the network.