### PR TITLE
feat(ui): show address dialog for fetched ledger and wallet connect accounts

### DIFF
--- a/packages/renderer/src/contexts/import/RenameHandler/defaults.ts
+++ b/packages/renderer/src/contexts/import/RenameHandler/defaults.ts
@@ -16,7 +16,7 @@ export const defaultRenameHandlerContext: RenameHandlerContextInterface = {
     isOpen: false,
   }),
   getShowAddressDialogData: () => ({
-    encodedAccount: null,
+    address: null,
     isOpen: false,
   }),
   renameHandler: () => new Promise(() => {}),

--- a/packages/renderer/src/contexts/import/RenameHandler/index.tsx
+++ b/packages/renderer/src/contexts/import/RenameHandler/index.tsx
@@ -75,7 +75,7 @@ export const RenameHandlerProvider = ({
   const [showAddressDialogState, setShowAddressDialogState] =
     useState<DialogShowAddressData>({
       isOpen: false,
-      encodedAccount: null,
+      address: null,
     });
 
   const getShowAddressDialogData = () => showAddressDialogState;

--- a/packages/renderer/src/contexts/import/RenameHandler/types.ts
+++ b/packages/renderer/src/contexts/import/RenameHandler/types.ts
@@ -24,7 +24,7 @@ export interface DialogRenameData {
 
 export interface DialogShowAddressData {
   isOpen: boolean;
-  encodedAccount: EncodedAccount | null;
+  address: string | null;
 }
 
 export interface RenameHandlerContextInterface {

--- a/packages/renderer/src/screens/Import/Addresses/Address.tsx
+++ b/packages/renderer/src/screens/Import/Addresses/Address.tsx
@@ -50,7 +50,10 @@ export const Address = ({ genericAccount, setSection }: AddressProps) => {
         setManageAccountDialogData({ genericAccount, isOpen: true })
       }
       handleShowAddressClick={(encodedAccount) =>
-        setShowAddressDialogData({ encodedAccount, isOpen: true })
+        setShowAddressDialogData({
+          address: encodedAccount.address,
+          isOpen: true,
+        })
       }
       handleAddSubscriptions={async (encodedAccount: EncodedAccount) =>
         await handleAddAddress(encodedAccount, genericAccount)

--- a/packages/renderer/src/screens/Import/Addresses/Dialogs/DialogManageAccounts.tsx
+++ b/packages/renderer/src/screens/Import/Addresses/Dialogs/DialogManageAccounts.tsx
@@ -167,23 +167,15 @@ export const DialogManageAccounts = ({
                                 await window.myAPI.copyToClipboard(a.address)
                               }
                             />
-                            <UI.TooltipRx text={'Show Address'} theme={theme}>
-                              <Style.ViewIconWrapper
-                                $theme={theme}
-                                onClick={() =>
-                                  setShowAddressDialogData({
-                                    encodedAccount: a,
-                                    isOpen: true,
-                                  })
-                                }
-                              >
-                                <FontAwesomeIcon
-                                  className="ViewIcon"
-                                  icon={FA.faEye}
-                                  transform={'shrink-4'}
-                                />
-                              </Style.ViewIconWrapper>
-                            </UI.TooltipRx>
+                            <UI.ViewAddressIcon
+                              theme={theme}
+                              onClick={() =>
+                                setShowAddressDialogData({
+                                  address: a.address,
+                                  isOpen: true,
+                                })
+                              }
+                            />
                           </Style.FlexRow>
                         </Style.FlexRow>
                       </Style.FlexRow>

--- a/packages/renderer/src/screens/Import/Addresses/Dialogs/DialogShowAddress.tsx
+++ b/packages/renderer/src/screens/Import/Addresses/Dialogs/DialogShowAddress.tsx
@@ -13,7 +13,6 @@ import {
 } from '@polkadot-live/ui/styles';
 import { CopyButton } from '@polkadot-live/ui/components';
 import styled from 'styled-components';
-import type { EncodedAccount } from '@polkadot-live/types/accounts';
 
 const AddressText = styled.p`
   line-height: 2rem;
@@ -28,22 +27,17 @@ const AddressText = styled.p`
   }
 `;
 
-export const DialogShowAddress = ({
-  encodedAccount,
-}: {
-  encodedAccount: EncodedAccount;
-}) => {
+export const DialogShowAddress = ({ address }: { address: string }) => {
   const { getTheme } = useConnections();
   const { getShowAddressDialogData, setShowAddressDialogData } =
     useRenameHandler();
 
-  const { address } = encodedAccount;
   const theme = getTheme();
 
   const handleOpenChange = (open: boolean) =>
     open
-      ? setShowAddressDialogData({ encodedAccount, isOpen: open })
-      : setShowAddressDialogData({ encodedAccount: null, isOpen: open });
+      ? setShowAddressDialogData({ address, isOpen: open })
+      : setShowAddressDialogData({ address: null, isOpen: open });
 
   return (
     <Dialog.Root

--- a/packages/renderer/src/screens/Import/Addresses/Dropdowns/DropdownAccount.tsx
+++ b/packages/renderer/src/screens/Import/Addresses/Dropdowns/DropdownAccount.tsx
@@ -48,7 +48,7 @@ export const DropdownAccount = ({
   };
 
   const onShowAddressClick = () => {
-    setShowAddressDialogData({ encodedAccount, isOpen: true });
+    setShowAddressDialogData({ address: encodedAccount.address, isOpen: true });
   };
 
   const onRenameClick = () => {

--- a/packages/renderer/src/screens/Import/Addresses/Listing.tsx
+++ b/packages/renderer/src/screens/Import/Addresses/Listing.tsx
@@ -63,10 +63,8 @@ export const Listing = ({ source, setSection }: ManageAccountsProps) => {
         />
       )}
 
-      {getShowAddressDialogData().encodedAccount && (
-        <DialogShowAddress
-          encodedAccount={getShowAddressDialogData().encodedAccount!}
-        />
+      {getShowAddressDialogData().address && (
+        <DialogShowAddress address={getShowAddressDialogData().address!} />
       )}
 
       {/* Address List */}

--- a/packages/renderer/src/screens/Import/Ledger/Import/index.tsx
+++ b/packages/renderer/src/screens/Import/Ledger/Import/index.tsx
@@ -14,6 +14,7 @@ import {
   useAddresses,
   useImportHandler,
   useLedgerHardware,
+  useRenameHandler,
 } from '@ren/contexts/import';
 
 import { BarLoader } from 'react-spinners';
@@ -32,6 +33,7 @@ import {
 import { ellipsisFn } from '@w3ux/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ConnectButton } from './Wrappers';
+import { DialogShowAddress } from '../../Addresses/Dialogs';
 import { AddressListFooter, ImportAddressRow } from '../../Wrappers';
 import { InfoCardSteps } from '../../InfoCardSteps';
 import { determineStatusFromCode } from './Utils';
@@ -49,6 +51,9 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
   const ledger = useLedgerHardware();
   const { connectedNetwork, selectedAddresses, receivedAddresses } =
     useLedgerHardware();
+
+  const { getShowAddressDialogData, setShowAddressDialogData } =
+    useRenameHandler();
 
   /**
    * Accordion state.
@@ -175,6 +180,10 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
           cssOverride={{ position: 'fixed', top: 0, zIndex: 99 }}
           speedMultiplier={0.75}
         />
+      )}
+
+      {getShowAddressDialogData().address && (
+        <DialogShowAddress address={getShowAddressDialogData().address!} />
       )}
 
       <Styles.PadWrapper>
@@ -407,6 +416,15 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                                           }
                                         />
                                       </span>
+                                      <UI.ViewAddressIcon
+                                        theme={theme}
+                                        onClick={() =>
+                                          setShowAddressDialogData({
+                                            address,
+                                            isOpen: true,
+                                          })
+                                        }
+                                      />
                                     </Styles.FlexRow>
                                   </div>
                                   <div className="right">

--- a/packages/renderer/src/screens/Import/WalletConnect/Import/index.tsx
+++ b/packages/renderer/src/screens/Import/WalletConnect/Import/index.tsx
@@ -5,6 +5,7 @@ import * as UI from '@polkadot-live/ui/components';
 import * as Styles from '@polkadot-live/ui/styles';
 import * as AccordionRx from '@radix-ui/react-accordion';
 import * as Checkbox from '@radix-ui/react-checkbox';
+import * as FA from '@fortawesome/free-solid-svg-icons';
 
 import { BarLoader } from 'react-spinners';
 import { CheckIcon, ChevronDownIcon } from '@radix-ui/react-icons';
@@ -14,19 +15,20 @@ import {
 } from '@polkadot-live/ui/kits/buttons';
 import { ItemsColumn } from '@ren/screens/Home/Manage/Wrappers';
 import { ChainIcon, InfoCard } from '@polkadot-live/ui/components';
-import {
-  faCaretLeft,
-  faCaretRight,
-  faCircleDot,
-} from '@fortawesome/free-solid-svg-icons';
 
 /** Temp */
-import { useAddresses, useWalletConnectImport } from '@ren/contexts/import';
+import {
+  useAddresses,
+  useRenameHandler,
+  useWalletConnectImport,
+} from '@ren/contexts/import';
 import { useConnections } from '@ren/contexts/common';
 import { useState } from 'react';
 import { ellipsisFn } from '@w3ux/utils';
 import { WcSessionButton } from './Wrappers';
 import { AddressListFooter, ImportAddressRow } from '../../Wrappers';
+import { DialogShowAddress } from '../../Addresses/Dialogs';
+
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { ImportProps } from './types';
 
@@ -54,6 +56,9 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
     handleImportProcess,
     setWcNetworks,
   } = useWalletConnectImport();
+
+  const { getShowAddressDialogData, setShowAddressDialogData } =
+    useRenameHandler();
 
   /**
    * Accordion state.
@@ -111,6 +116,10 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
         />
       )}
 
+      {getShowAddressDialogData().address && (
+        <DialogShowAddress address={getShowAddressDialogData().address!} />
+      )}
+
       <Styles.PadWrapper>
         <Styles.FlexColumn $rowGap={'1.75rem'}>
           <section>
@@ -126,7 +135,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                   <ButtonPrimaryInvert
                     className="back-btn"
                     text="Back"
-                    iconLeft={faCaretLeft}
+                    iconLeft={FA.faCaretLeft}
                     onClick={() => {
                       setSection(0);
                     }}
@@ -135,7 +144,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                 </Styles.FlexRow>
                 <Styles.FlexRow>
                   <ButtonText
-                    iconLeft={faCaretRight}
+                    iconLeft={FA.faCaretRight}
                     text={'WalletConnect Accounts'}
                     disabled={wcAddresses.length === 0}
                     onClick={() => setShowImportUi(false)}
@@ -178,7 +187,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                               style={{ flex: 1 }}
                             >
                               <InfoCard
-                                icon={faCircleDot}
+                                icon={FA.faCircleDot}
                                 iconTransform={'shrink-3'}
                                 style={{ margin: '0', flex: 1 }}
                               >
@@ -266,7 +275,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                           <Styles.FlexColumn style={{ marginTop: '0.5rem' }}>
                             <Styles.FlexRow $gap={'0.5rem'}>
                               <InfoCard
-                                icon={faCircleDot}
+                                icon={FA.faCircleDot}
                                 iconTransform={'shrink-3'}
                                 style={{ margin: '0', flex: 1 }}
                               >
@@ -310,7 +319,7 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                     <UI.AccordionContent transparent={true}>
                       {wcFetchedAddresses.length === 0 ? (
                         <InfoCard
-                          icon={faCircleDot}
+                          icon={FA.faCircleDot}
                           iconTransform={'shrink-3'}
                           style={{ marginTop: '0', marginBottom: '0.75rem' }}
                         >
@@ -352,6 +361,15 @@ export const Import = ({ setSection, setShowImportUi }: ImportProps) => {
                                           }
                                         />
                                       </span>
+                                      <UI.ViewAddressIcon
+                                        theme={theme}
+                                        onClick={() =>
+                                          setShowAddressDialogData({
+                                            address: encoded,
+                                            isOpen: true,
+                                          })
+                                        }
+                                      />
                                     </Styles.FlexRow>
                                   </div>
                                   <div className="right">

--- a/packages/ui/src/components/Hardware/HardwareAddress/HardwareAddress.tsx
+++ b/packages/ui/src/components/Hardware/HardwareAddress/HardwareAddress.tsx
@@ -6,10 +6,11 @@ import { ellipsisFn } from '@w3ux/utils';
 import { EllipsisSpinner } from '../../Spinners';
 import { ActionBtn, HardwareAddressWrapper } from './Wrapper';
 import { TooltipRx } from '../../TooltipRx';
-import { FlexColumn, FlexRow, ViewIconWrapper } from '../../../styles';
+import { FlexColumn, FlexRow } from '../../../styles';
 import { ChainIcon } from '../../ChainIcon';
 import { CopyButton } from '../../CopyButton';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ViewAddressIcon } from '../../ViewAddressIcon';
 import type { ChainID } from '@polkadot-live/types/chains';
 import type { HardwareAddressProps } from './types';
 
@@ -133,18 +134,10 @@ export const HardwareAddress = ({
                     theme={theme}
                     onCopyClick={async () => await onClipboardCopy(a.address)}
                   />
-                  <TooltipRx text={'Show Address'} theme={theme}>
-                    <ViewIconWrapper
-                      $theme={theme}
-                      onClick={() => handleShowAddressClick(a)}
-                    >
-                      <FontAwesomeIcon
-                        className="ViewIcon"
-                        icon={FA.faEye}
-                        transform={'shrink-4'}
-                      />
-                    </ViewIconWrapper>
-                  </TooltipRx>
+                  <ViewAddressIcon
+                    theme={theme}
+                    onClick={() => handleShowAddressClick(a)}
+                  />
                 </FlexRow>
               </FlexRow>
 

--- a/packages/ui/src/components/ViewAddressIcon/ViewAddressIcon.styles.ts
+++ b/packages/ui/src/components/ViewAddressIcon/ViewAddressIcon.styles.ts
@@ -11,6 +11,7 @@ export const ViewIconWrapper = styled.div.attrs<{
 }))`
   .ViewIcon {
     cursor: pointer;
+    color: ${({ $theme }) => $theme.textColorSecondary};
     &:hover {
       color: ${({ $theme }) => $theme.textColorPrimary};
     }

--- a/packages/ui/src/components/ViewAddressIcon/ViewAddressIcon.tsx
+++ b/packages/ui/src/components/ViewAddressIcon/ViewAddressIcon.tsx
@@ -1,0 +1,25 @@
+// Copyright 2025 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { faEye } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { TooltipRx } from '../TooltipRx';
+import { ViewIconWrapper } from './ViewAddressIcon.styles';
+import type { AnyData } from '@polkadot-live/types/misc';
+
+export interface ViewAddressIconProps {
+  onClick: () => void;
+  theme: AnyData;
+}
+
+export const ViewAddressIcon = ({ onClick, theme }: ViewAddressIconProps) => (
+  <TooltipRx text={'Show Address'} theme={theme}>
+    <ViewIconWrapper $theme={theme} onClick={() => onClick()}>
+      <FontAwesomeIcon
+        className="ViewIcon"
+        icon={faEye}
+        transform={'shrink-4'}
+      />
+    </ViewIconWrapper>
+  </TooltipRx>
+);

--- a/packages/ui/src/components/ViewAddressIcon/index.ts
+++ b/packages/ui/src/components/ViewAddressIcon/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2025 @polkadot-live/polkadot-live-app authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+export * from './ViewAddressIcon';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -29,4 +29,5 @@ export * from './Switch';
 export * from './TooltipRx';
 export * from './Tx';
 export * from './Utils';
+export * from './ViewAddressIcon';
 export * from './Wrappers';

--- a/packages/ui/src/styles/index.ts
+++ b/packages/ui/src/styles/index.ts
@@ -9,4 +9,3 @@ export * from './grid';
 
 export * from './ScrollWrappers';
 export * from './StatsFooter';
-export * from './ViewIconWrapper';


### PR DESCRIPTION
Implements a reusable `ViewAddressIcon` component used to open a dialog to show a full address. This component has been added to fetched Ledger and WalletConnect account listings. 