### PR TITLE
feat(ui): wallet connect signing feedback

### DIFF
--- a/packages/consts/src/walletConnect.ts
+++ b/packages/consts/src/walletConnect.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import type { ChainID } from '@polkadot-live/types/chains';
-import type { WcSelectNetwork } from '@polkadot-live/types/walletConnect';
+import type {
+  WalletConnectMeta,
+  WcErrorStatusCode,
+  WcSelectNetwork,
+} from '@polkadot-live/types/walletConnect';
 
 export const WC_PROJECT_ID = 'ebded8e9ff244ba8b6d173b6c2885d87';
 export const WC_RELAY_URL = 'wss://relay.walletconnect.com';
@@ -59,4 +63,50 @@ export const getWalletConnectChainId = (chainId: ChainID) => {
     case 'Westend Asset Hub':
       return WC_WESTMINT_CAIP_ID;
   }
+};
+
+/**
+ * WalletConnect error feedback.
+ */
+export const wcErrorFeedback: Record<WcErrorStatusCode, WalletConnectMeta> = {
+  WcAccountNotApproved: {
+    ack: 'failure',
+    statusCode: 'WcAccountNotApproved',
+    body: { msg: 'The signing account is not authorized in the session.' },
+  },
+  WcCancelPending: {
+    ack: 'failure',
+    statusCode: 'WcCancelPending',
+    body: { msg: 'Cancel the pending signing request to proceed.' },
+  },
+  WcCatchAll: {
+    ack: 'failure',
+    statusCode: 'WcCatchAll',
+    body: { msg: 'Something went wrong with WalletConnect.' },
+  },
+  WcCanceledTx: {
+    ack: 'failure',
+    statusCode: 'WcCanceledTx',
+    body: { msg: 'The signing request has been canceled.' },
+  },
+  WcInsufficientTxData: {
+    ack: 'failure',
+    statusCode: 'WcInsufficientTxData',
+    body: { msg: 'Unable to proceed with signing due to incomplete data.' },
+  },
+  WcNotInitialized: {
+    ack: 'failure',
+    statusCode: 'WcNotInitialized',
+    body: { msg: 'WalletConnect is unavailable.' },
+  },
+  WcSessionError: {
+    ack: 'failure',
+    statusCode: 'WcSessionError',
+    body: { msg: 'Establish a new WalletConnect session to proceed.' },
+  },
+  WcSessionNotFound: {
+    ack: 'failure',
+    statusCode: 'WcSessionNotFound',
+    body: { msg: 'WalletConnect session not found.' },
+  },
 };

--- a/packages/renderer/src/Providers.tsx
+++ b/packages/renderer/src/Providers.tsx
@@ -48,6 +48,7 @@ import {
 // Actions window contexts.
 import {
   LedgerFeedbackProvider,
+  WcFeedbackProvider,
   TxMetaProvider,
   WcVerifierProvider,
 } from '@ren/contexts/action';
@@ -137,8 +138,9 @@ const getProvidersForWindow = () => {
         OverlayProvider,
         ConnectionsProvider,
         TxMetaProvider,
+        WcVerifierProvider,
         LedgerFeedbackProvider,
-        WcVerifierProvider
+        WcFeedbackProvider
       )(Theme);
     }
     case 'openGov': {

--- a/packages/renderer/src/contexts/action/WcFeedback/defaults.ts
+++ b/packages/renderer/src/contexts/action/WcFeedback/defaults.ts
@@ -1,0 +1,11 @@
+// Copyright 2025 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import type { WcFeedbackContextInterface } from './types';
+
+export const defaultWcFeedbackContext: WcFeedbackContextInterface = {
+  message: null,
+  clearFeedback: () => {},
+  resolveMessage: () => {},
+};

--- a/packages/renderer/src/contexts/action/WcFeedback/index.tsx
+++ b/packages/renderer/src/contexts/action/WcFeedback/index.tsx
@@ -1,0 +1,45 @@
+// Copyright 2025 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import * as defaults from './defaults';
+import { createContext, useContext, useState } from 'react';
+import type { WalletConnectMeta } from '@polkadot-live/types/walletConnect';
+import type { WcFeedbackContextInterface } from './types';
+
+export const WcFeedbackContext = createContext<WcFeedbackContextInterface>(
+  defaults.defaultWcFeedbackContext
+);
+
+export const useWcFeedback = () => useContext(WcFeedbackContext);
+
+export const WcFeedbackProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [message, setMessage] = useState<WalletConnectMeta | null>(null);
+
+  /**
+   * Clear feedback state.
+   */
+  const clearFeedback = () => setMessage(null);
+
+  /**
+   * Set feedback message state based on received status code.
+   */
+  const resolveMessage = (errorMeta: WalletConnectMeta) => {
+    setMessage(errorMeta);
+  };
+
+  return (
+    <WcFeedbackContext.Provider
+      value={{
+        message,
+        clearFeedback,
+        resolveMessage,
+      }}
+    >
+      {children}
+    </WcFeedbackContext.Provider>
+  );
+};

