### PR TITLE
feat(ui): integrate block explorer link for extrinsics

### DIFF
--- a/packages/renderer/src/screens/Action/Dropdowns/ExtrinsicDropdownMenu.tsx
+++ b/packages/renderer/src/screens/Action/Dropdowns/ExtrinsicDropdownMenu.tsx
@@ -18,10 +18,12 @@ import type { ExtrinsicDropdownMenuProps } from './types';
 export const ExtrinsicDropdownMenu = ({
   isBuilt,
   txStatus,
+  hasTxHash,
   onSign,
   onMockSign,
   onDelete,
   onSummaryClick,
+  onBlockExplorerClick,
 }: ExtrinsicDropdownMenuProps) => {
   const { showMockUI } = useTxMeta();
   const { cacheGet, getTheme, getOnlineMode } = useConnections();
@@ -89,7 +91,6 @@ export const ExtrinsicDropdownMenu = ({
             </DropdownMenu.Item>
           )}
 
-          <DropdownMenu.Separator className="DropdownMenuSeparator" />
           <DropdownMenu.Item
             className="DropdownMenuItem"
             disabled={isBuildingExtrinsic}
@@ -99,6 +100,21 @@ export const ExtrinsicDropdownMenu = ({
               <FontAwesomeIcon icon={FA.faTrash} transform={'shrink-3'} />
             </div>
             <span>Delete</span>
+          </DropdownMenu.Item>
+
+          <DropdownMenu.Separator className="DropdownMenuSeparator" />
+          <DropdownMenu.Item
+            className="DropdownMenuItem"
+            onSelect={() => onBlockExplorerClick()}
+            disabled={!hasTxHash}
+          >
+            <div className="LeftSlot">
+              <FontAwesomeIcon
+                icon={FA.faUpRightFromSquare}
+                transform={'shrink-3'}
+              />
+            </div>
+            <span>Block Explorer</span>
           </DropdownMenu.Item>
 
           {/** Arrow */}

--- a/packages/renderer/src/screens/Action/Dropdowns/types.ts
+++ b/packages/renderer/src/screens/Action/Dropdowns/types.ts
@@ -5,9 +5,11 @@ import type { TxStatus } from 'packages/types/src';
 
 export interface ExtrinsicDropdownMenuProps {
   isBuilt: boolean;
+  hasTxHash: boolean;
   txStatus: TxStatus;
   onSign: () => void;
   onMockSign: () => void;
   onDelete: () => void;
   onSummaryClick: () => void;
+  onBlockExplorerClick: () => void;
 }

--- a/packages/renderer/src/screens/Action/index.tsx
+++ b/packages/renderer/src/screens/Action/index.tsx
@@ -7,6 +7,7 @@ import * as UI from '@polkadot-live/ui/components';
 import * as FA from '@fortawesome/free-solid-svg-icons';
 
 import { DropdownExtrinsicsFilter, ExtrinsicDropdownMenu } from './Dropdowns';
+import { getSubscanSubdomain } from '@polkadot-live/consts/chains';
 import { ellipsisFn } from '@w3ux/utils';
 import { formatDistanceToNow } from 'date-fns';
 import { useActionMessagePorts } from '@ren/hooks/useActionMessagePorts';
@@ -362,8 +363,18 @@ export const Action = () => {
                           setDialogInfo(info);
                           setDialogOpen(true);
                         }}
+                        onBlockExplorerClick={() => {
+                          if (!info.txHash) {
+                            return;
+                          }
+                          const { chainId } = info.actionMeta;
+                          const network = getSubscanSubdomain(chainId);
+                          const uri = `https://${network}.subscan.io/extrinsic/${info.txHash}`;
+                          window.myAPI.openBrowserURL(uri);
+                        }}
                         isBuilt={info.estimatedFee !== undefined}
                         txStatus={info.txStatus}
+                        hasTxHash={Boolean(info.txHash)}
                         onDelete={async () => await removeExtrinsic(info)}
                         onSign={() => initTxDynamicInfo(info.txId)}
                         onMockSign={() => submitMockTx(info.txId)}


### PR DESCRIPTION
Adds a "Block Explorer" link to the extrinsics menu.

The link is enabled once a transaction is finalised. Clicking it opens detailed extrinsic info in an external block explorer.