--- a/packages/renderer/src/contexts/action/WcFeedback/types.ts
+++ b/packages/renderer/src/contexts/action/WcFeedback/types.ts
@@ -1,0 +1,10 @@
+// Copyright 2025 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import type { WalletConnectMeta } from '@polkadot-live/types/walletConnect';
+
+export interface WcFeedbackContextInterface {
+  message: WalletConnectMeta | null;
+  clearFeedback: () => void;
+  resolveMessage: (errorMeta: WalletConnectMeta) => void;
+}

--- a/packages/renderer/src/contexts/action/index.ts
+++ b/packages/renderer/src/contexts/action/index.ts
@@ -3,4 +3,5 @@
 
 export * from './LedgerFeedback';
 export * from './TxMeta';
+export * from './WcFeedback';
 export * from './WcVerifier';

--- a/packages/renderer/src/contexts/main/WalletConnect/types.ts
+++ b/packages/renderer/src/contexts/main/WalletConnect/types.ts
@@ -15,7 +15,7 @@ export interface WalletConnectContextInterface {
     errorThrown: boolean;
   }) => void;
   setSigningChain: (signingChain: ChainID | null) => void;
-  tryCacheSession: () => Promise<void>;
+  tryCacheSession: (origin?: 'extrinsics' | 'import' | null) => Promise<void>;
   wcEstablishSessionForExtrinsic: (
     signingAddress: string,
     chainId: ChainID

--- a/packages/renderer/src/hooks/useActionMessagePorts.ts
+++ b/packages/renderer/src/hooks/useActionMessagePorts.ts
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import {
   useLedgerFeedback,
   useTxMeta,
+  useWcFeedback,
   useWcVerifier,
 } from '@ren/contexts/action';
 import { useOverlay } from '@polkadot-live/ui/contexts';
@@ -13,6 +14,7 @@ import { renderToast } from '@polkadot-live/ui/utils';
 import type { ActionMeta, TxStatus } from '@polkadot-live/types/tx';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { LedgerErrorMeta } from '@polkadot-live/types/ledger';
+import type { WalletConnectMeta } from '@polkadot-live/types/walletConnect';
 
 export const useActionMessagePorts = () => {
   /**
@@ -31,6 +33,7 @@ export const useActionMessagePorts = () => {
   } = useTxMeta();
 
   const { resolveMessage, setIsSigning } = useLedgerFeedback();
+  const { resolveMessage: resolveWcMessage, clearFeedback } = useWcFeedback();
   const { setDisableClose, setStatus: setOverlayStatus } = useOverlay();
   const { setWcAccountApproved, setWcAccountVerifying } = useWcVerifier();
 
@@ -181,6 +184,12 @@ export const useActionMessagePorts = () => {
               const { approved }: { approved: boolean } = ev.data.data;
               setWcAccountApproved(approved);
               setWcAccountVerifying(false);
+              approved && clearFeedback();
+              break;
+            }
+            case 'action:wc:error': {
+              const feedback: WalletConnectMeta = ev.data.data;
+              resolveWcMessage(feedback);
               break;
             }
             case 'action:wc:modal:close': {

--- a/packages/renderer/src/hooks/useMainMessagePorts.ts
+++ b/packages/renderer/src/hooks/useMainMessagePorts.ts
@@ -894,7 +894,7 @@ export const useMainMessagePorts = () => {
                 ev.data.data;
 
               setSigningChain(chainId);
-              await tryCacheSession();
+              await tryCacheSession('extrinsics');
               const result = await verifySigningAccount(target, chainId);
               postApprovedResult(result);
               break;

--- a/packages/renderer/src/screens/Action/Overlays/SignLedgerOverlay.tsx
+++ b/packages/renderer/src/screens/Action/Overlays/SignLedgerOverlay.tsx
@@ -61,12 +61,16 @@ export const SignLedgerOverlay = ({ info }: LedgerSignOverlayProps) => {
   return (
     <LedgerOverlayWrapper>
       {ledgerFeedback && (
-        <UI.InfoCard
-          kind={'warning'}
-          icon={faExclamationTriangle}
-          style={{ width: '100%' }}
-        >
-          <span>{ledgerFeedback.text}</span>
+        <UI.InfoCard kind={'warning'} style={{ width: '100%' }}>
+          <span className="Label">
+            <span style={{ marginRight: '0.6rem' }}>
+              <FontAwesomeIcon
+                icon={faExclamationTriangle}
+                transform={'shrink-1'}
+              />
+            </span>
+            {ledgerFeedback.text}
+          </span>
           <button className="dismiss" onClick={() => clearFeedback()}>
             <FontAwesomeIcon icon={faX} />
           </button>

--- a/packages/renderer/src/screens/Action/Overlays/WcSignOverlay.tsx
+++ b/packages/renderer/src/screens/Action/Overlays/WcSignOverlay.tsx
@@ -1,17 +1,19 @@
 // Copyright 2025 @polkadot-live/polkadot-live-app authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import * as FA from '@fortawesome/free-solid-svg-icons';
+import WalletConnectSVG from '@w3ux/extension-assets/WalletConnect.svg?react';
 import { ConfigAction } from '@polkadot-live/core';
 import { useConnections } from '@ren/contexts/common';
 import { useEffect } from 'react';
-import { useWcVerifier } from '@ren/contexts/action';
-import WalletConnectSVG from '@w3ux/extension-assets/WalletConnect.svg?react';
-import { ButtonPrimary, ButtonSecondary } from '@polkadot-live/ui/kits/buttons';
-import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
-import { WcOverlayWrapper } from './Wrappers';
-import { PuffLoader } from 'react-spinners';
 import { useOverlay } from '@polkadot-live/ui/contexts';
+import { useWcFeedback, useWcVerifier } from '@ren/contexts/action';
+import { ButtonPrimary, ButtonSecondary } from '@polkadot-live/ui/kits/buttons';
 import { FlexRow } from '@polkadot-live/ui/styles';
+import { InfoCard } from '@polkadot-live/ui/components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { PuffLoader } from 'react-spinners';
+import { WcOverlayWrapper } from './Wrappers';
 import type { ExtrinsicInfo } from '@polkadot-live/types/tx';
 
 interface WcSignOverlayProps {
@@ -21,6 +23,7 @@ interface WcSignOverlayProps {
 export const WcSignOverlay = ({ info }: WcSignOverlayProps) => {
   const { cacheGet } = useConnections();
   const isBuildingExtrinsic = cacheGet('extrinsic:building');
+  const { message: wcFeedback, clearFeedback } = useWcFeedback();
 
   const { setDisableClose, setStatus: setOverlayStatus } = useOverlay();
   const {
@@ -39,6 +42,7 @@ export const WcSignOverlay = ({ info }: WcSignOverlayProps) => {
     checkVerifiedSession(info);
 
     return () => {
+      clearFeedback();
       resetVerification();
     };
   }, []);
@@ -71,6 +75,23 @@ export const WcSignOverlay = ({ info }: WcSignOverlayProps) => {
 
   return (
     <WcOverlayWrapper>
+      {wcFeedback && (
+        <InfoCard kind={'warning'} style={{ width: '100%' }}>
+          <span className="Label">
+            <span style={{ marginRight: '0.6rem' }}>
+              <FontAwesomeIcon
+                icon={FA.faExclamationTriangle}
+                transform={'shrink-1'}
+              />
+            </span>
+            {wcFeedback.body.msg}
+          </span>
+          <button className="dismiss" onClick={() => clearFeedback()}>
+            <FontAwesomeIcon icon={FA.faX} />
+          </button>
+        </InfoCard>
+      )}
+
       <WalletConnectSVG style={{ height: '3rem' }} />
       {wcAccountApproved ? (
         <div className="ContentColumn">
@@ -91,7 +112,7 @@ export const WcSignOverlay = ({ info }: WcSignOverlayProps) => {
               text="Sign"
               disabled={isBuildingExtrinsic}
               onClick={() => handleSign()}
-              iconRight={faChevronRight}
+              iconRight={FA.faChevronRight}
               iconTransform="shrink-3"
             />
           </FlexRow>
@@ -136,7 +157,7 @@ export const WcSignOverlay = ({ info }: WcSignOverlayProps) => {
                   text="Connect"
                   disabled={isBuildingExtrinsic}
                   onClick={() => initVerifiedSession(info)}
-                  iconRight={faChevronRight}
+                  iconRight={FA.faChevronRight}
                   iconTransform="shrink-3"
                 />
               </FlexRow>

--- a/packages/types/src/ledger.ts
+++ b/packages/types/src/ledger.ts
@@ -56,7 +56,7 @@ export type LedgerErrorStatusCode =
   | 'UnexpectedBufferEnd'
   | 'ValueOutOfRange'
   | 'WrongMetadataDigest'
-  /** Custom */
+  // Custom
   | 'TransportUndefined'
   | 'TxDataUndefined'
   | 'TxDynamicInfoUndefined'

--- a/packages/types/src/walletConnect.ts
+++ b/packages/types/src/walletConnect.ts
@@ -4,8 +4,10 @@
 import type { ChainID } from './chains';
 
 export type WcErrorStatusCode =
-  | 'WcCancelPending'
+  | 'WcAccountNotApproved'
+  | 'WcCatchAll'
   | 'WcCanceledTx'
+  | 'WcCancelPending'
   | 'WcInsufficientTxData'
   | 'WcNotInitialized'
   | 'WcSessionError'
@@ -23,4 +25,13 @@ export interface WcFetchedAddress {
   publicKeyHex: string;
   substrate: string;
   selected: boolean;
+}
+
+/**
+ * Types for handling WalletConnect feedback.
+ */
+export interface WalletConnectMeta {
+  ack: 'failure' | 'success';
+  statusCode: WcErrorStatusCode;
+  body: { msg: string };
 }

--- a/packages/ui/src/components/Cards/InfoCard.styles.ts
+++ b/packages/ui/src/components/Cards/InfoCard.styles.ts
@@ -29,8 +29,11 @@ export const InfoCardWrapper = styled.div`
       flex: 1;
     }
   }
+  .Label {
+    line-height: 1.4rem;
+  }
 
-  span {
+  > span {
     display: flex;
     gap: 0.9rem;
     align-items: center;


### PR DESCRIPTION
- [x] Refactor WalletConnect error metadata and store in `consts` package.
  * Adds new error status codes and user-friendly feedback message. 
- [x] Display WalletConnect signing feedback  within the signing overlay.